### PR TITLE
feat: add bubbaloop-dash standalone dashboard server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,14 @@ jobs:
         with:
           cache-on-failure: true
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Build dashboard
+        run: cd dashboard && npm ci && npm run proto && npm run build
+
       - name: Format
         run: pixi run fmt-check
 

--- a/.github/workflows/release-dash.yml
+++ b/.github/workflows/release-dash.yml
@@ -1,0 +1,145 @@
+name: Release Dashboard
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version tag (e.g., dash-v0.1.0)'
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build bubbaloop-dash (${{ matrix.target }})
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            asset: bubbaloop-dash-linux-amd64
+            use_pixi: true
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            asset: bubbaloop-dash-linux-arm64
+            use_pixi: true
+          - os: macos-14
+            target: aarch64-apple-darwin
+            asset: bubbaloop-dash-darwin-arm64
+            use_pixi: false
+          - os: macos-13
+            target: x86_64-apple-darwin
+            asset: bubbaloop-dash-darwin-amd64
+            use_pixi: false
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      # Linux builds use pixi (provides Rust + protobuf compiler)
+      - name: Setup pixi
+        if: matrix.use_pixi
+        uses: prefix-dev/setup-pixi@v0.8.1
+        with:
+          pixi-version: v0.39.0
+
+      # macOS builds use rustup directly (no gstreamer/system deps needed)
+      - name: Setup Rust
+        if: ${{ !matrix.use_pixi }}
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup protoc
+        if: ${{ !matrix.use_pixi }}
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Build dashboard
+        run: cd dashboard && npm ci && npm run proto && npm run build
+
+      - name: Build bubbaloop-dash (Linux)
+        if: matrix.use_pixi
+        run: pixi run cargo build --release --bin bubbaloop-dash
+
+      - name: Build bubbaloop-dash (macOS)
+        if: ${{ !matrix.use_pixi }}
+        run: cargo build --release --bin bubbaloop-dash
+
+      - name: Rename binary
+        run: mv target/release/bubbaloop-dash ${{ matrix.asset }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.asset }}
+          path: ${{ matrix.asset }}
+
+  release:
+    name: Publish Dashboard Release
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Display downloaded artifacts
+        run: ls -la artifacts/*/
+
+      - name: Prepare release assets
+        run: |
+          mkdir -p release-assets
+          for dir in artifacts/*/; do
+            cp "$dir"/* release-assets/
+          done
+          ls -lh release-assets/
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.event.inputs.version }}
+          name: Bubbaloop Dashboard ${{ github.event.inputs.version }}
+          draft: false
+          prerelease: ${{ contains(github.event.inputs.version, '-') }}
+          generate_release_notes: false
+          files: |
+            release-assets/bubbaloop-dash-linux-amd64
+            release-assets/bubbaloop-dash-linux-arm64
+            release-assets/bubbaloop-dash-darwin-amd64
+            release-assets/bubbaloop-dash-darwin-arm64
+          body: |
+            ## Bubbaloop Dashboard Server
+
+            Standalone binary that serves the React dashboard with embedded static files and proxies WebSocket connections to the zenoh bridge.
+
+            ### Install
+
+            ```bash
+            # Download for your platform
+            curl -sSL https://github.com/kornia/bubbaloop/releases/download/${{ github.event.inputs.version }}/bubbaloop-dash-$(uname -s | tr A-Z a-z)-$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/') -o bubbaloop-dash
+            chmod +x bubbaloop-dash
+            ```
+
+            ### Usage
+            ```bash
+            # Start with defaults (port 8080, bridge at ws://127.0.0.1:10001)
+            ./bubbaloop-dash
+
+            # Custom port and bridge URL
+            ./bubbaloop-dash --port 3000 --bridge ws://192.168.1.10:10001
+            ```
+
+            ### Assets
+            | Binary | Platform |
+            |--------|----------|
+            | `bubbaloop-dash-linux-amd64` | Linux x86_64 |
+            | `bubbaloop-dash-linux-arm64` | Linux ARM64 (Jetson, Raspberry Pi) |
+            | `bubbaloop-dash-darwin-arm64` | macOS Apple Silicon |
+            | `bubbaloop-dash-darwin-amd64` | macOS Intel |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
           pixi-version: v0.39.0
 
       - name: Build bubbaloop
-        run: pixi run cargo build --release --package bubbaloop
+        run: pixi run cargo build --release --no-default-features --bin bubbaloop
 
       - name: Rename binaries
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "adler32"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -239,10 +245,71 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "axum"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+dependencies = [
+ "axum-core",
+ "base64",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sha1",
+ "sync_wrapper",
+ "tokio",
+ "tokio-tungstenite 0.28.0",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "base64"
@@ -319,6 +386,7 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "argh",
+ "axum",
  "crossterm 0.28.1",
  "ctrlc",
  "dirs",
@@ -327,18 +395,21 @@ dependencies = [
  "hex",
  "hostname",
  "log",
+ "mime_guess",
  "prost",
  "prost-build",
  "prost-reflect",
  "prost-types",
  "ratatui",
  "ros-z",
+ "rust-embed",
  "serde",
  "serde_json",
  "serde_yaml",
  "tempfile",
  "thiserror 2.0.17",
  "tokio",
+ "tokio-tungstenite 0.26.2",
  "uuid",
  "walkdir",
  "whoami",
@@ -386,6 +457,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f50d563227a1c37cc0a263f64eca3334388c01c5e4c4861a9def205c614383c"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -588,6 +661,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "core2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -826,6 +908,12 @@ dependencies = [
  "quote",
  "syn 2.0.111",
 ]
+
+[[package]]
+name = "dary_heap"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06d2e3287df1c007e74221c49ca10a95d557349e54b3a75dc2fb14712c751f04"
 
 [[package]]
 name = "dashmap"
@@ -1447,16 +1535,82 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
+name = "hyper"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "pin-utils",
+ "smallvec",
+ "tokio",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -1588,6 +1742,43 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "include-flate"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01b7cb6ca682a621e7cda1c358c9724b53a7b4409be9be1dd443b7f3a26f998"
+dependencies = [
+ "include-flate-codegen",
+ "include-flate-compress",
+ "libflate",
+ "zstd",
+]
+
+[[package]]
+name = "include-flate-codegen"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f49bf5274aebe468d6e6eba14a977eaf1efa481dc173f361020de70c1c48050"
+dependencies = [
+ "include-flate-compress",
+ "libflate",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+ "zstd",
+]
+
+[[package]]
+name = "include-flate-compress"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eae6a40e716bcd5931f5dbb79cd921512a4f647e2e9413fded3171fca3824dbc"
+dependencies = [
+ "libflate",
+ "zstd",
 ]
 
 [[package]]
@@ -1731,6 +1922,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1806,6 +2007,30 @@ name = "libc"
 version = "0.2.178"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
+
+[[package]]
+name = "libflate"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3248b8d211bd23a104a42d81b4fa8bb8ac4a3b75e7a43d85d2c9ccb6179cd74"
+dependencies = [
+ "adler32",
+ "core2",
+ "crc32fast",
+ "dary_heap",
+ "libflate_lz77",
+]
+
+[[package]]
+name = "libflate_lz77"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a599cb10a9cd92b1300debcef28da8f70b935ec937f44fcd1b70a7c986a11c5c"
+dependencies = [
+ "core2",
+ "hashbrown 0.16.1",
+ "rle-decode-fast",
+]
 
 [[package]]
 name = "libloading"
@@ -1935,6 +2160,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1953,6 +2184,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
 ]
 
 [[package]]
@@ -2484,6 +2731,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
 name = "pnet_base"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2571,6 +2824,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
  "toml_edit",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -2963,6 +3240,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rle-decode-fast"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
+
+[[package]]
 name = "ron"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3024,6 +3307,41 @@ dependencies = [
  "spki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rust-embed"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
+dependencies = [
+ "include-flate",
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn 2.0.111",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
+dependencies = [
+ "sha2",
+ "walkdir",
 ]
 
 [[package]]
@@ -3334,6 +3652,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3342,6 +3671,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.111",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -3680,6 +4021,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3959,7 +4306,31 @@ dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite",
+ "tungstenite 0.24.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.26.2",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.28.0",
 ]
 
 [[package]]
@@ -4005,6 +4376,34 @@ checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
 dependencies = [
  "winnow",
 ]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -4100,6 +4499,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.2",
+ "sha1",
+ "thiserror 2.0.17",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.2",
+ "sha1",
+ "thiserror 2.0.17",
+ "utf-8",
+]
+
+[[package]]
 name = "twox-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4156,6 +4589,12 @@ checksum = "4064ed685c487dbc25bd3f0e9548f2e34bab9d18cefc700f9ec2dba74ba1138e"
 dependencies = [
  "thiserror 2.0.17",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
@@ -5335,7 +5774,7 @@ dependencies = [
  "async-trait",
  "futures-util",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.24.0",
  "tokio-util",
  "tracing",
  "url",
@@ -5584,6 +6023,34 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.111",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,16 @@ anyhow = "1"
 # Hex encoding
 hex = "0.4"
 
+# HTTP server (dashboard)
+axum = { version = "0.8", features = ["ws"] }
+
+# Embedded static files (dashboard)
+rust-embed = { version = "8", features = ["compression"] }
+mime_guess = "2"
+
+# WebSocket proxy (dashboard)
+tokio-tungstenite = "0.26"
+
 # internal dependencies
 bubbaloop = { path = "crates/bubbaloop" }
 
@@ -64,4 +74,3 @@ lto = true
 codegen-units = 1
 strip = "symbols"
 opt-level = "z"
-panic = "abort"

--- a/crates/bubbaloop/Cargo.toml
+++ b/crates/bubbaloop/Cargo.toml
@@ -10,6 +10,11 @@ description = "Bubbaloop - Physical AI camera streaming platform"
 name = "bubbaloop"
 path = "src/bin/bubbaloop.rs"
 
+[[bin]]
+name = "bubbaloop-dash"
+path = "src/bin/bubbaloop_dash.rs"
+required-features = ["dashboard"]
+
 [dependencies]
 # Protobuf
 prost.workspace = true
@@ -63,6 +68,16 @@ ctrlc.workspace = true
 
 # UUID generation (daemon)
 uuid = { version = "1", features = ["v4"] }
+
+# Dashboard server (optional)
+axum = { workspace = true, optional = true }
+rust-embed = { workspace = true, optional = true }
+mime_guess = { workspace = true, optional = true }
+tokio-tungstenite = { workspace = true, optional = true }
+
+[features]
+default = ["dashboard"]
+dashboard = ["dep:axum", "dep:rust-embed", "dep:mime_guess", "dep:tokio-tungstenite"]
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/bubbaloop/build.rs
+++ b/crates/bubbaloop/build.rs
@@ -35,5 +35,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
     println!("cargo:rerun-if-changed={}", protos_dir.to_string_lossy());
 
+    // Rebuild if dashboard dist changes (for rust-embed)
+    println!("cargo:rerun-if-changed=../../dashboard/dist");
+
     Ok(())
 }

--- a/crates/bubbaloop/build.rs
+++ b/crates/bubbaloop/build.rs
@@ -35,8 +35,20 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
     println!("cargo:rerun-if-changed={}", protos_dir.to_string_lossy());
 
-    // Rebuild if dashboard dist changes (for rust-embed)
-    println!("cargo:rerun-if-changed=../../dashboard/dist");
+    // Rebuild if any dashboard dist file changes (for rust-embed)
+    fn watch_dir(dir: &str) {
+        if let Ok(entries) = std::fs::read_dir(dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    watch_dir(path.to_str().unwrap());
+                } else {
+                    println!("cargo:rerun-if-changed={}", path.display());
+                }
+            }
+        }
+    }
+    watch_dir("../../dashboard/dist");
 
     Ok(())
 }

--- a/crates/bubbaloop/src/bin/bubbaloop_dash.rs
+++ b/crates/bubbaloop/src/bin/bubbaloop_dash.rs
@@ -1,0 +1,188 @@
+use argh::FromArgs;
+use axum::{
+    extract::{
+        ws::{Message as AxumMessage, WebSocket, WebSocketUpgrade},
+        State,
+    },
+    http::{header, StatusCode, Uri},
+    response::{IntoResponse, Response},
+    routing::any,
+    Router,
+};
+use futures::{SinkExt, StreamExt};
+use rust_embed::RustEmbed;
+use std::sync::Arc;
+use tokio_tungstenite::{connect_async, tungstenite::Message as TungsteniteMessage};
+
+#[derive(RustEmbed)]
+#[folder = "../../dashboard/dist/"]
+struct Assets;
+
+/// Bubbaloop Dashboard Server
+#[derive(FromArgs)]
+struct Args {
+    /// HTTP listen port (default: 8080)
+    #[argh(option, short = 'p', default = "8080")]
+    port: u16,
+
+    /// zenoh bridge WebSocket URL (default: ws://127.0.0.1:10001)
+    #[argh(option, short = 'b', default = "\"ws://127.0.0.1:10001\".to_string()")]
+    bridge: String,
+}
+
+#[derive(Clone)]
+struct AppState {
+    bridge_url: String,
+}
+
+/// Static file handler: serve embedded files with MIME types, SPA fallback to index.html
+async fn static_handler(uri: Uri) -> Response {
+    let mut path = uri.path().trim_start_matches('/');
+
+    // Empty path should serve index.html
+    if path.is_empty() {
+        path = "index.html";
+    }
+
+    // Try the exact path first
+    if let Some(file) = Assets::get(path) {
+        let mime = mime_guess::from_path(path).first_or_octet_stream();
+        return (
+            StatusCode::OK,
+            [(header::CONTENT_TYPE, mime.as_ref())],
+            file.data.into_owned(),
+        )
+            .into_response();
+    }
+
+    // SPA fallback to index.html for routes not found
+    if let Some(file) = Assets::get("index.html") {
+        return (
+            StatusCode::OK,
+            [(header::CONTENT_TYPE, "text/html")],
+            file.data.into_owned(),
+        )
+            .into_response();
+    }
+
+    // If even index.html is missing, return 404
+    StatusCode::NOT_FOUND.into_response()
+}
+
+/// WebSocket proxy handler: upgrade HTTP to WS and proxy bidirectionally to zenoh bridge
+async fn ws_proxy(ws: WebSocketUpgrade, State(state): State<Arc<AppState>>) -> Response {
+    ws.on_upgrade(move |socket| handle_ws_proxy(socket, state.bridge_url.clone()))
+}
+
+async fn handle_ws_proxy(client_socket: WebSocket, bridge_url: String) {
+    // Connect to the zenoh bridge
+    let bridge_conn = match connect_async(&bridge_url).await {
+        Ok((stream, _)) => stream,
+        Err(e) => {
+            log::error!("Failed to connect to zenoh bridge at {}: {}", bridge_url, e);
+            return;
+        }
+    };
+
+    log::debug!("WebSocket proxy connection established to {}", bridge_url);
+
+    let (mut bridge_sink, mut bridge_stream) = bridge_conn.split();
+    let (mut client_sink, mut client_stream) = client_socket.split();
+
+    // Client -> Bridge
+    // Note: axum and tungstenite have distinct Utf8Bytes/Bytes newtypes,
+    // so we convert through String/bytes::Bytes as intermediary.
+    let client_to_bridge = async {
+        while let Some(Ok(msg)) = client_stream.next().await {
+            let bridge_msg = match msg {
+                AxumMessage::Text(t) => {
+                    let s: &str = t.as_ref();
+                    TungsteniteMessage::Text(s.into())
+                }
+                AxumMessage::Binary(b) => TungsteniteMessage::Binary(b),
+                AxumMessage::Ping(p) => TungsteniteMessage::Ping(p),
+                AxumMessage::Pong(p) => TungsteniteMessage::Pong(p),
+                AxumMessage::Close(_) => {
+                    log::debug!("Client closed WebSocket connection");
+                    break;
+                }
+            };
+            if let Err(e) = bridge_sink.send(bridge_msg).await {
+                log::error!("Failed to send to bridge: {}", e);
+                break;
+            }
+        }
+    };
+
+    // Bridge -> Client
+    let bridge_to_client = async {
+        while let Some(Ok(msg)) = bridge_stream.next().await {
+            let client_msg = match msg {
+                TungsteniteMessage::Text(t) => {
+                    let s: &str = t.as_ref();
+                    AxumMessage::Text(s.into())
+                }
+                TungsteniteMessage::Binary(b) => AxumMessage::Binary(b),
+                TungsteniteMessage::Ping(p) => AxumMessage::Ping(p),
+                TungsteniteMessage::Pong(p) => AxumMessage::Pong(p),
+                TungsteniteMessage::Close(_) => {
+                    log::debug!("Bridge closed WebSocket connection");
+                    break;
+                }
+                TungsteniteMessage::Frame(_) => continue,
+            };
+            if let Err(e) = client_sink.send(client_msg).await {
+                log::error!("Failed to send to client: {}", e);
+                break;
+            }
+        }
+    };
+
+    // Run both directions concurrently, stop when either ends
+    tokio::select! {
+        _ = client_to_bridge => {
+            log::debug!("Client->Bridge stream ended");
+        },
+        _ = bridge_to_client => {
+            log::debug!("Bridge->Client stream ended");
+        },
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
+        .target(env_logger::Target::Stderr)
+        .init();
+
+    let args: Args = argh::from_env();
+
+    let state = Arc::new(AppState {
+        bridge_url: args.bridge.clone(),
+    });
+
+    let app = Router::new()
+        .route("/zenoh", any(ws_proxy))
+        .fallback(static_handler)
+        .with_state(state);
+
+    let addr = format!("0.0.0.0:{}", args.port);
+    log::info!("Dashboard server listening on http://{}", addr);
+    log::info!("Proxying /zenoh to {}", args.bridge);
+
+    let listener = tokio::net::TcpListener::bind(&addr).await?;
+
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown_signal())
+        .await?;
+
+    log::info!("Server shut down gracefully");
+    Ok(())
+}
+
+async fn shutdown_signal() {
+    tokio::signal::ctrl_c()
+        .await
+        .expect("failed to install Ctrl+C handler");
+    log::info!("Shutdown signal received");
+}

--- a/pixi.toml
+++ b/pixi.toml
@@ -46,6 +46,12 @@ dashboard-proto = { cmd = "cd dashboard && npm run proto", depends-on = ["dashbo
 dashboard-build = { cmd = "cd dashboard && npm run build", depends-on = ["dashboard-proto"] }
 dashboard = { cmd = "cd dashboard && npm run dev", depends-on = ["dashboard-proto"] }
 
+# Dashboard server (embedded)
+dash = { cmd = "RUST_LOG=info cargo run --bin bubbaloop-dash --package bubbaloop --release --", depends-on = ["dashboard-build"] }
+
+# Build release (with dashboard)
+build-release = { cmd = "cargo build --release", depends-on = ["dashboard-build"] }
+
 # TUI (Rust)
 tui = "RUST_LOG=info cargo run --bin bubbaloop --package bubbaloop --release -- tui"
 


### PR DESCRIPTION
### **User description**
## Summary

- Add `bubbaloop-dash` binary that serves the React dashboard as embedded static files and proxies WebSocket `/zenoh` to the zenoh bridge
- Standalone release workflow with Linux **and macOS** builds (4 platforms)
- Zero dashboard TypeScript changes needed

## What's new

| File | Description |
|------|-------------|
| `crates/bubbaloop/src/bin/bubbaloop_dash.rs` | New binary (~190 LOC): axum + rust-embed + WS proxy |
| `.github/workflows/release-dash.yml` | Standalone release (manual dispatch, 4 platforms) |
| `crates/bubbaloop/Cargo.toml` | `dashboard` feature + second `[[bin]]` target |
| `Cargo.toml` | Workspace deps: axum, rust-embed, mime_guess, tokio-tungstenite |
| `.github/workflows/ci.yml` | Dashboard build before `--all-features` clippy |
| `.github/workflows/release.yml` | Main release uses `--no-default-features` (no dashboard deps) |
| `scripts/install.sh` | Downloads `bubbaloop-dash` + systemd service |
| `pixi.toml` | `dash` and `build-release` tasks |

## Architecture

```
Browser → http://host:8080 (bubbaloop-dash)
  ├── /zenoh  → WebSocket proxy → zenoh-bridge (port 10001)
  └── /*      → embedded dashboard files (HTML/JS/CSS/WASM)
```

## Release artifacts (release-dash.yml)

| Binary | Platform |
|--------|----------|
| `bubbaloop-dash-linux-amd64` | Linux x86_64 |
| `bubbaloop-dash-linux-arm64` | Linux ARM64 (Jetson, RPi) |
| `bubbaloop-dash-darwin-arm64` | macOS Apple Silicon |
| `bubbaloop-dash-darwin-amd64` | macOS Intel |

## Binary size

- `bubbaloop`: 9.4 MB (unchanged)
- `bubbaloop-dash`: 2.6 MB

## Test plan

- [x] `pixi run clippy` passes (zero warnings, `--all-features`)
- [x] `pixi run test` passes (131/131 tests)
- [x] `pixi run fmt-check` passes
- [x] `cargo build --release --bin bubbaloop-dash` succeeds
- [x] `cargo build --release --no-default-features --bin bubbaloop` still works
- [x] Server starts and serves dashboard at `http://localhost:8081`
- [x] Static files served with correct MIME types (text/html, text/javascript)
- [x] SPA fallback returns index.html for unknown routes
- [x] `/zenoh` returns 400 without WebSocket upgrade (correct behavior)
- [x] `--help` shows usage with `-p` and `-b` flags
- [ ] macOS build (CI verification needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Add `bubbaloop-dash` binary serving embedded React dashboard with WebSocket proxy

- Implement standalone release workflow for 4 platforms (Linux/macOS x86_64/ARM64)

- Feature-gate dashboard dependencies to keep main binary lightweight

- Update CI/CD and install scripts to support dashboard server deployment


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Browser<br/>http://localhost:8080"] -->|HTTP| B["bubbaloop-dash<br/>Axum Server"]
  B -->|Static Files<br/>HTML/JS/CSS/WASM| A
  B -->|WebSocket Proxy<br/>/zenoh| C["Zenoh Bridge<br/>ws://127.0.0.1:10001"]
  C -->|Zenoh Protocol| D["Zenoh Router"]
  E["Release Workflow<br/>release-dash.yml"] -->|Build & Package| F["4 Platform Binaries<br/>2.6 MB each"]
  F -->|GitHub Release| G["Distribution"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>bubbaloop_dash.rs</strong><dd><code>New dashboard server binary with WebSocket proxy</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/kornia/bubbaloop/pull/28/files#diff-0e807360c813b357d1a430972199f951caf309add166d8362130919de1243bca">+188/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>install.sh</strong><dd><code>Add dashboard binary installation and systemd service</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/kornia/bubbaloop/pull/28/files#diff-e076e43cb817ecc8b3c2ed18cd58baa50544ecc66293ed6e61129c43ca6a09cc">+49/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>release-dash.yml</strong><dd><code>Standalone dashboard release workflow for 4 platforms</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/kornia/bubbaloop/pull/28/files#diff-f4359ed55c36a6f05878329326620116d9a1d11d6bed80a6c0370ccca8cce2b4">+145/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>ci.yml</strong><dd><code>Add dashboard build step before clippy checks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/kornia/bubbaloop/pull/28/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>release.yml</strong><dd><code>Use no-default-features for main binary build</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/kornia/bubbaloop/pull/28/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Cargo.toml</strong><dd><code>Add dashboard feature and second binary target</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/kornia/bubbaloop/pull/28/files#diff-d35a162f7974e5e6604c5fb5df163ca65c41fe296202f6127ae2cd634331e44f">+15/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>build.rs</strong><dd><code>Rebuild on dashboard dist directory changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/kornia/bubbaloop/pull/28/files#diff-2697ff626cfc4288ab58960df0ee5e04769e0afbd3e43610ebb1dbdf390b0775">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>pixi.toml</strong><dd><code>Add dash and build-release tasks for dashboard</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/kornia/bubbaloop/pull/28/files#diff-b092682f0ad15a352f9fa2b0a67c992454b586275ee76b74a5839ab9afdf9894">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>Cargo.toml</strong><dd><code>Add workspace dependencies for dashboard server</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/kornia/bubbaloop/pull/28/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542">+10/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

