### PR TITLE
feat(dashboard): multi-machine fleet orchestration

### DIFF
--- a/crates/bubbaloop-schemas/protos/daemon.proto
+++ b/crates/bubbaloop-schemas/protos/daemon.proto
@@ -52,6 +52,8 @@ message NodeState {
   string machine_id = 14;
   // Human-readable hostname
   string machine_hostname = 15;
+  // Network IP addresses of the source machine
+  repeated string machine_ips = 16;
 }
 
 // List of all nodes (published periodically)

--- a/crates/bubbaloop/src/daemon/zenoh_service.rs
+++ b/crates/bubbaloop/src/daemon/zenoh_service.rs
@@ -433,6 +433,7 @@ mod tests {
             last_health_check_ms: 1234567890,
             machine_id: "test-machine".to_string(),
             machine_hostname: "test-hostname".to_string(),
+            machine_ips: vec!["192.168.1.100".to_string()],
         };
 
         let bytes = ZenohService::encode_proto(&state);

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -1,10 +1,13 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { useZenohSession, useZenohTopicDiscovery, ConnectionStatus } from './lib/zenoh';
 import { ZenohSubscriptionProvider } from './contexts/ZenohSubscriptionContext';
 import { FleetProvider } from './contexts/FleetContext';
 import { Dashboard } from './components/Dashboard';
 import { FleetBar } from './components/FleetBar';
+import { MeshView } from './components/MeshView';
 import { H264Decoder } from './lib/h264-decoder';
+
+type AppView = 'dashboard' | 'loop';
 
 // Zenoh endpoint - proxied through Vite on /zenoh path
 // This allows single-port HTTPS access (WebSocket tunneled through same connection)
@@ -192,13 +195,44 @@ export default function App() {
   const zenohConfig = useMemo(() => ({ endpoint: ZENOH_ENDPOINT }), []);
   const { session, status, error, reconnect } = useZenohSession(zenohConfig);
   const { topics: availableTopics } = useZenohTopicDiscovery(session, '**');
+  const [currentView, setCurrentView] = useState<AppView>('dashboard');
 
   return (
     <div className="app">
       <header className="app-header">
         <div className="header-left">
           <h1>Bubbaloop</h1>
-          <span className="header-subtitle">Dashboard</span>
+          <div className="view-switcher">
+            <button
+              className={`view-tab ${currentView === 'dashboard' ? 'active' : ''}`}
+              onClick={() => setCurrentView('dashboard')}
+            >
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <rect x="3" y="3" width="7" height="7" rx="1" />
+                <rect x="14" y="3" width="7" height="7" rx="1" />
+                <rect x="3" y="14" width="7" height="7" rx="1" />
+                <rect x="14" y="14" width="7" height="7" rx="1" />
+              </svg>
+              Dashboard
+            </button>
+            <button
+              className={`view-tab ${currentView === 'loop' ? 'active' : ''}`}
+              onClick={() => setCurrentView('loop')}
+            >
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <circle cx="12" cy="12" r="3" />
+                <circle cx="5" cy="6" r="2" />
+                <circle cx="19" cy="6" r="2" />
+                <circle cx="5" cy="18" r="2" />
+                <circle cx="19" cy="18" r="2" />
+                <line x1="9.5" y1="10.5" x2="6.5" y2="7.5" />
+                <line x1="14.5" y1="10.5" x2="17.5" y2="7.5" />
+                <line x1="9.5" y1="13.5" x2="6.5" y2="16.5" />
+                <line x1="14.5" y1="13.5" x2="17.5" y2="16.5" />
+              </svg>
+              The Loop
+            </button>
+          </div>
         </div>
         <StatusIndicator status={status} endpoint={ZENOH_ENDPOINT} onReconnect={reconnect} />
       </header>
@@ -215,7 +249,11 @@ export default function App() {
         <FleetProvider>
           <ZenohSubscriptionProvider session={session}>
             <FleetBar />
-            <Dashboard cameras={DEFAULT_CAMERAS} availableTopics={availableTopics} />
+            {currentView === 'dashboard' ? (
+              <Dashboard cameras={DEFAULT_CAMERAS} availableTopics={availableTopics} />
+            ) : (
+              <MeshView />
+            )}
           </ZenohSubscriptionProvider>
         </FleetProvider>
       ) : (
@@ -265,8 +303,8 @@ export default function App() {
 
         .header-left {
           display: flex;
-          align-items: baseline;
-          gap: 12px;
+          align-items: center;
+          gap: 16px;
         }
 
         .app-header h1 {
@@ -278,10 +316,45 @@ export default function App() {
           background-clip: text;
         }
 
-        .header-subtitle {
-          font-size: 13px;
+        .view-switcher {
+          display: flex;
+          gap: 2px;
+          background: var(--bg-primary);
+          padding: 3px;
+          border-radius: 10px;
+          border: 1px solid var(--border-color);
+        }
+
+        .view-tab {
+          display: flex;
+          align-items: center;
+          gap: 6px;
+          padding: 5px 14px;
+          border: none;
+          border-radius: 7px;
+          background: transparent;
           color: var(--text-muted);
-          font-weight: 400;
+          font-size: 12px;
+          font-weight: 500;
+          font-family: inherit;
+          cursor: pointer;
+          transition: all 0.2s;
+          white-space: nowrap;
+        }
+
+        .view-tab:hover {
+          color: var(--text-secondary);
+          background: rgba(255,255,255,0.03);
+        }
+
+        .view-tab.active {
+          background: var(--bg-tertiary);
+          color: var(--text-primary);
+          box-shadow: 0 1px 4px rgba(0,0,0,0.2);
+        }
+
+        .view-tab.active svg {
+          stroke: var(--accent-secondary);
         }
 
         .connecting-placeholder {
@@ -352,8 +425,15 @@ export default function App() {
             font-size: 16px;
           }
 
-          .header-subtitle {
-            display: none;
+          .view-tab {
+            padding: 5px 10px;
+            font-size: 11px;
+            gap: 4px;
+          }
+
+          .view-tab svg {
+            width: 12px;
+            height: 12px;
           }
 
           .error-banner {
@@ -369,6 +449,19 @@ export default function App() {
 
           .app-header h1 {
             font-size: 14px;
+          }
+
+          .view-switcher {
+            padding: 2px;
+          }
+
+          .view-tab {
+            padding: 4px 8px;
+            font-size: 10px;
+          }
+
+          .view-tab svg {
+            display: none;
           }
         }
       `}</style>

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -252,7 +252,7 @@ export default function App() {
             {currentView === 'dashboard' ? (
               <Dashboard cameras={DEFAULT_CAMERAS} availableTopics={availableTopics} />
             ) : (
-              <MeshView />
+              <MeshView availableTopics={availableTopics} zenohEndpoint={ZENOH_ENDPOINT} connectionStatus={status} />
             )}
           </ZenohSubscriptionProvider>
         </FleetProvider>

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -1,7 +1,9 @@
 import { useMemo } from 'react';
 import { useZenohSession, useZenohTopicDiscovery, ConnectionStatus } from './lib/zenoh';
 import { ZenohSubscriptionProvider } from './contexts/ZenohSubscriptionContext';
+import { FleetProvider } from './contexts/FleetContext';
 import { Dashboard } from './components/Dashboard';
+import { FleetBar } from './components/FleetBar';
 import { H264Decoder } from './lib/h264-decoder';
 
 // Zenoh endpoint - proxied through Vite on /zenoh path
@@ -210,9 +212,12 @@ export default function App() {
       )}
 
       {session ? (
-        <ZenohSubscriptionProvider session={session}>
-          <Dashboard cameras={DEFAULT_CAMERAS} availableTopics={availableTopics} />
-        </ZenohSubscriptionProvider>
+        <FleetProvider>
+          <ZenohSubscriptionProvider session={session}>
+            <FleetBar />
+            <Dashboard cameras={DEFAULT_CAMERAS} availableTopics={availableTopics} />
+          </ZenohSubscriptionProvider>
+        </FleetProvider>
       ) : (
         <div className="connecting-placeholder">
           <div className="placeholder-content">

--- a/dashboard/src/components/CameraView.tsx
+++ b/dashboard/src/components/CameraView.tsx
@@ -2,6 +2,8 @@ import { useRef, useEffect, useCallback, useState } from 'react';
 import { Sample } from '@eclipse-zenoh/zenoh-ts';
 import { getSamplePayload } from '../lib/zenoh';
 import { useZenohSubscription } from '../hooks/useZenohSubscription';
+import { useFleetContext } from '../contexts/FleetContext';
+import { MachineBadge } from './MachineBadge';
 import { H264Decoder } from '../lib/h264-decoder';
 import { decodeCompressedImage, Header } from '../proto/camera';
 
@@ -30,6 +32,7 @@ export function CameraView({
   availableTopics = [],
   dragHandleProps,
 }: CameraViewProps) {
+  const { machines } = useFleetContext();
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
   const decoderRef = useRef<H264Decoder | null>(null);
@@ -181,6 +184,7 @@ export function CameraView({
             </button>
           )}
           <span className="panel-type-badge">CAMERA</span>
+          <MachineBadge machines={machines} />
         </div>
         <div className="camera-stats">
           {dimensions && (
@@ -399,6 +403,19 @@ export function CameraView({
           background: rgba(0, 229, 255, 0.15);
           color: var(--accent-secondary);
           text-transform: uppercase;
+          white-space: nowrap;
+        }
+
+        .panel-machine-badge {
+          font-size: 10px;
+          font-family: 'JetBrains Mono', monospace;
+          color: var(--text-muted);
+          background: var(--bg-tertiary);
+          padding: 2px 6px;
+          border-radius: 4px;
+          max-width: 120px;
+          overflow: hidden;
+          text-overflow: ellipsis;
           white-space: nowrap;
         }
 

--- a/dashboard/src/components/FleetBar.tsx
+++ b/dashboard/src/components/FleetBar.tsx
@@ -33,6 +33,9 @@ export function FleetBar() {
             >
               <span className={`chip-dot ${m.isOnline ? 'online' : 'offline'}`} />
               <span className="chip-hostname">{m.hostname}</span>
+              {m.ips.length > 0 && (
+                <span className="chip-ip">{m.ips[0]}</span>
+              )}
               <span className="chip-badge">{m.runningCount}/{m.nodeCount}</span>
             </button>
           ))}
@@ -129,6 +132,12 @@ export function FleetBar() {
           max-width: 120px;
           overflow: hidden;
           text-overflow: ellipsis;
+        }
+
+        .chip-ip {
+          font-size: 10px;
+          font-family: 'JetBrains Mono', monospace;
+          color: var(--text-muted);
         }
 
         .chip-badge {

--- a/dashboard/src/components/FleetBar.tsx
+++ b/dashboard/src/components/FleetBar.tsx
@@ -1,0 +1,175 @@
+import { useFleetContext } from '../contexts/FleetContext';
+
+export function FleetBar() {
+  const { machines, selectedMachineId, setSelectedMachineId } = useFleetContext();
+
+  // Only render when machines are discovered
+  if (machines.length === 0) return null;
+
+  const totalNodes = machines.reduce((sum, m) => sum + m.nodeCount, 0);
+  const totalRunning = machines.reduce((sum, m) => sum + m.runningCount, 0);
+
+  return (
+    <div className="fleet-bar">
+      <div className="fleet-bar-inner">
+        <span className="fleet-label">Fleet</span>
+        <div className="fleet-chips">
+          {/* All Machines chip */}
+          <button
+            className={`fleet-chip ${selectedMachineId === null ? 'active' : ''}`}
+            onClick={() => setSelectedMachineId(null)}
+          >
+            <span className="chip-dot chip-dot-all" />
+            <span className="chip-hostname">All</span>
+            <span className="chip-badge">{totalRunning}/{totalNodes}</span>
+          </button>
+
+          {/* Per-machine chips */}
+          {machines.map(m => (
+            <button
+              key={m.machineId}
+              className={`fleet-chip ${selectedMachineId === m.machineId ? 'active' : ''}`}
+              onClick={() => setSelectedMachineId(m.machineId)}
+            >
+              <span className={`chip-dot ${m.isOnline ? 'online' : 'offline'}`} />
+              <span className="chip-hostname">{m.hostname}</span>
+              <span className="chip-badge">{m.runningCount}/{m.nodeCount}</span>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <style>{`
+        .fleet-bar {
+          padding: 8px 24px;
+          background: var(--bg-secondary);
+          border-bottom: 1px solid var(--border-color);
+        }
+
+        .fleet-bar-inner {
+          display: flex;
+          align-items: center;
+          gap: 12px;
+          max-width: 1800px;
+          margin: 0 auto;
+        }
+
+        .fleet-label {
+          font-size: 11px;
+          font-weight: 600;
+          color: var(--text-muted);
+          text-transform: uppercase;
+          letter-spacing: 0.5px;
+          flex-shrink: 0;
+        }
+
+        .fleet-chips {
+          display: flex;
+          gap: 8px;
+          overflow-x: auto;
+          flex-wrap: wrap;
+          -webkit-overflow-scrolling: touch;
+          scrollbar-width: none;
+        }
+
+        .fleet-chips::-webkit-scrollbar {
+          display: none;
+        }
+
+        .fleet-chip {
+          display: flex;
+          align-items: center;
+          gap: 6px;
+          padding: 5px 12px;
+          background: var(--bg-tertiary);
+          border: 1px solid var(--border-color);
+          border-radius: 16px;
+          color: var(--text-secondary);
+          font-size: 12px;
+          font-weight: 500;
+          cursor: pointer;
+          transition: all 0.15s;
+          white-space: nowrap;
+          flex-shrink: 0;
+          font-family: inherit;
+        }
+
+        .fleet-chip:hover {
+          background: var(--bg-card);
+          color: var(--text-primary);
+          border-color: var(--text-muted);
+        }
+
+        .fleet-chip.active {
+          background: rgba(61, 90, 254, 0.12);
+          border-color: var(--accent-primary);
+          color: var(--text-primary);
+        }
+
+        .chip-dot {
+          width: 6px;
+          height: 6px;
+          border-radius: 50%;
+          flex-shrink: 0;
+        }
+
+        .chip-dot.online {
+          background: var(--success);
+        }
+
+        .chip-dot.offline {
+          background: var(--error);
+        }
+
+        .chip-dot-all {
+          background: var(--accent-secondary);
+        }
+
+        .chip-hostname {
+          max-width: 120px;
+          overflow: hidden;
+          text-overflow: ellipsis;
+        }
+
+        .chip-badge {
+          font-size: 10px;
+          font-family: 'JetBrains Mono', monospace;
+          color: var(--text-muted);
+          padding: 1px 6px;
+          background: var(--bg-primary);
+          border-radius: 8px;
+        }
+
+        .fleet-chip.active .chip-badge {
+          background: rgba(61, 90, 254, 0.2);
+          color: var(--accent-secondary);
+        }
+
+        @media (max-width: 768px) {
+          .fleet-bar {
+            padding: 6px 16px;
+          }
+
+          .fleet-label {
+            display: none;
+          }
+
+          .fleet-chips {
+            flex-wrap: nowrap;
+          }
+
+          .fleet-chip {
+            padding: 6px 10px;
+            font-size: 11px;
+          }
+        }
+
+        @media (max-width: 480px) {
+          .fleet-bar {
+            padding: 6px 12px;
+          }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/dashboard/src/components/JsonView.tsx
+++ b/dashboard/src/components/JsonView.tsx
@@ -3,6 +3,8 @@ import { Sample, Reply, ReplyError } from '@eclipse-zenoh/zenoh-ts';
 import { getSamplePayload } from '../lib/zenoh';
 import { useZenohSubscription } from '../hooks/useZenohSubscription';
 import { useZenohSubscriptionContext } from '../contexts/ZenohSubscriptionContext';
+import { useFleetContext } from '../contexts/FleetContext';
+import { MachineBadge } from './MachineBadge';
 import { decodeCompressedImage } from '../proto/camera';
 import { decodeCurrentWeather, decodeHourlyForecast, decodeDailyForecast } from '../proto/weather';
 import { decodeNodeList, decodeNodeEvent } from '../proto/daemon';
@@ -192,6 +194,7 @@ export function RawDataViewPanel({
   availableTopics = [],
   dragHandleProps,
 }: RawDataViewPanelProps) {
+  const { machines } = useFleetContext();
   const [jsonData, setJsonData] = useState<unknown>(null);
   const [schemaName, setSchemaName] = useState<string | null>(null);
   const [parseError, setParseError] = useState<string | null>(null);
@@ -294,6 +297,7 @@ export function RawDataViewPanel({
             </button>
           )}
           <span className="panel-type-badge">{schemaName || 'RAW DATA'}</span>
+          <MachineBadge machines={machines} />
         </div>
         <div className="panel-stats">
           {onRemove && (
@@ -437,6 +441,19 @@ export function RawDataViewPanel({
           background: rgba(0, 229, 255, 0.15);
           color: var(--accent-secondary);
           text-transform: uppercase;
+          white-space: nowrap;
+        }
+
+        .panel-machine-badge {
+          font-size: 10px;
+          font-family: 'JetBrains Mono', monospace;
+          color: var(--text-muted);
+          background: var(--bg-tertiary);
+          padding: 2px 6px;
+          border-radius: 4px;
+          max-width: 120px;
+          overflow: hidden;
+          text-overflow: ellipsis;
           white-space: nowrap;
         }
 

--- a/dashboard/src/components/MachineBadge.tsx
+++ b/dashboard/src/components/MachineBadge.tsx
@@ -1,0 +1,23 @@
+import { type MachineInfo } from '../contexts/FleetContext';
+
+interface MachineBadgeProps {
+  machines: MachineInfo[];
+}
+
+export function MachineBadge({ machines }: MachineBadgeProps) {
+  if (machines.length === 0) return null;
+
+  const title = machines
+    .map(m => `${m.hostname} (${m.ips[0] || ''})`)
+    .join(', ');
+
+  const label = machines.length === 1
+    ? machines[0].hostname
+    : `${machines.length} machines`;
+
+  return (
+    <span className="panel-machine-badge" title={title}>
+      {label}
+    </span>
+  );
+}

--- a/dashboard/src/components/MeshView.tsx
+++ b/dashboard/src/components/MeshView.tsx
@@ -1447,19 +1447,6 @@ function StatusRow({ label, color, text }: { label: string; color: string; text:
   );
 }
 
-function TopicsList({ topics }: { topics: string[] }) {
-  if (topics.length === 0) {
-    return <div className="mesh-detail-empty">No matching topics</div>;
-  }
-  return (
-    <>
-      {topics.map((t, i) => (
-        <div key={i} className="mesh-detail-topic" title={t}>{t}</div>
-      ))}
-    </>
-  );
-}
-
 function getDetailTitle(detailNode: SimNode | null): { title: string; dotColor: string } {
   if (!detailNode) return { title: '', dotColor: '' };
 
@@ -1502,11 +1489,6 @@ function DetailSidePanel({
   if (detailNode?.type === 'machine') {
     const data = detailNode.data as MachineInfo;
     const childNodes = fleetNodes.filter(n => n.machineId === data.machineId);
-    const machineTopics = availableTopics.filter(t => {
-      const lower = t.toLowerCase();
-      return lower.includes(data.hostname.toLowerCase()) || lower.includes(data.machineId.toLowerCase());
-    });
-
     body = (
       <>
         <div className="mesh-detail-section">
@@ -1539,19 +1521,12 @@ function DetailSidePanel({
             <div className="mesh-detail-empty">No service nodes</div>
           )}
         </div>
-
-        <div className="mesh-detail-section">
-          <div className="mesh-detail-section-title">Zenoh Topics</div>
-          <TopicsList topics={machineTopics} />
-        </div>
       </>
     );
   } else if (detailNode?.type === 'service') {
     const data = detailNode.data as FleetNodeInfo;
     const parentMachine = machines.find(m => m.machineId === data.machineId);
     const color = STATUS_COLORS[data.status] || STATUS_COLORS.unknown;
-    const nodeTopics = availableTopics.filter(t => t.toLowerCase().includes(data.name.toLowerCase()));
-
     body = (
       <>
         <div className="mesh-detail-section">
@@ -1567,11 +1542,6 @@ function DetailSidePanel({
           {(parentMachine?.ips || data.ips || []).map((ip, i) => (
             <DetailRow key={i} label={i === 0 ? 'IP' : ''} value={ip} />
           ))}
-        </div>
-
-        <div className="mesh-detail-section">
-          <div className="mesh-detail-section-title">Zenoh Topics</div>
-          <TopicsList topics={nodeTopics} />
         </div>
       </>
     );

--- a/dashboard/src/components/MeshView.tsx
+++ b/dashboard/src/components/MeshView.tsx
@@ -1,0 +1,1159 @@
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
+import { useFleetContext, type MachineInfo, type FleetNodeInfo } from '../contexts/FleetContext';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface SimNode {
+  id: string;
+  type: 'hub' | 'machine' | 'service';
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  fx: number | null; // fixed x (while dragging)
+  fy: number | null;
+  radius: number;
+  data: HubData | MachineInfo | FleetNodeInfo;
+}
+
+interface HubData {
+  label: string;
+}
+
+interface SimEdge {
+  source: string;
+  target: string;
+  type: 'mesh' | 'service';
+}
+
+interface TooltipInfo {
+  x: number;
+  y: number;
+  node: SimNode;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const HUB_RADIUS = 36;
+const MACHINE_RADIUS = 28;
+const SERVICE_RADIUS = 10;
+
+const STATUS_COLORS: Record<string, string> = {
+  running: '#00c853',
+  stopped: '#9090a0',
+  failed: '#ff1744',
+  building: '#ffd600',
+  installing: '#ffd600',
+  'not-installed': '#606070',
+  unknown: '#606070',
+};
+
+// ---------------------------------------------------------------------------
+// Force simulation helpers
+// ---------------------------------------------------------------------------
+
+function distance(a: SimNode, b: SimNode): number {
+  const dx = a.x - b.x;
+  const dy = a.y - b.y;
+  return Math.sqrt(dx * dx + dy * dy) || 1;
+}
+
+function applyGravity(nodes: SimNode[], cx: number, cy: number, strength: number) {
+  for (const n of nodes) {
+    if (n.fx !== null) continue;
+    n.vx += (cx - n.x) * strength;
+    n.vy += (cy - n.y) * strength;
+  }
+}
+
+function applyRepulsion(nodes: SimNode[], strength: number) {
+  for (let i = 0; i < nodes.length; i++) {
+    for (let j = i + 1; j < nodes.length; j++) {
+      const a = nodes[i];
+      const b = nodes[j];
+      if (a.fx !== null && b.fx !== null) continue;
+      const d = distance(a, b);
+      const minDist = a.radius + b.radius + 40;
+      if (d < minDist) {
+        const force = (strength * (minDist - d)) / d;
+        const dx = (a.x - b.x) * force;
+        const dy = (a.y - b.y) * force;
+        if (a.fx === null) { a.vx += dx; a.vy += dy; }
+        if (b.fx === null) { b.vx -= dx; b.vy -= dy; }
+      }
+    }
+  }
+}
+
+function applySpringForce(_nodes: SimNode[], edges: SimEdge[], nodeMap: Map<string, SimNode>) {
+  for (const edge of edges) {
+    const source = nodeMap.get(edge.source);
+    const target = nodeMap.get(edge.target);
+    if (!source || !target) continue;
+
+    const idealLen = edge.type === 'mesh' ? 180 : 80;
+    const stiffness = edge.type === 'mesh' ? 0.004 : 0.008;
+
+    const d = distance(source, target);
+    const displacement = d - idealLen;
+    const force = displacement * stiffness;
+    const dx = ((source.x - target.x) / d) * force;
+    const dy = ((source.y - target.y) / d) * force;
+
+    if (source.fx === null) { source.vx -= dx; source.vy -= dy; }
+    if (target.fx === null) { target.vx += dx; target.vy += dy; }
+  }
+}
+
+function applyDamping(nodes: SimNode[], factor: number) {
+  for (const n of nodes) {
+    n.vx *= factor;
+    n.vy *= factor;
+  }
+}
+
+function updatePositions(nodes: SimNode[]): number {
+  let totalKinetic = 0;
+  for (const n of nodes) {
+    if (n.fx !== null) { n.x = n.fx; n.y = n.fy!; n.vx = 0; n.vy = 0; continue; }
+    // Clamp velocity
+    const maxV = 8;
+    n.vx = Math.max(-maxV, Math.min(maxV, n.vx));
+    n.vy = Math.max(-maxV, Math.min(maxV, n.vy));
+    n.x += n.vx;
+    n.y += n.vy;
+    totalKinetic += n.vx * n.vx + n.vy * n.vy;
+  }
+  return totalKinetic;
+}
+
+// ---------------------------------------------------------------------------
+// Build simulation graph from fleet data
+// ---------------------------------------------------------------------------
+
+function buildGraph(machines: MachineInfo[], fleetNodes: FleetNodeInfo[], cx: number, cy: number): { nodes: SimNode[]; edges: SimEdge[] } {
+  const simNodes: SimNode[] = [];
+  const edges: SimEdge[] = [];
+
+  // Hub
+  simNodes.push({
+    id: '__hub__',
+    type: 'hub',
+    x: cx,
+    y: cy,
+    vx: 0, vy: 0,
+    fx: cx, fy: cy,
+    radius: HUB_RADIUS,
+    data: { label: 'Zenoh Mesh' } as HubData,
+  });
+
+  // Machines
+  const machineCount = machines.length;
+  machines.forEach((m, i) => {
+    const angle = (2 * Math.PI * i) / (machineCount || 1) - Math.PI / 2;
+    const r = 180;
+    simNodes.push({
+      id: `machine-${m.machineId}`,
+      type: 'machine',
+      x: cx + Math.cos(angle) * r,
+      y: cy + Math.sin(angle) * r,
+      vx: 0, vy: 0,
+      fx: null, fy: null,
+      radius: MACHINE_RADIUS,
+      data: m,
+    });
+    edges.push({ source: '__hub__', target: `machine-${m.machineId}`, type: 'mesh' });
+  });
+
+  // Service nodes
+  const nodesByMachine = new Map<string, FleetNodeInfo[]>();
+  for (const n of fleetNodes) {
+    const mid = n.machineId || 'local';
+    if (!nodesByMachine.has(mid)) nodesByMachine.set(mid, []);
+    nodesByMachine.get(mid)!.push(n);
+  }
+
+  for (const [mid, serviceNodes] of nodesByMachine.entries()) {
+    const parentId = `machine-${mid}`;
+    const parent = simNodes.find(n => n.id === parentId);
+    if (!parent) continue;
+
+    const count = serviceNodes.length;
+    serviceNodes.forEach((sn, i) => {
+      const angle = (2 * Math.PI * i) / (count || 1) - Math.PI / 2;
+      const r = 65;
+      simNodes.push({
+        id: `service-${mid}-${sn.name}`,
+        type: 'service',
+        x: parent.x + Math.cos(angle) * r,
+        y: parent.y + Math.sin(angle) * r,
+        vx: 0, vy: 0,
+        fx: null, fy: null,
+        radius: SERVICE_RADIUS,
+        data: sn,
+      });
+      edges.push({ source: parentId, target: `service-${mid}-${sn.name}`, type: 'service' });
+    });
+  }
+
+  return { nodes: simNodes, edges };
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function MeshView() {
+  const { machines, nodes: fleetNodes } = useFleetContext();
+  const svgRef = useRef<SVGSVGElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Simulation state stored in refs for performance (avoid re-renders during animation)
+  const simNodesRef = useRef<SimNode[]>([]);
+  const simEdgesRef = useRef<SimEdge[]>([]);
+  const nodeMapRef = useRef<Map<string, SimNode>>(new Map());
+  const animRef = useRef<number>(0);
+  const isSettledRef = useRef(false);
+
+  // Viewport (pan/zoom)
+  const [viewBox, setViewBox] = useState({ x: 0, y: 0, w: 1200, h: 800 });
+  const viewBoxRef = useRef(viewBox);
+  viewBoxRef.current = viewBox;
+
+  // Drag state
+  const [dragNodeId, setDragNodeId] = useState<string | null>(null);
+  const dragNodeIdRef = useRef<string | null>(null);
+  dragNodeIdRef.current = dragNodeId;
+
+  // Pan state
+  const isPanningRef = useRef(false);
+  const panStartRef = useRef({ x: 0, y: 0, vbx: 0, vby: 0 });
+
+  // Tooltip
+  const [tooltip, setTooltip] = useState<TooltipInfo | null>(null);
+
+  // Selected machine
+  const [selectedMachineId, setSelectedMachineId] = useState<string | null>(null);
+
+  // Dimensions
+  const [dims, setDims] = useState({ w: 1200, h: 800 });
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const obs = new ResizeObserver(entries => {
+      for (const entry of entries) {
+        const { width, height } = entry.contentRect;
+        if (width > 0 && height > 0) {
+          setDims({ w: width, h: height });
+        }
+      }
+    });
+    obs.observe(el);
+    return () => obs.disconnect();
+  }, []);
+
+  // Rebuild graph when machines/nodes change
+  const graphKey = useMemo(() => {
+    const machineIds = machines.map(m => m.machineId).sort().join(',');
+    const nodeIds = fleetNodes.map(n => `${n.machineId}:${n.name}`).sort().join(',');
+    return `${machineIds}|${nodeIds}`;
+  }, [machines, fleetNodes]);
+
+  useEffect(() => {
+    const cx = dims.w / 2;
+    const cy = dims.h / 2;
+    const { nodes, edges } = buildGraph(machines, fleetNodes, cx, cy);
+
+    // Preserve positions for nodes that already exist
+    const oldMap = nodeMapRef.current;
+    for (const n of nodes) {
+      const old = oldMap.get(n.id);
+      if (old) {
+        n.x = old.x;
+        n.y = old.y;
+        n.vx = old.vx;
+        n.vy = old.vy;
+        if (n.type === 'hub') {
+          n.fx = cx;
+          n.fy = cy;
+          n.x = cx;
+          n.y = cy;
+        }
+      }
+    }
+
+    simNodesRef.current = nodes;
+    simEdgesRef.current = edges;
+    const map = new Map<string, SimNode>();
+    for (const n of nodes) map.set(n.id, n);
+    nodeMapRef.current = map;
+    isSettledRef.current = false;
+
+    // Update viewBox to center
+    setViewBox({ x: 0, y: 0, w: dims.w, h: dims.h });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [graphKey, dims.w, dims.h]);
+
+  // Update data on existing nodes without rebuilding (for status changes)
+  useEffect(() => {
+    const map = nodeMapRef.current;
+    for (const m of machines) {
+      const node = map.get(`machine-${m.machineId}`);
+      if (node) node.data = m;
+    }
+    for (const fn of fleetNodes) {
+      const node = map.get(`service-${fn.machineId}-${fn.name}`);
+      if (node) node.data = fn;
+    }
+  }, [machines, fleetNodes]);
+
+  // Render loop
+  const render = useCallback(() => {
+    const svg = svgRef.current;
+    if (!svg) return;
+
+    const nodes = simNodesRef.current;
+    const edges = simEdgesRef.current;
+
+    // Render edges
+    const edgeGroup = svg.querySelector('.edges') as SVGGElement | null;
+    if (edgeGroup) {
+      // Reconcile edge elements
+      while (edgeGroup.children.length > edges.length) {
+        edgeGroup.removeChild(edgeGroup.lastChild!);
+      }
+      while (edgeGroup.children.length < edges.length) {
+        const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+        edgeGroup.appendChild(line);
+      }
+      for (let i = 0; i < edges.length; i++) {
+        const edge = edges[i];
+        const line = edgeGroup.children[i] as SVGLineElement;
+        const src = nodeMapRef.current.get(edge.source);
+        const tgt = nodeMapRef.current.get(edge.target);
+        if (!src || !tgt) continue;
+        line.setAttribute('x1', String(src.x));
+        line.setAttribute('y1', String(src.y));
+        line.setAttribute('x2', String(tgt.x));
+        line.setAttribute('y2', String(tgt.y));
+
+        const isMesh = edge.type === 'mesh';
+        const isSelected = selectedMachineId && (
+          edge.target === `machine-${selectedMachineId}` ||
+          edge.source === `machine-${selectedMachineId}` ||
+          tgt.id.startsWith(`service-${selectedMachineId}-`) ||
+          src.id.startsWith(`service-${selectedMachineId}-`)
+        );
+
+        line.setAttribute('stroke', isMesh
+          ? (isSelected ? 'rgba(61,90,254,0.7)' : 'rgba(61,90,254,0.25)')
+          : (isSelected ? 'rgba(0,229,255,0.6)' : 'rgba(0,229,255,0.15)'));
+        line.setAttribute('stroke-width', isMesh ? '2' : '1');
+        line.setAttribute('stroke-dasharray', isMesh ? '6 4' : '3 3');
+        line.setAttribute('class', 'sim-edge');
+      }
+    }
+
+    // Render nodes
+    const nodeGroup = svg.querySelector('.nodes') as SVGGElement | null;
+    if (nodeGroup) {
+      // We use a keyed approach: create elements on first pass, then update
+      const existingMap = new Map<string, SVGGElement>();
+      for (const child of Array.from(nodeGroup.children)) {
+        const id = child.getAttribute('data-id');
+        if (id) existingMap.set(id, child as SVGGElement);
+      }
+
+      for (const node of nodes) {
+        let g = existingMap.get(node.id);
+        if (!g) {
+          g = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+          g.setAttribute('data-id', node.id);
+          g.setAttribute('class', `sim-node sim-node-${node.type}`);
+          nodeGroup.appendChild(g);
+          // Build initial structure
+          if (node.type === 'hub') {
+            buildHubNode(g);
+          } else if (node.type === 'machine') {
+            buildMachineNode(g);
+          } else {
+            buildServiceNode(g);
+          }
+        }
+
+        // Update transform
+        g.setAttribute('transform', `translate(${node.x}, ${node.y})`);
+
+        // Update data-dependent attributes
+        if (node.type === 'machine') {
+          updateMachineNode(g, node.data as MachineInfo, selectedMachineId === (node.data as MachineInfo).machineId);
+        } else if (node.type === 'service') {
+          updateServiceNode(g, node.data as FleetNodeInfo,
+            selectedMachineId === (node.data as FleetNodeInfo).machineId);
+        }
+
+        existingMap.delete(node.id);
+      }
+
+      // Remove stale
+      for (const stale of existingMap.values()) {
+        nodeGroup.removeChild(stale);
+      }
+    }
+  }, [selectedMachineId]);
+
+  // Animation loop
+  useEffect(() => {
+    let running = true;
+    const cx = dims.w / 2;
+    const cy = dims.h / 2;
+
+    const tick = () => {
+      if (!running) return;
+
+      const nodes = simNodesRef.current;
+      const edges = simEdgesRef.current;
+
+      if (nodes.length > 0 && !isSettledRef.current) {
+        applyGravity(nodes, cx, cy, 0.002);
+        applyRepulsion(nodes, 2.5);
+        applySpringForce(nodes, edges, nodeMapRef.current);
+        applyDamping(nodes, 0.88);
+        const kinetic = updatePositions(nodes);
+        if (kinetic < 0.01 && !dragNodeIdRef.current) {
+          isSettledRef.current = true;
+        }
+      }
+
+      render();
+      animRef.current = requestAnimationFrame(tick);
+    };
+
+    animRef.current = requestAnimationFrame(tick);
+    return () => {
+      running = false;
+      cancelAnimationFrame(animRef.current);
+    };
+  }, [dims.w, dims.h, render]);
+
+  // Kick simulation when data changes
+  useEffect(() => {
+    isSettledRef.current = false;
+  }, [graphKey]);
+
+  // ---- Interaction: drag ----
+  const screenToSvg = useCallback((clientX: number, clientY: number) => {
+    const svg = svgRef.current;
+    if (!svg) return { x: 0, y: 0 };
+    const rect = svg.getBoundingClientRect();
+    const vb = viewBoxRef.current;
+    return {
+      x: vb.x + ((clientX - rect.left) / rect.width) * vb.w,
+      y: vb.y + ((clientY - rect.top) / rect.height) * vb.h,
+    };
+  }, []);
+
+  const handlePointerDown = useCallback((e: React.PointerEvent) => {
+    const svg = svgRef.current;
+    if (!svg) return;
+
+    const pt = screenToSvg(e.clientX, e.clientY);
+
+    // Check if clicking on a node
+    const nodes = simNodesRef.current;
+    let hit: SimNode | null = null;
+    // Check in reverse order (top-most first)
+    for (let i = nodes.length - 1; i >= 0; i--) {
+      const n = nodes[i];
+      const dx = pt.x - n.x;
+      const dy = pt.y - n.y;
+      const hitRadius = n.type === 'machine' ? n.radius + 20 : n.radius + 6;
+      if (dx * dx + dy * dy < hitRadius * hitRadius) {
+        hit = n;
+        break;
+      }
+    }
+
+    if (hit && hit.type !== 'hub') {
+      // Start dragging node
+      setDragNodeId(hit.id);
+      hit.fx = hit.x;
+      hit.fy = hit.y;
+      isSettledRef.current = false;
+      svg.setPointerCapture(e.pointerId);
+      e.preventDefault();
+
+      // Select machine on click
+      if (hit.type === 'machine') {
+        const machineData = hit.data as MachineInfo;
+        setSelectedMachineId(prev => prev === machineData.machineId ? null : machineData.machineId);
+      } else if (hit.type === 'service') {
+        const serviceData = hit.data as FleetNodeInfo;
+        setSelectedMachineId(prev => prev === serviceData.machineId ? null : serviceData.machineId);
+      }
+    } else if (!hit) {
+      // Start panning
+      isPanningRef.current = true;
+      panStartRef.current = { x: e.clientX, y: e.clientY, vbx: viewBoxRef.current.x, vby: viewBoxRef.current.y };
+      svg.setPointerCapture(e.pointerId);
+      e.preventDefault();
+      setSelectedMachineId(null);
+    }
+  }, [screenToSvg]);
+
+  const handlePointerMove = useCallback((e: React.PointerEvent) => {
+    if (dragNodeIdRef.current) {
+      const pt = screenToSvg(e.clientX, e.clientY);
+      const node = nodeMapRef.current.get(dragNodeIdRef.current);
+      if (node) {
+        node.fx = pt.x;
+        node.fy = pt.y;
+        isSettledRef.current = false;
+      }
+      e.preventDefault();
+    } else if (isPanningRef.current) {
+      const svg = svgRef.current;
+      if (!svg) return;
+      const rect = svg.getBoundingClientRect();
+      const vb = viewBoxRef.current;
+      const scaleX = vb.w / rect.width;
+      const scaleY = vb.h / rect.height;
+      const dx = (e.clientX - panStartRef.current.x) * scaleX;
+      const dy = (e.clientY - panStartRef.current.y) * scaleY;
+      setViewBox(prev => ({
+        ...prev,
+        x: panStartRef.current.vbx - dx,
+        y: panStartRef.current.vby - dy,
+      }));
+      e.preventDefault();
+    } else {
+      // Hover tooltip
+      const pt = screenToSvg(e.clientX, e.clientY);
+      const nodes = simNodesRef.current;
+      let hit: SimNode | null = null;
+      for (let i = nodes.length - 1; i >= 0; i--) {
+        const n = nodes[i];
+        const dx = pt.x - n.x;
+        const dy = pt.y - n.y;
+        const hitR = n.type === 'machine' ? n.radius + 20 : n.radius + 6;
+        if (dx * dx + dy * dy < hitR * hitR) {
+          hit = n;
+          break;
+        }
+      }
+      if (hit) {
+        setTooltip({ x: e.clientX, y: e.clientY, node: hit });
+      } else {
+        setTooltip(null);
+      }
+    }
+  }, [screenToSvg]);
+
+  const handlePointerUp = useCallback((e: React.PointerEvent) => {
+    if (dragNodeIdRef.current) {
+      const node = nodeMapRef.current.get(dragNodeIdRef.current);
+      if (node) {
+        node.fx = null;
+        node.fy = null;
+      }
+      setDragNodeId(null);
+      isSettledRef.current = false;
+    }
+    if (isPanningRef.current) {
+      isPanningRef.current = false;
+    }
+    const svg = svgRef.current;
+    if (svg) svg.releasePointerCapture(e.pointerId);
+  }, []);
+
+  // Zoom
+  const handleWheel = useCallback((e: React.WheelEvent) => {
+    e.preventDefault();
+    const svg = svgRef.current;
+    if (!svg) return;
+
+    const rect = svg.getBoundingClientRect();
+    const vb = viewBoxRef.current;
+
+    // Mouse position in SVG coordinates
+    const mx = vb.x + ((e.clientX - rect.left) / rect.width) * vb.w;
+    const my = vb.y + ((e.clientY - rect.top) / rect.height) * vb.h;
+
+    const factor = e.deltaY > 0 ? 1.08 : 0.93;
+    const newW = Math.max(400, Math.min(6000, vb.w * factor));
+    const newH = Math.max(300, Math.min(4500, vb.h * factor));
+
+    // Zoom toward mouse position
+    const newX = mx - ((mx - vb.x) / vb.w) * newW;
+    const newY = my - ((my - vb.y) / vb.h) * newH;
+
+    setViewBox({ x: newX, y: newY, w: newW, h: newH });
+  }, []);
+
+  // Empty state
+  const isEmpty = machines.length === 0 && fleetNodes.length === 0;
+
+  return (
+    <div className="mesh-view" ref={containerRef}>
+      {isEmpty ? (
+        <div className="mesh-empty">
+          <div className="mesh-empty-inner">
+            <div className="mesh-empty-pulse" />
+            <div className="mesh-empty-icon">
+              <svg width="48" height="48" viewBox="0 0 48 48" fill="none">
+                <circle cx="24" cy="24" r="8" stroke="url(#emptyGrad)" strokeWidth="2" />
+                <circle cx="10" cy="14" r="3" stroke="var(--text-muted)" strokeWidth="1.5" />
+                <circle cx="38" cy="14" r="3" stroke="var(--text-muted)" strokeWidth="1.5" />
+                <circle cx="10" cy="34" r="3" stroke="var(--text-muted)" strokeWidth="1.5" />
+                <circle cx="38" cy="34" r="3" stroke="var(--text-muted)" strokeWidth="1.5" />
+                <line x1="17" y1="19" x2="13" y2="16" stroke="var(--text-muted)" strokeWidth="1" strokeDasharray="2 2" />
+                <line x1="31" y1="19" x2="35" y2="16" stroke="var(--text-muted)" strokeWidth="1" strokeDasharray="2 2" />
+                <line x1="17" y1="29" x2="13" y2="32" stroke="var(--text-muted)" strokeWidth="1" strokeDasharray="2 2" />
+                <line x1="31" y1="29" x2="35" y2="32" stroke="var(--text-muted)" strokeWidth="1" strokeDasharray="2 2" />
+                <defs>
+                  <linearGradient id="emptyGrad" x1="16" y1="16" x2="32" y2="32">
+                    <stop offset="0%" stopColor="#3d5afe" />
+                    <stop offset="100%" stopColor="#00e5ff" />
+                  </linearGradient>
+                </defs>
+              </svg>
+            </div>
+            <p className="mesh-empty-text">Waiting for machines to connect to the mesh...</p>
+            <p className="mesh-empty-hint">Nodes will appear here as they join the Zenoh network</p>
+          </div>
+        </div>
+      ) : (
+        <>
+          <svg
+            ref={svgRef}
+            className="mesh-svg"
+            viewBox={`${viewBox.x} ${viewBox.y} ${viewBox.w} ${viewBox.h}`}
+            onPointerDown={handlePointerDown}
+            onPointerMove={handlePointerMove}
+            onPointerUp={handlePointerUp}
+            onWheel={handleWheel}
+          >
+            <defs>
+              <radialGradient id="meshHubGradient" cx="40%" cy="40%">
+                <stop offset="0%" stopColor="#5c7cff" />
+                <stop offset="50%" stopColor="#3d5afe" />
+                <stop offset="100%" stopColor="#00b8d4" />
+              </radialGradient>
+              <radialGradient id="meshHubGlow" cx="50%" cy="50%">
+                <stop offset="0%" stopColor="rgba(61,90,254,0.4)" />
+                <stop offset="100%" stopColor="rgba(61,90,254,0)" />
+              </radialGradient>
+              <filter id="meshGlow" x="-50%" y="-50%" width="200%" height="200%">
+                <feGaussianBlur stdDeviation="6" result="blur" />
+                <feMerge>
+                  <feMergeNode in="blur" />
+                  <feMergeNode in="SourceGraphic" />
+                </feMerge>
+              </filter>
+              <filter id="meshGlowSmall" x="-50%" y="-50%" width="200%" height="200%">
+                <feGaussianBlur stdDeviation="3" result="blur" />
+                <feMerge>
+                  <feMergeNode in="blur" />
+                  <feMergeNode in="SourceGraphic" />
+                </feMerge>
+              </filter>
+              <linearGradient id="meshAccentGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+                <stop offset="0%" stopColor="#3d5afe" />
+                <stop offset="100%" stopColor="#00e5ff" />
+              </linearGradient>
+            </defs>
+
+            {/* Background grid pattern */}
+            <defs>
+              <pattern id="meshGrid" width="40" height="40" patternUnits="userSpaceOnUse">
+                <path d="M 40 0 L 0 0 0 40" fill="none" stroke="rgba(42,42,58,0.3)" strokeWidth="0.5" />
+              </pattern>
+            </defs>
+            <rect x={viewBox.x - 500} y={viewBox.y - 500} width={viewBox.w + 1000} height={viewBox.h + 1000} fill="url(#meshGrid)" />
+
+            {/* Edges layer */}
+            <g className="edges" />
+
+            {/* Nodes layer */}
+            <g className="nodes" />
+          </svg>
+
+          {/* Tooltip overlay */}
+          {tooltip && <MeshTooltip tooltip={tooltip} />}
+        </>
+      )}
+
+      <style>{`
+        .mesh-view {
+          flex: 1;
+          position: relative;
+          overflow: hidden;
+          background:
+            radial-gradient(ellipse at 30% 20%, rgba(61, 90, 254, 0.06) 0%, transparent 60%),
+            radial-gradient(ellipse at 70% 80%, rgba(0, 229, 255, 0.04) 0%, transparent 60%),
+            var(--bg-primary);
+        }
+
+        .mesh-svg {
+          width: 100%;
+          height: 100%;
+          display: block;
+          cursor: grab;
+          user-select: none;
+          touch-action: none;
+        }
+
+        .mesh-svg:active {
+          cursor: grabbing;
+        }
+
+        .sim-edge {
+          animation: meshEdgeFlow 1.2s linear infinite;
+        }
+
+        @keyframes meshEdgeFlow {
+          from { stroke-dashoffset: 10; }
+          to { stroke-dashoffset: 0; }
+        }
+
+        .sim-node {
+          cursor: pointer;
+        }
+
+        .sim-node-hub {
+          cursor: default;
+        }
+
+        /* Empty state */
+        .mesh-empty {
+          position: absolute;
+          inset: 0;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+        }
+
+        .mesh-empty-inner {
+          text-align: center;
+          position: relative;
+        }
+
+        .mesh-empty-pulse {
+          position: absolute;
+          top: 50%;
+          left: 50%;
+          transform: translate(-50%, -50%);
+          width: 120px;
+          height: 120px;
+          border-radius: 50%;
+          background: radial-gradient(circle, rgba(61,90,254,0.08) 0%, transparent 70%);
+          animation: meshEmptyPulse 3s ease-in-out infinite;
+        }
+
+        @keyframes meshEmptyPulse {
+          0%, 100% { transform: translate(-50%, -50%) scale(1); opacity: 0.6; }
+          50% { transform: translate(-50%, -50%) scale(1.4); opacity: 0.2; }
+        }
+
+        .mesh-empty-icon {
+          position: relative;
+          margin-bottom: 20px;
+          display: inline-block;
+        }
+
+        .mesh-empty-text {
+          font-size: 15px;
+          color: var(--text-secondary);
+          margin: 0 0 6px;
+        }
+
+        .mesh-empty-hint {
+          font-size: 12px;
+          color: var(--text-muted);
+          margin: 0;
+        }
+
+        /* Tooltip */
+        .mesh-tooltip {
+          position: fixed;
+          pointer-events: none;
+          z-index: 200;
+          background: var(--bg-card);
+          border: 1px solid var(--border-color);
+          border-radius: 10px;
+          padding: 12px 16px;
+          box-shadow: 0 8px 32px rgba(0,0,0,0.5);
+          min-width: 160px;
+          max-width: 280px;
+        }
+
+        .mesh-tooltip-title {
+          font-size: 13px;
+          font-weight: 600;
+          color: var(--text-primary);
+          margin-bottom: 6px;
+          display: flex;
+          align-items: center;
+          gap: 6px;
+        }
+
+        .mesh-tooltip-dot {
+          width: 6px;
+          height: 6px;
+          border-radius: 50%;
+          flex-shrink: 0;
+        }
+
+        .mesh-tooltip-row {
+          display: flex;
+          justify-content: space-between;
+          gap: 12px;
+          font-size: 11px;
+          line-height: 1.6;
+        }
+
+        .mesh-tooltip-label {
+          color: var(--text-muted);
+          text-transform: uppercase;
+          letter-spacing: 0.3px;
+          font-weight: 600;
+        }
+
+        .mesh-tooltip-value {
+          color: var(--text-secondary);
+          font-family: 'JetBrains Mono', monospace;
+          text-align: right;
+        }
+
+        /* Mobile */
+        @media (max-width: 768px) {
+          .mesh-tooltip {
+            display: none;
+          }
+        }
+      `}</style>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// SVG node builders (imperative for performance in the render loop)
+// ---------------------------------------------------------------------------
+
+function buildHubNode(g: SVGGElement) {
+  const ns = 'http://www.w3.org/2000/svg';
+
+  // Outer glow
+  const glowCircle = document.createElementNS(ns, 'circle');
+  glowCircle.setAttribute('r', String(HUB_RADIUS + 20));
+  glowCircle.setAttribute('fill', 'url(#meshHubGlow)');
+  g.appendChild(glowCircle);
+
+  // Pulse ring
+  const pulseRing = document.createElementNS(ns, 'circle');
+  pulseRing.setAttribute('r', String(HUB_RADIUS + 4));
+  pulseRing.setAttribute('fill', 'none');
+  pulseRing.setAttribute('stroke', 'rgba(61,90,254,0.3)');
+  pulseRing.setAttribute('stroke-width', '1');
+  pulseRing.setAttribute('class', 'hub-pulse-ring');
+  g.appendChild(pulseRing);
+
+  // Main circle
+  const circle = document.createElementNS(ns, 'circle');
+  circle.setAttribute('r', String(HUB_RADIUS));
+  circle.setAttribute('fill', 'url(#meshHubGradient)');
+  circle.setAttribute('filter', 'url(#meshGlow)');
+  g.appendChild(circle);
+
+  // Inner highlight
+  const inner = document.createElementNS(ns, 'circle');
+  inner.setAttribute('r', String(HUB_RADIUS - 8));
+  inner.setAttribute('fill', 'none');
+  inner.setAttribute('stroke', 'rgba(255,255,255,0.15)');
+  inner.setAttribute('stroke-width', '1');
+  g.appendChild(inner);
+
+  // Label
+  const text = document.createElementNS(ns, 'text');
+  text.setAttribute('text-anchor', 'middle');
+  text.setAttribute('dy', '0.35em');
+  text.setAttribute('fill', '#fff');
+  text.setAttribute('font-size', '11');
+  text.setAttribute('font-weight', '700');
+  text.setAttribute('font-family', "'Outfit', sans-serif");
+  text.setAttribute('letter-spacing', '0.5');
+  text.textContent = 'ZENOH';
+  g.appendChild(text);
+
+  // Sub-label
+  const sub = document.createElementNS(ns, 'text');
+  sub.setAttribute('text-anchor', 'middle');
+  sub.setAttribute('dy', '0');
+  sub.setAttribute('y', '16');
+  sub.setAttribute('fill', 'rgba(255,255,255,0.6)');
+  sub.setAttribute('font-size', '8');
+  sub.setAttribute('font-family', "'Outfit', sans-serif");
+  sub.setAttribute('letter-spacing', '1');
+  sub.textContent = 'MESH';
+  g.appendChild(sub);
+
+  // Add CSS animation for pulse ring
+  const style = document.createElementNS(ns, 'style');
+  style.textContent = `
+    .hub-pulse-ring {
+      animation: hubPulse 2.5s ease-in-out infinite;
+      transform-origin: center;
+    }
+    @keyframes hubPulse {
+      0%, 100% { r: ${HUB_RADIUS + 4}; opacity: 0.4; }
+      50% { r: ${HUB_RADIUS + 14}; opacity: 0; }
+    }
+  `;
+  g.appendChild(style);
+}
+
+function buildMachineNode(g: SVGGElement) {
+  const ns = 'http://www.w3.org/2000/svg';
+  const w = 130;
+  const h = 56;
+
+  // Glow backdrop
+  const glow = document.createElementNS(ns, 'rect');
+  glow.setAttribute('x', String(-w / 2 - 3));
+  glow.setAttribute('y', String(-h / 2 - 3));
+  glow.setAttribute('width', String(w + 6));
+  glow.setAttribute('height', String(h + 6));
+  glow.setAttribute('rx', '14');
+  glow.setAttribute('fill', 'none');
+  glow.setAttribute('stroke', 'rgba(0,200,83,0.2)');
+  glow.setAttribute('stroke-width', '1');
+  glow.setAttribute('class', 'machine-glow');
+  glow.setAttribute('filter', 'url(#meshGlowSmall)');
+  g.appendChild(glow);
+
+  // Background rect
+  const rect = document.createElementNS(ns, 'rect');
+  rect.setAttribute('x', String(-w / 2));
+  rect.setAttribute('y', String(-h / 2));
+  rect.setAttribute('width', String(w));
+  rect.setAttribute('height', String(h));
+  rect.setAttribute('rx', '12');
+  rect.setAttribute('fill', 'var(--bg-card)');
+  rect.setAttribute('stroke', 'var(--border-color)');
+  rect.setAttribute('stroke-width', '1');
+  rect.setAttribute('class', 'machine-rect');
+  g.appendChild(rect);
+
+  // Status dot
+  const dot = document.createElementNS(ns, 'circle');
+  dot.setAttribute('cx', String(-w / 2 + 14));
+  dot.setAttribute('cy', String(-h / 2 + 14));
+  dot.setAttribute('r', '3');
+  dot.setAttribute('fill', '#00c853');
+  dot.setAttribute('class', 'machine-status-dot');
+  g.appendChild(dot);
+
+  // Hostname
+  const hostname = document.createElementNS(ns, 'text');
+  hostname.setAttribute('x', '0');
+  hostname.setAttribute('y', String(-6));
+  hostname.setAttribute('text-anchor', 'middle');
+  hostname.setAttribute('fill', 'var(--text-primary)');
+  hostname.setAttribute('font-size', '12');
+  hostname.setAttribute('font-weight', '600');
+  hostname.setAttribute('font-family', "'Outfit', sans-serif");
+  hostname.setAttribute('class', 'machine-hostname');
+  hostname.textContent = '';
+  g.appendChild(hostname);
+
+  // IP + node count
+  const info = document.createElementNS(ns, 'text');
+  info.setAttribute('x', '0');
+  info.setAttribute('y', String(10));
+  info.setAttribute('text-anchor', 'middle');
+  info.setAttribute('fill', 'var(--text-muted)');
+  info.setAttribute('font-size', '9');
+  info.setAttribute('font-family', "'JetBrains Mono', monospace");
+  info.setAttribute('class', 'machine-info');
+  info.textContent = '';
+  g.appendChild(info);
+}
+
+function updateMachineNode(g: SVGGElement, data: MachineInfo, isSelected: boolean) {
+  const hostname = g.querySelector('.machine-hostname') as SVGTextElement | null;
+  if (hostname) {
+    const label = data.hostname.length > 14 ? data.hostname.slice(0, 13) + '...' : data.hostname;
+    if (hostname.textContent !== label) hostname.textContent = label;
+  }
+
+  const info = g.querySelector('.machine-info') as SVGTextElement | null;
+  if (info) {
+    const ip = data.ips[0] || '';
+    const label = `${ip}  ${data.runningCount}/${data.nodeCount}`;
+    if (info.textContent !== label) info.textContent = label;
+  }
+
+  const dot = g.querySelector('.machine-status-dot') as SVGCircleElement | null;
+  if (dot) {
+    dot.setAttribute('fill', data.isOnline ? '#00c853' : '#ff1744');
+  }
+
+  const glowRect = g.querySelector('.machine-glow') as SVGRectElement | null;
+  if (glowRect) {
+    glowRect.setAttribute('stroke', data.isOnline ? 'rgba(0,200,83,0.25)' : 'rgba(255,23,68,0.25)');
+  }
+
+  const rect = g.querySelector('.machine-rect') as SVGRectElement | null;
+  if (rect) {
+    rect.setAttribute('stroke', isSelected ? 'var(--accent-primary)' : 'var(--border-color)');
+    rect.setAttribute('stroke-width', isSelected ? '2' : '1');
+  }
+}
+
+function buildServiceNode(g: SVGGElement) {
+  const ns = 'http://www.w3.org/2000/svg';
+
+  // Outer ring
+  const ring = document.createElementNS(ns, 'circle');
+  ring.setAttribute('r', String(SERVICE_RADIUS + 3));
+  ring.setAttribute('fill', 'none');
+  ring.setAttribute('stroke', 'rgba(0,200,83,0.2)');
+  ring.setAttribute('stroke-width', '1');
+  ring.setAttribute('class', 'service-ring');
+  g.appendChild(ring);
+
+  // Main circle
+  const circle = document.createElementNS(ns, 'circle');
+  circle.setAttribute('r', String(SERVICE_RADIUS));
+  circle.setAttribute('fill', '#00c853');
+  circle.setAttribute('class', 'service-circle');
+  circle.setAttribute('filter', 'url(#meshGlowSmall)');
+  g.appendChild(circle);
+
+  // Label
+  const text = document.createElementNS(ns, 'text');
+  text.setAttribute('y', String(SERVICE_RADIUS + 14));
+  text.setAttribute('text-anchor', 'middle');
+  text.setAttribute('fill', 'var(--text-muted)');
+  text.setAttribute('font-size', '9');
+  text.setAttribute('font-family', "'Outfit', sans-serif");
+  text.setAttribute('class', 'service-label');
+  text.textContent = '';
+  g.appendChild(text);
+}
+
+function updateServiceNode(g: SVGGElement, data: FleetNodeInfo, isSelected: boolean) {
+  const color = STATUS_COLORS[data.status] || STATUS_COLORS.unknown;
+
+  const circle = g.querySelector('.service-circle') as SVGCircleElement | null;
+  if (circle) {
+    circle.setAttribute('fill', color);
+  }
+
+  const ring = g.querySelector('.service-ring') as SVGCircleElement | null;
+  if (ring) {
+    const alpha = isSelected ? '0.5' : '0.2';
+    ring.setAttribute('stroke', color.replace(')', `, ${alpha})`).replace('rgb', 'rgba').replace('#', ''));
+    // For hex colors, convert to rgba
+    ring.setAttribute('stroke', `${color}${isSelected ? '80' : '33'}`);
+    ring.setAttribute('stroke-width', isSelected ? '2' : '1');
+  }
+
+  const label = g.querySelector('.service-label') as SVGTextElement | null;
+  if (label) {
+    const name = data.name.length > 16 ? data.name.slice(0, 15) + '..' : data.name;
+    if (label.textContent !== name) label.textContent = name;
+    label.setAttribute('fill', isSelected ? 'var(--text-secondary)' : 'var(--text-muted)');
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tooltip subcomponent
+// ---------------------------------------------------------------------------
+
+function MeshTooltip({ tooltip }: { tooltip: TooltipInfo }) {
+  const { node, x, y } = tooltip;
+
+  let content: React.ReactNode;
+
+  if (node.type === 'hub') {
+    content = (
+      <>
+        <div className="mesh-tooltip-title">Zenoh Mesh Hub</div>
+        <div className="mesh-tooltip-row">
+          <span className="mesh-tooltip-label">Role</span>
+          <span className="mesh-tooltip-value">Router</span>
+        </div>
+      </>
+    );
+  } else if (node.type === 'machine') {
+    const data = node.data as MachineInfo;
+    content = (
+      <>
+        <div className="mesh-tooltip-title">
+          <span className="mesh-tooltip-dot" style={{ backgroundColor: data.isOnline ? '#00c853' : '#ff1744' }} />
+          {data.hostname}
+        </div>
+        <div className="mesh-tooltip-row">
+          <span className="mesh-tooltip-label">Status</span>
+          <span className="mesh-tooltip-value">{data.isOnline ? 'Online' : 'Offline'}</span>
+        </div>
+        {data.ips.length > 0 && (
+          <div className="mesh-tooltip-row">
+            <span className="mesh-tooltip-label">IP</span>
+            <span className="mesh-tooltip-value">{data.ips[0]}</span>
+          </div>
+        )}
+        <div className="mesh-tooltip-row">
+          <span className="mesh-tooltip-label">Nodes</span>
+          <span className="mesh-tooltip-value">{data.runningCount}/{data.nodeCount} running</span>
+        </div>
+      </>
+    );
+  } else {
+    const data = node.data as FleetNodeInfo;
+    const color = STATUS_COLORS[data.status] || STATUS_COLORS.unknown;
+    content = (
+      <>
+        <div className="mesh-tooltip-title">
+          <span className="mesh-tooltip-dot" style={{ backgroundColor: color }} />
+          {data.name}
+        </div>
+        <div className="mesh-tooltip-row">
+          <span className="mesh-tooltip-label">Status</span>
+          <span className="mesh-tooltip-value">{data.status}</span>
+        </div>
+        <div className="mesh-tooltip-row">
+          <span className="mesh-tooltip-label">Machine</span>
+          <span className="mesh-tooltip-value">{data.hostname}</span>
+        </div>
+        <div className="mesh-tooltip-row">
+          <span className="mesh-tooltip-label">Type</span>
+          <span className="mesh-tooltip-value">{data.nodeType}</span>
+        </div>
+        {data.version && (
+          <div className="mesh-tooltip-row">
+            <span className="mesh-tooltip-label">Version</span>
+            <span className="mesh-tooltip-value">{data.version}</span>
+          </div>
+        )}
+      </>
+    );
+  }
+
+  return (
+    <div
+      className="mesh-tooltip"
+      style={{
+        left: x + 16,
+        top: y - 10,
+      }}
+    >
+      {content}
+    </div>
+  );
+}

--- a/dashboard/src/components/NodesView.tsx
+++ b/dashboard/src/components/NodesView.tsx
@@ -20,6 +20,7 @@ interface NodeState {
   build_output: string[];
   machine_id?: string;
   machine_hostname?: string;
+  machine_ips?: string[];
   stale?: boolean;
 }
 
@@ -102,6 +103,7 @@ export function NodesViewPanel({
           build_output: n.buildOutput,
           machine_id: n.machineId || listMachineId,
           machine_hostname: n.machineHostname,
+          machine_ips: n.machineIps || [],
         }));
         setDaemonConnected(true);
         setError(null);
@@ -405,6 +407,7 @@ export function NodesViewPanel({
       nodeCount: g.nodes.length,
       runningCount: g.nodes.filter(n => n.status === 'running').length,
       isOnline: g.isOnline,
+      ips: g.nodes[0]?.machine_ips || [],
     })));
   }, [machineGroups, reportMachines]);
 
@@ -534,6 +537,7 @@ export function NodesViewPanel({
                         <span className={`collapse-arrow ${isCollapsed ? 'collapsed' : ''}`}>&#9660;</span>
                         <span className={`machine-status-dot ${group.isOnline ? 'online' : 'offline'}`} />
                         <span>{group.hostname}</span>
+                        <span className="machine-ip">{group.nodes[0]?.machine_ips?.[0] || ''}</span>
                         <span className="machine-node-count">
                           {runningCount}/{group.nodes.length} running
                         </span>
@@ -814,6 +818,12 @@ export function NodesViewPanel({
           background: var(--error);
         }
 
+        .machine-ip {
+          font-size: 11px;
+          font-family: 'JetBrains Mono', monospace;
+          color: var(--text-muted);
+        }
+
         .machine-node-count {
           color: var(--text-muted);
           font-weight: 400;
@@ -910,6 +920,12 @@ function NodeDetail({ node, onCommand, onFetchLogs, actionLoading, onClose }: No
           <span className="label">Machine</span>
           <span className="value">{node.machine_hostname || 'local'}</span>
         </div>
+        {node.machine_ips && node.machine_ips.length > 0 && (
+          <div className="info-row full">
+            <span className="label">IPs</span>
+            <span className="value mono">{node.machine_ips.join(', ')}</span>
+          </div>
+        )}
         {node.description && (
           <div className="info-row full">
             <span className="label">Description</span>

--- a/dashboard/src/components/NodesView.tsx
+++ b/dashboard/src/components/NodesView.tsx
@@ -506,6 +506,7 @@ export function NodesViewPanel({
                 <span className="col-status">St</span>
                 <span className="col-name">Name</span>
                 <span className="col-machine">Machine</span>
+                <span className="col-ip">IP</span>
                 <span className="col-version">Version</span>
                 <span className="col-type">Type</span>
               </div>
@@ -529,6 +530,7 @@ export function NodesViewPanel({
                       </span>
                       <span className="col-name">{node.name}</span>
                       <span className="col-machine">{node.machine_hostname || 'local'}</span>
+                      <span className="col-ip mono">{node.machine_ips?.[0] || ''}</span>
                       <span className="col-version">{node.version}</span>
                       <span className={`col-type type-${node.node_type}`}>{node.node_type}</span>
                     </div>
@@ -570,6 +572,7 @@ export function NodesViewPanel({
                             </span>
                             <span className="col-name">{node.name}</span>
                             <span className="col-machine">{node.machine_hostname || 'local'}</span>
+                            <span className="col-ip mono">{node.machine_ips?.[0] || ''}</span>
                             <span className="col-version">{node.version}</span>
                             <span className={`col-type type-${node.node_type}`}>{node.node_type}</span>
                           </div>
@@ -756,6 +759,11 @@ export function NodesViewPanel({
           z-index: 1;
         }
 
+        .list-header .col-ip {
+          font-family: inherit;
+          font-size: inherit;
+        }
+
         .node-row {
           display: flex;
           padding: 10px 16px;
@@ -777,6 +785,15 @@ export function NodesViewPanel({
         .col-status { width: 30px; text-align: center; }
         .col-name { flex: 1; color: var(--text-primary); font-weight: 500; }
         .col-machine { width: 100px; color: var(--text-muted); font-size: 11px; }
+        .col-ip {
+          flex: 1.2;
+          font-family: 'JetBrains Mono', monospace;
+          font-size: 11px;
+          color: var(--text-muted);
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
         .col-version { width: 70px; color: var(--accent-secondary); font-family: 'JetBrains Mono', monospace; }
         .col-type { width: 60px; text-transform: uppercase; font-size: 10px; font-weight: 600; }
 

--- a/dashboard/src/components/NodesView.tsx
+++ b/dashboard/src/components/NodesView.tsx
@@ -397,8 +397,8 @@ export function NodesViewPanel({
     return Array.from(groups.values());
   }, [nodes]);
 
-  // Report machines to FleetContext for the FleetBar
-  const { reportMachines, selectedMachineId } = useFleetContext();
+  // Report machines and nodes to FleetContext for the FleetBar and MeshView
+  const { reportMachines, reportNodes, selectedMachineId } = useFleetContext();
 
   useEffect(() => {
     reportMachines(machineGroups.map(g => ({
@@ -410,6 +410,18 @@ export function NodesViewPanel({
       ips: g.nodes[0]?.machine_ips || [],
     })));
   }, [machineGroups, reportMachines]);
+
+  useEffect(() => {
+    reportNodes(nodes.map(n => ({
+      name: n.name,
+      status: n.status,
+      machineId: n.machine_id || 'local',
+      hostname: n.machine_hostname || 'local',
+      ips: n.machine_ips || [],
+      nodeType: n.node_type,
+      version: n.version,
+    })));
+  }, [nodes, reportNodes]);
 
   // Filter by selected machine from FleetBar
   const filteredMachineGroups = useMemo(() => {

--- a/dashboard/src/components/SortableNodesCard.tsx
+++ b/dashboard/src/components/SortableNodesCard.tsx
@@ -31,6 +31,7 @@ export function SortableNodesCard({
     minWidth: 0,
     overflow: 'hidden',
     display: isHidden ? 'none' : undefined,
+    gridColumn: '1 / -1',
   };
 
   return (

--- a/dashboard/src/components/StatsView.tsx
+++ b/dashboard/src/components/StatsView.tsx
@@ -1,5 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
 import { useZenohSubscriptionContext } from '../contexts/ZenohSubscriptionContext';
+import { useFleetContext } from '../contexts/FleetContext';
+import { MachineBadge } from './MachineBadge';
 
 interface DragHandleProps {
   [key: string]: unknown;
@@ -22,6 +24,7 @@ export function StatsViewPanel({
   onRemove,
   dragHandleProps,
 }: StatsViewProps) {
+  const { machines } = useFleetContext();
   const { getAllMonitoredStats, startMonitoring, isMonitoringEnabled } = useZenohSubscriptionContext();
   const [stats, setStats] = useState<DisplayStats[]>([]);
   const [monitoringStarted, setMonitoringStarted] = useState(false);
@@ -95,6 +98,7 @@ export function StatsViewPanel({
             <path d="M18 20V10M12 20V4M6 20v-6" />
           </svg>
           <span className="panel-type-badge">STATS</span>
+          <MachineBadge machines={machines} />
         </div>
         <div className="panel-actions">
           <button
@@ -191,6 +195,19 @@ export function StatsViewPanel({
           background: rgba(0, 229, 255, 0.15);
           color: var(--accent-secondary);
           text-transform: uppercase;
+          white-space: nowrap;
+        }
+
+        .panel-machine-badge {
+          font-size: 10px;
+          font-family: 'JetBrains Mono', monospace;
+          color: var(--text-muted);
+          background: var(--bg-tertiary);
+          padding: 2px 6px;
+          border-radius: 4px;
+          max-width: 120px;
+          overflow: hidden;
+          text-overflow: ellipsis;
           white-space: nowrap;
         }
 

--- a/dashboard/src/components/WeatherView.tsx
+++ b/dashboard/src/components/WeatherView.tsx
@@ -3,6 +3,8 @@ import { Sample, IntoZBytes } from '@eclipse-zenoh/zenoh-ts';
 import { getSamplePayload } from '../lib/zenoh';
 import { useZenohSubscription } from '../hooks/useZenohSubscription';
 import { useZenohSubscriptionContext } from '../contexts/ZenohSubscriptionContext';
+import { useFleetContext } from '../contexts/FleetContext';
+import { MachineBadge } from './MachineBadge';
 import {
   decodeCurrentWeather,
   decodeHourlyForecast,
@@ -39,6 +41,7 @@ export function WeatherViewPanel({
   onRemove,
   dragHandleProps,
 }: WeatherViewPanelProps) {
+  const { machines } = useFleetContext();
   // Get session from context for publishing
   const { getSession } = useZenohSubscriptionContext();
   // Store all three types of weather data
@@ -308,6 +311,7 @@ export function WeatherViewPanel({
             </button>
           )}
           <span className="panel-type-badge">WEATHER</span>
+          <MachineBadge machines={machines} />
         </div>
         <div className="panel-stats">
           <span className="stat">
@@ -512,6 +516,19 @@ export function WeatherViewPanel({
           text-transform: uppercase;
           white-space: nowrap;
           flex-shrink: 0;
+        }
+
+        .panel-machine-badge {
+          font-size: 10px;
+          font-family: 'JetBrains Mono', monospace;
+          color: var(--text-muted);
+          background: var(--bg-tertiary);
+          padding: 2px 6px;
+          border-radius: 4px;
+          max-width: 120px;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
         }
 
         .panel-stats {

--- a/dashboard/src/contexts/FleetContext.tsx
+++ b/dashboard/src/contexts/FleetContext.tsx
@@ -9,9 +9,21 @@ export interface MachineInfo {
   ips: string[];
 }
 
+export interface FleetNodeInfo {
+  name: string;
+  status: string;
+  machineId: string;
+  hostname: string;
+  ips: string[];
+  nodeType: string;
+  version: string;
+}
+
 interface FleetContextValue {
   machines: MachineInfo[];
   reportMachines: (machines: MachineInfo[]) => void;
+  nodes: FleetNodeInfo[];
+  reportNodes: (nodes: FleetNodeInfo[]) => void;
   selectedMachineId: string | null; // null = all machines
   setSelectedMachineId: (id: string | null) => void;
 }
@@ -20,20 +32,27 @@ interface FleetContextValue {
 const FleetContext = createContext<FleetContextValue>({
   machines: [],
   reportMachines: () => {},
+  nodes: [],
+  reportNodes: () => {},
   selectedMachineId: null,
   setSelectedMachineId: () => {},
 });
 
 export function FleetProvider({ children }: { children: ReactNode }) {
   const [machines, setMachines] = useState<MachineInfo[]>([]);
+  const [nodes, setNodes] = useState<FleetNodeInfo[]>([]);
   const [selectedMachineId, setSelectedMachineId] = useState<string | null>(null);
 
   const reportMachines = useCallback((newMachines: MachineInfo[]) => {
     setMachines(newMachines);
   }, []);
 
+  const reportNodes = useCallback((newNodes: FleetNodeInfo[]) => {
+    setNodes(newNodes);
+  }, []);
+
   return (
-    <FleetContext.Provider value={{ machines, reportMachines, selectedMachineId, setSelectedMachineId }}>
+    <FleetContext.Provider value={{ machines, reportMachines, nodes, reportNodes, selectedMachineId, setSelectedMachineId }}>
       {children}
     </FleetContext.Provider>
   );

--- a/dashboard/src/contexts/FleetContext.tsx
+++ b/dashboard/src/contexts/FleetContext.tsx
@@ -1,0 +1,43 @@
+import { createContext, useContext, useState, useCallback, type ReactNode } from 'react';
+
+export interface MachineInfo {
+  machineId: string;
+  hostname: string;
+  nodeCount: number;
+  runningCount: number;
+  isOnline: boolean;
+}
+
+interface FleetContextValue {
+  machines: MachineInfo[];
+  reportMachines: (machines: MachineInfo[]) => void;
+  selectedMachineId: string | null; // null = all machines
+  setSelectedMachineId: (id: string | null) => void;
+}
+
+// Default value with no-ops so NodesViewPanel works even without FleetProvider
+const FleetContext = createContext<FleetContextValue>({
+  machines: [],
+  reportMachines: () => {},
+  selectedMachineId: null,
+  setSelectedMachineId: () => {},
+});
+
+export function FleetProvider({ children }: { children: ReactNode }) {
+  const [machines, setMachines] = useState<MachineInfo[]>([]);
+  const [selectedMachineId, setSelectedMachineId] = useState<string | null>(null);
+
+  const reportMachines = useCallback((newMachines: MachineInfo[]) => {
+    setMachines(newMachines);
+  }, []);
+
+  return (
+    <FleetContext.Provider value={{ machines, reportMachines, selectedMachineId, setSelectedMachineId }}>
+      {children}
+    </FleetContext.Provider>
+  );
+}
+
+export function useFleetContext() {
+  return useContext(FleetContext);
+}

--- a/dashboard/src/contexts/FleetContext.tsx
+++ b/dashboard/src/contexts/FleetContext.tsx
@@ -6,6 +6,7 @@ export interface MachineInfo {
   nodeCount: number;
   runningCount: number;
   isOnline: boolean;
+  ips: string[];
 }
 
 interface FleetContextValue {

--- a/dashboard/src/proto/daemon.ts
+++ b/dashboard/src/proto/daemon.ts
@@ -29,6 +29,7 @@ export interface NodeState {
   buildOutput: string[];
   machineId: string;
   machineHostname: string;
+  machineIps: string[];
 }
 
 export interface NodeList {
@@ -91,6 +92,7 @@ function decodeNodeState(msg: unknown): NodeState | null {
     buildOutput: (m.buildOutput as string[]) ?? [],
     machineId: (m.machineId as string) ?? '',
     machineHostname: (m.machineHostname as string) ?? '',
+    machineIps: (m.machineIps as string[]) ?? [],
   };
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -122,11 +122,35 @@ install_zenoh() {
 
     # Copy binaries
     cp "$zenoh_dir/zenohd" "$BIN_DIR/"
-    cp "$zenoh_dir/zenoh-bridge-remote-api" "$BIN_DIR/" 2>/dev/null || true
     chmod +x "$BIN_DIR/zenohd"
-    chmod +x "$BIN_DIR/zenoh-bridge-remote-api" 2>/dev/null || true
 
     info "Zenoh installed: $("$BIN_DIR/zenohd" --version 2>/dev/null | head -1 || echo "$ZENOH_VERSION")"
+}
+
+# Install Zenoh Bridge
+install_bridge() {
+    local arch="$1"
+    local bridge_dir="$INSTALL_DIR/zenoh-bridge"
+
+    step "Installing zenoh-bridge-remote-api $ZENOH_VERSION..."
+
+    mkdir -p "$bridge_dir"
+
+    # Download zenoh-bridge-remote-api from zenoh-ts repo
+    local bridge_url="https://github.com/eclipse-zenoh/zenoh-ts/releases/download/${ZENOH_VERSION}/zenoh-ts-${ZENOH_VERSION}-${arch}-standalone.zip"
+
+    info "Downloading zenoh-bridge-remote-api..."
+    curl -sSL "$bridge_url" -o "/tmp/zenoh-bridge.zip" || error "Failed to download zenoh-bridge-remote-api"
+
+    info "Extracting zenoh-bridge-remote-api..."
+    unzip -o -q "/tmp/zenoh-bridge.zip" -d "$bridge_dir"
+    rm "/tmp/zenoh-bridge.zip"
+
+    # Copy binary
+    cp "$bridge_dir/zenoh-bridge-remote-api" "$BIN_DIR/"
+    chmod +x "$BIN_DIR/zenoh-bridge-remote-api"
+
+    info "zenoh-bridge-remote-api installed"
 }
 
 # Install Bubbaloop binaries
@@ -348,6 +372,7 @@ main() {
 
     # Install components
     install_zenoh "$arch"
+    install_bridge "$arch"
     install_bubbaloop "$version" "$os" "$short_arch"
     setup_systemd
     enable_linger


### PR DESCRIPTION
## Summary

- **Fix install script**: Download `zenoh-bridge-remote-api` from the correct repository
- **Multi-machine data flow**: Accumulate replies from all daemons, machine-scoped commands, stale detection
- **Fleet orchestration UI**: FleetBar, FleetContext, machine grouping/filtering
- **The Loop (MeshView)**: Force-directed network topology visualizer with pan/zoom/drag
- **Machine IP addresses**: Added to protobuf schema, Rust daemon, and dashboard
- **Machine badges**: Each panel shows source machine
- **IP column in Nodes panel**: Shows machine IP per node
- **Zoom controls + Detail side panel**: Interactive node inspection in The Loop
- **Dashboard-as-node**: Purple client node with connection status

## Code quality fixes (from review)
- Fix passive wheel handler with native `{passive: false}` listener
- Fix stale closures in animation render loop with refs
- Add render dirty-checking (every 3rd frame when settled)
- Fix tooltip viewport overflow with boundary clamping
- Extract shared `MachineBadge` component
- Extract `svgEl` helper and sub-components in MeshView

## Test plan
- [ ] FleetBar shows machine chips with 1+ machines
- [ ] The Loop renders mesh graph with hub, machines, services, dashboard node
- [ ] Scroll-wheel zoom works in Chrome/Firefox (toward cursor)
- [ ] Drag nodes smoothly, no jitter on collision
- [ ] Click nodes opens detail side panel with correct info
- [ ] Dashboard node shows "You are here" badge
- [ ] Machine badges on Camera, Weather, JSON, Stats panels
- [ ] IP column in Nodes panel
- [ ] Multi-machine: 2+ daemons all appear in mesh