### PR TITLE
fix: add missing machine-scoped nodes queryable and remove dead HTTP proxy

### DIFF
--- a/crates/bubbaloop/src/daemon/zenoh_service.rs
+++ b/crates/bubbaloop/src/daemon/zenoh_service.rs
@@ -215,9 +215,8 @@ impl ZenohService {
         // Publish initial state (both legacy and new)
         let initial_list = self.node_manager.get_node_list().await;
         let initial_bytes = Self::encode_proto(&initial_list);
-        let initial_bytes_new = Self::encode_proto(&initial_list);
-        list_publisher.put(initial_bytes).await?;
-        list_publisher_new.put(initial_bytes_new).await?;
+        list_publisher.put(initial_bytes.clone()).await?;
+        list_publisher_new.put(initial_bytes).await?;
         log::info!(
             "Published initial node list ({} nodes)",
             initial_list.nodes.len()
@@ -245,11 +244,10 @@ impl ZenohService {
                     let list = self.node_manager.get_node_list().await;
                     if !list.nodes.is_empty() {
                         let bytes = Self::encode_proto(&list);
-                        let bytes_new = Self::encode_proto(&list);
-                        if let Err(e) = list_publisher.put(bytes).await {
+                        if let Err(e) = list_publisher.put(bytes.clone()).await {
                             log::warn!("Failed to publish node list (legacy): {}", e);
                         }
-                        if let Err(e) = list_publisher_new.put(bytes_new).await {
+                        if let Err(e) = list_publisher_new.put(bytes).await {
                             log::warn!("Failed to publish node list (new): {}", e);
                         }
                     }
@@ -319,11 +317,10 @@ impl ZenohService {
                         Ok(event) => {
                             // Publish event (both legacy and new)
                             let event_bytes = Self::encode_proto(&event);
-                            let event_bytes_new = Self::encode_proto(&event);
-                            if let Err(e) = event_publisher.put(event_bytes).await {
+                            if let Err(e) = event_publisher.put(event_bytes.clone()).await {
                                 log::warn!("Failed to publish event (legacy): {}", e);
                             }
-                            if let Err(e) = event_publisher_new.put(event_bytes_new).await {
+                            if let Err(e) = event_publisher_new.put(event_bytes).await {
                                 log::warn!("Failed to publish event (new): {}", e);
                             }
 
@@ -332,11 +329,10 @@ impl ZenohService {
                                 let key_legacy = keys::node_state_key_legacy(&state.name);
                                 let key_new = keys::node_state_key(&self.machine_id, &state.name);
                                 let state_bytes = Self::encode_proto(state);
-                                let state_bytes_new = Self::encode_proto(state);
-                                if let Err(e) = self.session.put(&key_legacy, state_bytes).await {
+                                if let Err(e) = self.session.put(&key_legacy, state_bytes.clone()).await {
                                     log::warn!("Failed to publish node state (legacy): {}", e);
                                 }
-                                if let Err(e) = self.session.put(&key_new, state_bytes_new).await {
+                                if let Err(e) = self.session.put(&key_new, state_bytes).await {
                                     log::warn!("Failed to publish node state (new): {}", e);
                                 }
                             }
@@ -345,11 +341,10 @@ impl ZenohService {
                             let list = self.node_manager.get_node_list().await;
                             if !list.nodes.is_empty() {
                                 let list_bytes = Self::encode_proto(&list);
-                                let list_bytes_new = Self::encode_proto(&list);
-                                if let Err(e) = list_publisher.put(list_bytes).await {
+                                if let Err(e) = list_publisher.put(list_bytes.clone()).await {
                                     log::warn!("Failed to publish node list (legacy): {}", e);
                                 }
-                                if let Err(e) = list_publisher_new.put(list_bytes_new).await {
+                                if let Err(e) = list_publisher_new.put(list_bytes).await {
                                     log::warn!("Failed to publish node list (new): {}", e);
                                 }
                             }

--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -95,12 +95,6 @@ export default defineConfig({
     host: true,
     // Proxy through Vite for cross-machine access
     proxy: {
-      // Daemon HTTP API proxy
-      '/daemon': {
-        target: 'http://127.0.0.1:8088',
-        changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/daemon/, ''),
-      },
       // Zenoh WebSocket proxy
       '/zenoh': {
         target: 'ws://127.0.0.1:10001',


### PR DESCRIPTION
### **User description**
## Summary

- **Add missing machine-scoped nodes queryable** in `zenoh_service.rs`: PR #26 introduced machine-scoped Zenoh keys (`bubbaloop/{machine_id}/daemon/nodes`) for multi-machine fleet support, but only declared a queryable on the legacy key. Direct query/reply on the new key had no responder. Now both keys have queryables with identical handlers, matching the pattern already used for commands.
- **Remove dead `/daemon` HTTP proxy** from `vite.config.ts`: The proxy entry pointed to `http://127.0.0.1:8088` but no dashboard code calls it and the daemon has no HTTP server — all communication goes through the Zenoh WebSocket proxy.

## Test plan

- [x] `pixi run check` — compiles cleanly
- [x] `pixi run clippy` — zero warnings
- [x] `pixi run test` — 131 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- Add missing machine-scoped nodes queryable handler in Zenoh service
  - Declares queryable on new `bubbaloop/{machine_id}/daemon/nodes` key
  - Implements identical handler for multi-machine fleet support

- Remove unused `/daemon` HTTP proxy from Vite configuration
  - Proxy pointed to non-existent daemon HTTP server
  - All communication uses Zenoh WebSocket proxy instead


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Zenoh Service"] -->|"Declare queryable"| B["Legacy nodes key"]
  A -->|"Declare queryable"| C["Machine-scoped nodes key"]
  B -->|"Handle queries"| D["Node list response"]
  C -->|"Handle queries"| D
  E["Vite Config"] -->|"Remove"| F["Dead /daemon proxy"]
  E -->|"Keep"| G["Zenoh WebSocket proxy"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>zenoh_service.rs</strong><dd><code>Add machine-scoped nodes queryable handler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

crates/bubbaloop/src/daemon/zenoh_service.rs

<ul><li>Declare additional queryable on machine-scoped <code>nodes_list_key_new</code> key<br> <li> Add handler for new queryable with identical logic to legacy handler<br> <li> Update log messages to distinguish between legacy and new queryable <br>operations<br> <li> Maintain backward compatibility with legacy key while supporting <br>multi-machine setups</ul>


</details>


  </td>
  <td><a href="https://github.com/kornia/bubbaloop/pull/27/files#diff-4d569a6adb0b705a34121a5b782eca103e7a2990e5628186df6800067fad95c2">+26/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vite.config.ts</strong><dd><code>Remove dead daemon HTTP proxy entry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dashboard/vite.config.ts

<ul><li>Remove unused <code>/daemon</code> HTTP proxy configuration block<br> <li> Retain <code>/zenoh</code> WebSocket proxy for actual daemon communication<br> <li> Simplify proxy configuration by removing dead code</ul>


</details>


  </td>
  <td><a href="https://github.com/kornia/bubbaloop/pull/27/files#diff-2dff8f693803d85fe93013a36ece84f7fef1ccfddf9f6c473caf051e4deeac7e">+0/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

