### PR TITLE
feat: add `bubbaloop launch` command for multi-instance node support

### DIFF
--- a/crates/bubbaloop-schemas/protos/daemon.proto
+++ b/crates/bubbaloop-schemas/protos/daemon.proto
@@ -54,6 +54,8 @@ message NodeState {
   string machine_hostname = 15;
   // Network IP addresses of the source machine
   repeated string machine_ips = 16;
+  // Base node template name (non-empty only for instances with name_override)
+  string base_node = 17;
 }
 
 // List of all nodes (published periodically)
@@ -97,6 +99,10 @@ message NodeCommand {
   string source_machine = 6;
   // Target machine (empty = local)
   string target_machine = 7;
+  // Instance name override (for multi-instance nodes, overrides node.yaml name)
+  string name_override = 8;
+  // Config file path override (appended as -c to command for this instance)
+  string config_override = 9;
 }
 
 // Result of a command execution

--- a/crates/bubbaloop-schemas/protos/daemon.proto
+++ b/crates/bubbaloop-schemas/protos/daemon.proto
@@ -56,6 +56,8 @@ message NodeState {
   repeated string machine_ips = 16;
   // Base node template name (non-empty only for instances with name_override)
   string base_node = 17;
+  // Config file path override (for instances)
+  string config_override = 18;
 }
 
 // List of all nodes (published periodically)

--- a/crates/bubbaloop/src/bin/bubbaloop.rs
+++ b/crates/bubbaloop/src/bin/bubbaloop.rs
@@ -19,6 +19,7 @@
 //!   bubbaloop debug info               # Show Zenoh connection info
 
 use argh::FromArgs;
+use bubbaloop::cli::launch::LaunchCommand;
 use bubbaloop::cli::{DebugCommand, NodeCommand};
 
 /// Bubbaloop - AI-native orchestration for Physical AI
@@ -40,6 +41,7 @@ enum Command {
     Doctor(DoctorArgs),
     Daemon(DaemonArgs),
     Node(NodeCommand),
+    Launch(LaunchCommand),
     Debug(DebugCommand),
 }
 
@@ -119,6 +121,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             eprintln!("              init, validate, list, add, remove");
             eprintln!("              install, uninstall, start, stop, restart");
             eprintln!("              logs, build");
+            eprintln!("  launch    Launch node instances from a YAML file");
+            eprintln!("              (default: ~/.bubbaloop/launch.yaml)");
             eprintln!("  debug     Debug Zenoh connectivity:");
             eprintln!("              info, topics, query, subscribe");
             eprintln!("\nRun 'bubbaloop <command> --help' for more information.");
@@ -142,6 +146,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             bubbaloop::daemon::run(args.zenoh_endpoint, args.strict).await?;
         }
         Some(Command::Node(cmd)) => {
+            cmd.run()
+                .await
+                .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)?;
+        }
+        Some(Command::Launch(cmd)) => {
             cmd.run()
                 .await
                 .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)?;

--- a/crates/bubbaloop/src/bin/bubbaloop.rs
+++ b/crates/bubbaloop/src/bin/bubbaloop.rs
@@ -20,7 +20,7 @@
 
 use argh::FromArgs;
 use bubbaloop::cli::launch::LaunchCommand;
-use bubbaloop::cli::{DebugCommand, NodeCommand};
+use bubbaloop::cli::{DebugCommand, MarketplaceCommand, NodeCommand};
 
 /// Bubbaloop - AI-native orchestration for Physical AI
 #[derive(FromArgs)]
@@ -42,6 +42,7 @@ enum Command {
     Daemon(DaemonArgs),
     Node(NodeCommand),
     Launch(LaunchCommand),
+    Marketplace(MarketplaceCommand),
     Debug(DebugCommand),
 }
 
@@ -123,6 +124,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             eprintln!("              logs, build");
             eprintln!("  launch    Launch node instances from a YAML file");
             eprintln!("              (default: ~/.bubbaloop/launch.yaml)");
+            eprintln!("  marketplace  Manage marketplace sources:");
+            eprintln!("              list, add, remove, enable, disable");
             eprintln!("  debug     Debug Zenoh connectivity:");
             eprintln!("              info, topics, query, subscribe");
             eprintln!("\nRun 'bubbaloop <command> --help' for more information.");
@@ -151,6 +154,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)?;
         }
         Some(Command::Launch(cmd)) => {
+            cmd.run()
+                .await
+                .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)?;
+        }
+        Some(Command::Marketplace(cmd)) => {
             cmd.run()
                 .await
                 .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)?;

--- a/crates/bubbaloop/src/cli/launch.rs
+++ b/crates/bubbaloop/src/cli/launch.rs
@@ -1,0 +1,364 @@
+//! Launch a single node instance from a launch YAML file
+//!
+//! Usage:
+//!   bubbaloop launch rtsp-camera entrance.yaml
+//!   bubbaloop launch rtsp-camera entrance.yaml --build --start
+//!   bubbaloop launch rtsp-camera entrance.yaml --dry-run
+//!
+//! launch file format:
+//!
+//! ```yaml
+//! name: rtsp-camera-entrance
+//! config:
+//!   name: entrance
+//!   publish_topic: camera/entrance/compressed
+//!   url: "rtsp://user:pass@192.168.1.141:554/stream2"
+//! ```
+
+use std::path::PathBuf;
+
+use argh::FromArgs;
+use serde::Deserialize;
+use thiserror::Error;
+
+use crate::cli::node;
+
+#[derive(Debug, Error)]
+pub enum LaunchError {
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("YAML parse error: {0}")]
+    Yaml(#[from] serde_yaml::Error),
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("Launch file not found: {0}")]
+    FileNotFound(String),
+    #[error("Instance error: {0}")]
+    Instance(String),
+    #[error("Node error: {0}")]
+    Node(#[from] node::NodeError),
+}
+
+pub type Result<T> = std::result::Result<T, LaunchError>;
+
+/// Launch a node instance from a YAML file
+#[derive(FromArgs, PartialEq, Debug)]
+#[argh(subcommand, name = "launch")]
+pub struct LaunchCommand {
+    /// registered node name (e.g. rtsp-camera)
+    #[argh(positional)]
+    pub node: String,
+
+    /// path to launch YAML file
+    #[argh(positional)]
+    pub file: String,
+
+    /// build the instance before starting
+    #[argh(switch)]
+    pub build: bool,
+
+    /// install as systemd service
+    #[argh(switch)]
+    pub install: bool,
+
+    /// start the instance after registering
+    #[argh(switch)]
+    pub start: bool,
+
+    /// show what would be done without executing
+    #[argh(switch)]
+    pub dry_run: bool,
+}
+
+/// Single instance definition
+#[derive(Debug, Deserialize)]
+pub struct LaunchFile {
+    /// Instance name (e.g. rtsp-camera-entrance)
+    pub name: String,
+    /// Inline config for this instance
+    pub config: Option<serde_yaml::Value>,
+}
+
+/// Parse a launch YAML file
+fn parse_launch_file(content: &str) -> Result<LaunchFile> {
+    let launch: LaunchFile = serde_yaml::from_str(content)?;
+    if launch.name.is_empty() {
+        return Err(LaunchError::Instance(
+            "launch file must have a non-empty 'name' field".to_string(),
+        ));
+    }
+    Ok(launch)
+}
+
+/// Write an inline config block to ~/.bubbaloop/configs/{name}.yaml
+fn write_config(
+    configs_dir: &std::path::Path,
+    name: &str,
+    config: &serde_yaml::Value,
+) -> Result<PathBuf> {
+    std::fs::create_dir_all(configs_dir)?;
+    let dest = configs_dir.join(format!("{}.yaml", name));
+    let yaml = serde_yaml::to_string(config)?;
+    std::fs::write(&dest, &yaml)?;
+    Ok(dest)
+}
+
+fn default_configs_dir() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".bubbaloop")
+        .join("configs")
+}
+
+impl LaunchCommand {
+    pub async fn run(self) -> Result<()> {
+        // 1. Read and parse the launch file
+        let file_path = std::path::Path::new(&self.file);
+        if !file_path.exists() {
+            return Err(LaunchError::FileNotFound(self.file.clone()));
+        }
+
+        let content = std::fs::read_to_string(file_path)?;
+        let launch = parse_launch_file(&content)?;
+
+        if self.dry_run {
+            println!("[DRY RUN] Instance: {}", launch.name);
+            println!("  Base node: {}", self.node);
+            println!("  Launch file: {}", self.file);
+            if launch.config.is_some() {
+                println!(
+                    "  Config: would write to ~/.bubbaloop/configs/{}.yaml",
+                    launch.name
+                );
+            }
+            if self.build {
+                println!("  Would: build");
+            }
+            if self.install {
+                println!("  Would: install as systemd service");
+            }
+            if self.start {
+                println!("  Would: start");
+            }
+            if !self.build && !self.install && !self.start {
+                println!("  Would: register with daemon");
+            }
+            return Ok(());
+        }
+
+        // 2. Resolve the base node's path from the daemon
+        let node_path = self.resolve_node_path(&self.node).await?;
+
+        // 3. Write config if present
+        let config_path = if let Some(ref config) = launch.config {
+            let dest = write_config(&default_configs_dir(), &launch.name, config)?;
+            println!("Config written to {}", dest.display());
+            Some(dest.to_string_lossy().to_string())
+        } else {
+            None
+        };
+
+        // 4. name_override: only if instance name differs from base node
+        let name_override = if launch.name != self.node {
+            Some(launch.name.as_str())
+        } else {
+            None
+        };
+
+        // 5. Register instance via Zenoh
+        self.register_instance(&node_path, name_override, config_path.as_deref())
+            .await?;
+        println!("Registered: {}", launch.name);
+
+        // 6. Optional build / install / start
+        if self.build {
+            println!("Building...");
+            node::send_command(&launch.name, "build").await?;
+        }
+
+        if self.install {
+            println!("Installing as systemd service...");
+            node::send_command(&launch.name, "install").await?;
+        }
+
+        if self.start {
+            println!("Starting...");
+            node::send_command(&launch.name, "start").await?;
+        }
+
+        println!("\nLaunched {} successfully!", launch.name);
+        Ok(())
+    }
+
+    async fn resolve_node_path(&self, node_name: &str) -> Result<String> {
+        let session = node::get_zenoh_session().await?;
+        let replies = session
+            .get("bubbaloop/daemon/api/nodes")
+            .target(zenoh::query::QueryTarget::BestMatching)
+            .timeout(std::time::Duration::from_secs(10))
+            .await
+            .map_err(|e| LaunchError::Node(node::NodeError::Zenoh(e.to_string())))?;
+
+        #[derive(Deserialize)]
+        struct NodeInfo {
+            name: String,
+            path: String,
+        }
+        #[derive(Deserialize)]
+        struct NodeListResponse {
+            nodes: Vec<NodeInfo>,
+        }
+
+        for reply in replies {
+            if let Ok(sample) = reply.into_result() {
+                let payload = sample.payload().to_bytes();
+                if let Ok(response) = serde_json::from_slice::<NodeListResponse>(&payload) {
+                    for info in response.nodes {
+                        if info.name == node_name {
+                            session.close().await.map_err(|e| {
+                                LaunchError::Node(node::NodeError::Zenoh(e.to_string()))
+                            })?;
+                            return Ok(info.path);
+                        }
+                    }
+                }
+            }
+        }
+
+        session
+            .close()
+            .await
+            .map_err(|e| LaunchError::Node(node::NodeError::Zenoh(e.to_string())))?;
+
+        Err(LaunchError::Node(node::NodeError::NotFound(format!(
+            "Node '{}' not registered. Register it first with: bubbaloop node add <path>",
+            node_name
+        ))))
+    }
+
+    async fn register_instance(
+        &self,
+        node_path: &str,
+        name_override: Option<&str>,
+        config_path: Option<&str>,
+    ) -> Result<()> {
+        let session = node::get_zenoh_session().await?;
+
+        let payload = serde_json::to_string(&serde_json::json!({
+            "command": "add",
+            "node_path": node_path,
+            "name": name_override,
+            "config": config_path,
+        }))?;
+
+        let replies = session
+            .get("bubbaloop/daemon/api/nodes/add")
+            .payload(payload)
+            .target(zenoh::query::QueryTarget::BestMatching)
+            .timeout(std::time::Duration::from_secs(30))
+            .await
+            .map_err(|e| LaunchError::Node(node::NodeError::Zenoh(e.to_string())))?;
+
+        let mut success = false;
+        for reply in replies {
+            if let Ok(sample) = reply.into_result() {
+                let data: serde_json::Value = serde_json::from_slice(&sample.payload().to_bytes())?;
+                if data.get("success").and_then(|v| v.as_bool()) == Some(true) {
+                    success = true;
+                    break;
+                } else {
+                    let msg = data
+                        .get("message")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("unknown error");
+                    session.close().await.ok();
+                    return Err(LaunchError::Instance(msg.to_string()));
+                }
+            }
+        }
+
+        session
+            .close()
+            .await
+            .map_err(|e| LaunchError::Node(node::NodeError::Zenoh(e.to_string())))?;
+
+        if !success {
+            return Err(LaunchError::Instance("No response from daemon".to_string()));
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_full_launch_file() {
+        let yaml = r#"
+name: rtsp-camera-entrance
+config:
+  name: entrance
+  publish_topic: camera/entrance/compressed
+  url: "rtsp://user:pass@192.168.1.141:554/stream2"
+  latency: 200
+"#;
+        let launch = parse_launch_file(yaml).unwrap();
+        assert_eq!(launch.name, "rtsp-camera-entrance");
+        assert!(launch.config.is_some());
+    }
+
+    #[test]
+    fn test_parse_minimal_launch_file() {
+        let yaml = "name: my-instance\n";
+        let launch = parse_launch_file(yaml).unwrap();
+        assert_eq!(launch.name, "my-instance");
+        assert!(launch.config.is_none());
+    }
+
+    #[test]
+    fn test_parse_empty_name_rejected() {
+        let yaml = "name: \"\"\n";
+        assert!(parse_launch_file(yaml).is_err());
+    }
+
+    #[test]
+    fn test_parse_missing_name_rejected() {
+        let yaml = "config:\n  key: value\n";
+        assert!(parse_launch_file(yaml).is_err());
+    }
+
+    #[test]
+    fn test_parse_invalid_yaml() {
+        assert!(parse_launch_file("not valid yaml: [[[").is_err());
+    }
+
+    #[test]
+    fn test_write_config_to_tempdir() {
+        let dir = tempfile::tempdir().unwrap();
+        let config: serde_yaml::Value =
+            serde_yaml::from_str("name: terrace\npublish_topic: camera/terrace/compressed\n")
+                .unwrap();
+
+        let dest = write_config(dir.path(), "rtsp-camera-terrace", &config).unwrap();
+        assert!(dest.exists());
+        assert!(dest.to_string_lossy().ends_with("rtsp-camera-terrace.yaml"));
+
+        let content = std::fs::read_to_string(&dest).unwrap();
+        assert!(content.contains("terrace"));
+        assert!(content.contains("publish_topic"));
+    }
+
+    #[test]
+    fn test_write_config_nested_values() {
+        let dir = tempfile::tempdir().unwrap();
+        let config: serde_yaml::Value =
+            serde_yaml::from_str("location:\n  latitude: 41.39\n  longitude: 2.17\n").unwrap();
+
+        let dest = write_config(dir.path(), "openmeteo", &config).unwrap();
+        let content = std::fs::read_to_string(&dest).unwrap();
+        assert!(content.contains("latitude"));
+        assert!(content.contains("41.39"));
+    }
+}

--- a/crates/bubbaloop/src/cli/marketplace.rs
+++ b/crates/bubbaloop/src/cli/marketplace.rs
@@ -1,0 +1,364 @@
+//! Marketplace CLI commands
+//!
+//! Manages marketplace sources (node registries) from the command line.
+//! Sources are stored in ~/.bubbaloop/sources.json (same format as TUI Registry).
+
+use argh::FromArgs;
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::PathBuf;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum MarketplaceError {
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("{0}")]
+    Other(String),
+}
+
+pub type Result<T> = std::result::Result<T, MarketplaceError>;
+
+/// Manage marketplace sources (node registries)
+#[derive(FromArgs)]
+#[argh(subcommand, name = "marketplace")]
+pub struct MarketplaceCommand {
+    #[argh(subcommand)]
+    action: MarketplaceAction,
+}
+
+#[derive(FromArgs)]
+#[argh(subcommand)]
+enum MarketplaceAction {
+    List(ListArgs),
+    Add(AddArgs),
+    Remove(RemoveArgs),
+    Enable(EnableArgs),
+    Disable(DisableArgs),
+}
+
+/// List all marketplace sources
+#[derive(FromArgs)]
+#[argh(subcommand, name = "list")]
+struct ListArgs {
+    /// output format: table, json (default: table)
+    #[argh(option, short = 'f', default = "String::from(\"table\")")]
+    format: String,
+}
+
+/// Add a marketplace source
+#[derive(FromArgs)]
+#[argh(subcommand, name = "add")]
+struct AddArgs {
+    /// source name
+    #[argh(positional)]
+    name: String,
+
+    /// source path (local directory)
+    #[argh(positional)]
+    path: String,
+
+    /// source type: local or git (default: local)
+    #[argh(option, short = 't', default = "String::from(\"local\")")]
+    source_type: String,
+}
+
+/// Remove a marketplace source
+#[derive(FromArgs)]
+#[argh(subcommand, name = "remove")]
+struct RemoveArgs {
+    /// source name or path to remove
+    #[argh(positional)]
+    name_or_path: String,
+}
+
+/// Enable a marketplace source
+#[derive(FromArgs)]
+#[argh(subcommand, name = "enable")]
+struct EnableArgs {
+    /// source name or path to enable
+    #[argh(positional)]
+    name_or_path: String,
+}
+
+/// Disable a marketplace source
+#[derive(FromArgs)]
+#[argh(subcommand, name = "disable")]
+struct DisableArgs {
+    /// source name or path to disable
+    #[argh(positional)]
+    name_or_path: String,
+}
+
+const OFFICIAL_SOURCE_TYPE: &str = "builtin";
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+struct SourcesRegistry {
+    sources: Vec<SourceEntry>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+struct SourceEntry {
+    name: String,
+    path: String,
+    #[serde(rename = "type")]
+    source_type: String,
+    enabled: bool,
+}
+
+fn sources_path() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".bubbaloop")
+        .join("sources.json")
+}
+
+fn load_sources() -> SourcesRegistry {
+    let path = sources_path();
+    if path.exists() {
+        fs::read_to_string(&path)
+            .ok()
+            .and_then(|s| serde_json::from_str(&s).ok())
+            .unwrap_or_default()
+    } else {
+        SourcesRegistry::default()
+    }
+}
+
+fn save_sources(registry: &SourcesRegistry) -> Result<()> {
+    let path = sources_path();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let json = serde_json::to_string_pretty(registry)?;
+    fs::write(path, json)?;
+    Ok(())
+}
+
+fn find_source_mut<'a>(
+    registry: &'a mut SourcesRegistry,
+    name_or_path: &str,
+) -> Option<&'a mut SourceEntry> {
+    registry
+        .sources
+        .iter_mut()
+        .find(|s| s.name == name_or_path || s.path == name_or_path)
+}
+
+impl MarketplaceCommand {
+    pub async fn run(self) -> Result<()> {
+        match self.action {
+            MarketplaceAction::List(args) => list_sources(args),
+            MarketplaceAction::Add(args) => add_source(args),
+            MarketplaceAction::Remove(args) => remove_source(args),
+            MarketplaceAction::Enable(args) => enable_source(args),
+            MarketplaceAction::Disable(args) => disable_source(args),
+        }
+    }
+}
+
+fn list_sources(args: ListArgs) -> Result<()> {
+    let registry = load_sources();
+
+    if args.format == "json" {
+        println!("{}", serde_json::to_string_pretty(&registry.sources)?);
+        return Ok(());
+    }
+
+    if registry.sources.is_empty() {
+        println!("No marketplace sources configured.");
+        println!("Add one with: bubbaloop marketplace add <name> <path>");
+        return Ok(());
+    }
+
+    println!("{:<3} {:<20} {:<10} PATH", "ON", "NAME", "TYPE");
+    println!("{}", "-".repeat(70));
+    for source in &registry.sources {
+        let enabled = if source.enabled { "yes" } else { "no" };
+        println!(
+            "{:<3} {:<20} {:<10} {}",
+            enabled, source.name, source.source_type, source.path
+        );
+    }
+
+    Ok(())
+}
+
+fn add_source(args: AddArgs) -> Result<()> {
+    let mut registry = load_sources();
+
+    if registry.sources.iter().any(|s| s.path == args.path) {
+        return Err(MarketplaceError::Other(
+            "Source with this path already exists".into(),
+        ));
+    }
+
+    registry.sources.push(SourceEntry {
+        name: args.name.clone(),
+        path: args.path.clone(),
+        source_type: args.source_type,
+        enabled: true,
+    });
+
+    save_sources(&registry)?;
+    println!("Added marketplace source: {}", args.name);
+    Ok(())
+}
+
+fn remove_source(args: RemoveArgs) -> Result<()> {
+    let mut registry = load_sources();
+
+    // Prevent removing builtin sources
+    if let Some(source) = registry
+        .sources
+        .iter()
+        .find(|s| s.name == args.name_or_path || s.path == args.name_or_path)
+    {
+        if source.source_type == OFFICIAL_SOURCE_TYPE {
+            return Err(MarketplaceError::Other(
+                "Cannot remove builtin source".into(),
+            ));
+        }
+    }
+
+    let before = registry.sources.len();
+    registry
+        .sources
+        .retain(|s| s.name != args.name_or_path && s.path != args.name_or_path);
+
+    if registry.sources.len() == before {
+        return Err(MarketplaceError::Other(format!(
+            "Source '{}' not found",
+            args.name_or_path
+        )));
+    }
+
+    save_sources(&registry)?;
+    println!("Removed marketplace source: {}", args.name_or_path);
+    Ok(())
+}
+
+fn enable_source(args: EnableArgs) -> Result<()> {
+    update_source_enabled(&args.name_or_path, true, "Enabled")
+}
+
+fn disable_source(args: DisableArgs) -> Result<()> {
+    update_source_enabled(&args.name_or_path, false, "Disabled")
+}
+
+fn update_source_enabled(name_or_path: &str, enabled: bool, action: &str) -> Result<()> {
+    let mut registry = load_sources();
+
+    let source = find_source_mut(&mut registry, name_or_path)
+        .ok_or_else(|| MarketplaceError::Other(format!("Source '{}' not found", name_or_path)))?;
+
+    source.enabled = enabled;
+    save_sources(&registry)?;
+    println!("{} marketplace source: {}", action, name_or_path);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sources_registry_round_trip() {
+        let registry = SourcesRegistry {
+            sources: vec![
+                SourceEntry {
+                    name: "Official Nodes".into(),
+                    path: "kornia/bubbaloop-nodes-official".into(),
+                    source_type: "builtin".into(),
+                    enabled: true,
+                },
+                SourceEntry {
+                    name: "My Local".into(),
+                    path: "/home/user/nodes".into(),
+                    source_type: "local".into(),
+                    enabled: false,
+                },
+            ],
+        };
+
+        let json = serde_json::to_string_pretty(&registry).unwrap();
+        let parsed: SourcesRegistry = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(parsed.sources.len(), 2);
+        assert_eq!(parsed.sources[0].name, "Official Nodes");
+        assert_eq!(parsed.sources[0].source_type, "builtin");
+        assert!(parsed.sources[0].enabled);
+        assert_eq!(parsed.sources[1].name, "My Local");
+        assert!(!parsed.sources[1].enabled);
+    }
+
+    #[test]
+    fn test_serde_rename_type_field() {
+        let json = r#"{"name":"test","path":"/path","type":"local","enabled":true}"#;
+        let entry: SourceEntry = serde_json::from_str(json).unwrap();
+        assert_eq!(entry.source_type, "local");
+
+        // Verify it serializes back with "type" key
+        let serialized = serde_json::to_string(&entry).unwrap();
+        assert!(serialized.contains("\"type\""));
+        assert!(!serialized.contains("\"source_type\""));
+    }
+
+    #[test]
+    fn test_cannot_remove_builtin() {
+        let mut registry = SourcesRegistry {
+            sources: vec![SourceEntry {
+                name: "Official Nodes".into(),
+                path: "kornia/bubbaloop-nodes-official".into(),
+                source_type: "builtin".into(),
+                enabled: true,
+            }],
+        };
+
+        // Verify the source is found as builtin
+        let source = registry
+            .sources
+            .iter()
+            .find(|s| s.name == "Official Nodes")
+            .unwrap();
+        assert_eq!(source.source_type, OFFICIAL_SOURCE_TYPE);
+
+        // Simulate removal check
+        let is_builtin = registry
+            .sources
+            .iter()
+            .find(|s| s.name == "Official Nodes")
+            .map(|s| s.source_type == OFFICIAL_SOURCE_TYPE)
+            .unwrap_or(false);
+        assert!(is_builtin);
+
+        // Non-builtin should be removable
+        registry.sources.push(SourceEntry {
+            name: "Removable".into(),
+            path: "/tmp/nodes".into(),
+            source_type: "local".into(),
+            enabled: true,
+        });
+        let before = registry.sources.len();
+        registry.sources.retain(|s| s.name != "Removable");
+        assert_eq!(registry.sources.len(), before - 1);
+    }
+
+    #[test]
+    fn test_find_source_by_name_or_path() {
+        let mut registry = SourcesRegistry {
+            sources: vec![SourceEntry {
+                name: "My Nodes".into(),
+                path: "/home/user/nodes".into(),
+                source_type: "local".into(),
+                enabled: true,
+            }],
+        };
+
+        assert!(find_source_mut(&mut registry, "My Nodes").is_some());
+        assert!(find_source_mut(&mut registry, "/home/user/nodes").is_some());
+        assert!(find_source_mut(&mut registry, "nonexistent").is_none());
+    }
+}

--- a/crates/bubbaloop/src/cli/mod.rs
+++ b/crates/bubbaloop/src/cli/mod.rs
@@ -3,8 +3,10 @@
 pub mod debug;
 pub mod doctor;
 pub mod launch;
+pub mod marketplace;
 pub mod node;
 pub mod status;
 
 pub use debug::{DebugCommand, DebugError};
+pub use marketplace::MarketplaceCommand;
 pub use node::{NodeCommand, NodeError};

--- a/crates/bubbaloop/src/cli/mod.rs
+++ b/crates/bubbaloop/src/cli/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod debug;
 pub mod doctor;
+pub mod launch;
 pub mod node;
 pub mod status;
 

--- a/crates/bubbaloop/src/cli/node.rs
+++ b/crates/bubbaloop/src/cli/node.rs
@@ -51,6 +51,7 @@ enum NodeAction {
     List(ListArgs),
     Add(AddArgs),
     Remove(RemoveArgs),
+    Instance(InstanceArgs),
     Install(InstallArgs),
     Uninstall(UninstallArgs),
     Start(StartArgs),
@@ -62,6 +63,7 @@ enum NodeAction {
     Enable(EnableArgs),
     Disable(DisableArgs),
     Search(SearchArgs),
+    Discover(DiscoverArgs),
 }
 
 /// Initialize a new node from template
@@ -105,6 +107,14 @@ struct ListArgs {
     /// output format: table, json (default: table)
     #[argh(option, short = 'f', default = "String::from(\"table\")")]
     format: String,
+
+    /// show only base nodes (excludes instances)
+    #[argh(switch)]
+    base: bool,
+
+    /// show only instances (excludes base nodes)
+    #[argh(switch)]
+    instances: bool,
 }
 
 /// Add a node from local path or GitHub URL
@@ -155,6 +165,44 @@ struct RemoveArgs {
     /// also delete files
     #[argh(switch)]
     delete_files: bool,
+}
+
+/// Create an instance of a base node with specific config
+///
+/// Multi-instance nodes (like rtsp-camera) need different configs for each instance.
+/// This command creates a named instance from an already-registered base node.
+///
+/// Example:
+///   bubbaloop node instance rtsp-camera terrace --config ~/.bubbaloop/configs/rtsp-camera-terrace.yaml
+///
+/// This creates "rtsp-camera-terrace" instance that uses the rtsp-camera binary
+/// but with its own config file.
+#[derive(FromArgs)]
+#[argh(subcommand, name = "instance")]
+struct InstanceArgs {
+    /// base node name (must be already registered, e.g., "rtsp-camera")
+    #[argh(positional)]
+    base_node: String,
+
+    /// instance suffix (e.g., "terrace" creates "rtsp-camera-terrace")
+    #[argh(positional)]
+    suffix: String,
+
+    /// config file path for this instance (required for most multi-instance nodes)
+    #[argh(option, short = 'c')]
+    config: Option<String>,
+
+    /// copy example config from base node's configs/ directory
+    #[argh(switch)]
+    copy_config: bool,
+
+    /// install as systemd service after creating
+    #[argh(switch)]
+    install: bool,
+
+    /// start the instance after creating (implies --install)
+    #[argh(switch)]
+    start: bool,
 }
 
 /// Install a node as a systemd service (or from marketplace by name)
@@ -280,6 +328,15 @@ struct SearchArgs {
     tag: Option<String>,
 }
 
+/// Discover available nodes from marketplace sources (with status from daemon)
+#[derive(FromArgs)]
+#[argh(subcommand, name = "discover")]
+struct DiscoverArgs {
+    /// output format: table, json (default: table)
+    #[argh(option, short = 'f', default = "String::from(\"table\")")]
+    format: String,
+}
+
 /// Response from daemon API
 #[derive(Deserialize)]
 struct CommandResponse {
@@ -329,6 +386,7 @@ impl NodeCommand {
             Some(NodeAction::List(args)) => list_nodes(args).await,
             Some(NodeAction::Add(args)) => add_node(args).await,
             Some(NodeAction::Remove(args)) => remove_node(args).await,
+            Some(NodeAction::Instance(args)) => create_instance(args).await,
             Some(NodeAction::Install(args)) => handle_install(args).await,
             Some(NodeAction::Uninstall(args)) => send_command(&args.name, "uninstall").await,
             Some(NodeAction::Start(args)) => send_command(&args.name, "start").await,
@@ -340,6 +398,7 @@ impl NodeCommand {
             Some(NodeAction::Enable(args)) => send_command(&args.name, "enable").await,
             Some(NodeAction::Disable(args)) => send_command(&args.name, "disable").await,
             Some(NodeAction::Search(args)) => search_nodes(args),
+            Some(NodeAction::Discover(args)) => discover_nodes(args).await,
         }
     }
 
@@ -352,7 +411,12 @@ impl NodeCommand {
         eprintln!("  list        List all registered nodes");
         eprintln!("  add         Add a node from local path or GitHub URL");
         eprintln!("  remove      Remove a node from the registry");
+        eprintln!("  instance    Create an instance of a multi-instance node");
+        eprintln!(
+            "              Example: bubbaloop node instance rtsp-camera terrace -c config.yaml"
+        );
         eprintln!("  search      Search the node marketplace");
+        eprintln!("  discover    Discover available nodes with status");
         eprintln!("  install     Install a node (or from marketplace by name)");
         eprintln!("  uninstall   Uninstall a node's systemd service");
         eprintln!("  start       Start a node service");
@@ -493,10 +557,15 @@ fn validate_node(args: ValidateArgs) -> Result<()> {
 }
 
 async fn list_nodes(args: ListArgs) -> Result<()> {
+    if args.base && args.instances {
+        return Err(NodeError::InvalidArgs(
+            "Cannot use --base and --instances together".into(),
+        ));
+    }
+
     let session = get_zenoh_session().await?;
 
     // Retry up to 3 times with 1 second delay between retries
-    let mut last_error = None;
     let mut best_data: Option<NodeListResponse> = None;
 
     for attempt in 1..=3 {
@@ -506,44 +575,40 @@ async fn list_nodes(args: ListArgs) -> Result<()> {
             .timeout(std::time::Duration::from_secs(30))
             .await;
 
-        match replies_result {
-            Ok(replies) => {
-                let replies: Vec<_> = replies.into_iter().collect();
-
-                // Find the first response with actual nodes, or use any response
-                for reply in replies {
-                    if let Ok(sample) = reply.into_result() {
-                        let payload = sample.payload().to_bytes();
-                        if let Ok(data) = serde_json::from_slice::<NodeListResponse>(&payload) {
-                            if !data.nodes.is_empty() {
-                                best_data = Some(data);
-                                break; // Found response with nodes, use it
-                            } else if best_data.is_none() {
-                                best_data = Some(data); // Keep first empty response as fallback
+        if let Ok(replies) = replies_result {
+            for reply in replies {
+                if let Ok(sample) = reply.into_result() {
+                    if let Ok(data) =
+                        serde_json::from_slice::<NodeListResponse>(&sample.payload().to_bytes())
+                    {
+                        if !data.nodes.is_empty() || best_data.is_none() {
+                            best_data = Some(data);
+                            if !best_data.as_ref().unwrap().nodes.is_empty() {
+                                break;
                             }
                         }
                     }
                 }
-
-                if best_data.is_some() {
-                    break; // Success, exit retry loop
-                }
-
-                // No valid response, retry
-                if attempt < 3 {
-                    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-                }
             }
-            Err(e) => {
-                last_error = Some(NodeError::Zenoh(e.to_string()));
-                if attempt < 3 {
-                    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-                }
+
+            if best_data.as_ref().is_some_and(|d| !d.nodes.is_empty()) {
+                break;
             }
+        }
+
+        if attempt < 3 {
+            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
         }
     }
 
-    if let Some(data) = best_data {
+    if let Some(mut data) = best_data {
+        // Apply --base / --instances filter
+        if args.base {
+            data.nodes.retain(|n| n.base_node.is_empty());
+        } else if args.instances {
+            data.nodes.retain(|n| !n.base_node.is_empty());
+        }
+
         if args.format == "json" {
             println!("{}", serde_json::to_string_pretty(&data.nodes)?);
         } else if data.nodes.is_empty() {
@@ -592,8 +657,6 @@ async fn list_nodes(args: ListArgs) -> Result<()> {
                 }
             }
         }
-    } else if let Some(err) = last_error {
-        return Err(err);
     } else {
         println!("No response from daemon. Is it running?");
     }
@@ -731,65 +794,41 @@ async fn add_node(args: AddArgs) -> Result<()> {
         "config": args.config,
     }))?;
 
-    // Retry up to 3 times with 1 second delay between retries
     let mut node_name: Option<String> = None;
-    let mut last_error = None;
 
     for attempt in 1..=3 {
-        let replies_result = session
+        if let Ok(replies) = session
             .get("bubbaloop/daemon/api/nodes/add")
             .payload(payload.clone())
             .target(QueryTarget::BestMatching)
             .timeout(std::time::Duration::from_secs(30))
-            .await;
-
-        match replies_result {
-            Ok(replies) => {
-                let replies: Vec<_> = replies.into_iter().collect();
-                let mut success = false;
-
-                for reply in replies {
-                    if let Ok(sample) = reply.into_result() {
-                        let data: CommandResponse =
-                            serde_json::from_slice(&sample.payload().to_bytes())?;
-                        if data.success {
-                            println!("Added node from: {}", node_path);
-                            // Extract node name from path for build/install
-                            node_name = extract_node_name(&node_path).ok();
-                            success = true;
-                            break;
-                        } else {
-                            last_error = Some(NodeError::CommandFailed(data.message));
-                        }
+            .await
+        {
+            for reply in replies {
+                if let Ok(sample) = reply.into_result() {
+                    let data: CommandResponse =
+                        serde_json::from_slice(&sample.payload().to_bytes())?;
+                    if data.success {
+                        println!("Added node from: {}", node_path);
+                        node_name = extract_node_name(&node_path).ok();
+                        break;
+                    } else if attempt == 3 {
+                        session
+                            .close()
+                            .await
+                            .map_err(|e| NodeError::Zenoh(e.to_string()))?;
+                        return Err(NodeError::CommandFailed(data.message));
                     }
                 }
-
-                if success {
-                    break; // Success, exit retry loop
-                }
-
-                // Failed, retry
-                if attempt < 3 {
-                    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-                }
             }
-            Err(e) => {
-                last_error = Some(NodeError::Zenoh(e.to_string()));
-                if attempt < 3 {
-                    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-                }
+
+            if node_name.is_some() {
+                break;
             }
         }
-    }
 
-    // Check if we failed after all retries
-    if node_name.is_none() {
-        if let Some(err) = last_error {
-            session
-                .close()
-                .await
-                .map_err(|e| NodeError::Zenoh(e.to_string()))?;
-            return Err(err);
+        if attempt < 3 {
+            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
         }
     }
 
@@ -814,6 +853,218 @@ async fn add_node(args: AddArgs) -> Result<()> {
         .await
         .map_err(|e| NodeError::Zenoh(e.to_string()))?;
     Ok(())
+}
+
+/// Create an instance of a multi-instance node (like rtsp-camera)
+///
+/// This command creates a named instance from an already-registered base node.
+/// The instance will use the base node's binary but with its own config file.
+///
+/// # Arguments
+/// * `args.base_node` - Name of the registered base node (e.g., "rtsp-camera")
+/// * `args.suffix` - Instance suffix (e.g., "terrace" creates "rtsp-camera-terrace")
+/// * `args.config` - Path to config file for this instance
+/// * `args.copy_config` - Copy example config from base node's configs/ directory
+/// * `args.install` - Install as systemd service after creating
+/// * `args.start` - Start the instance after creating (implies --install)
+///
+/// # Example
+/// ```bash
+/// bubbaloop node instance rtsp-camera terrace --config ~/.bubbaloop/configs/rtsp-camera-terrace.yaml
+/// ```
+async fn create_instance(args: InstanceArgs) -> Result<()> {
+    // Validate suffix (same rules as node names: alphanumeric, hyphens, underscores)
+    if args.suffix.is_empty() || args.suffix.len() > 64 {
+        return Err(NodeError::InvalidArgs(
+            "Instance suffix must be 1-64 characters".into(),
+        ));
+    }
+    if !args
+        .suffix
+        .chars()
+        .all(|c| c.is_alphanumeric() || c == '-' || c == '_')
+    {
+        return Err(NodeError::InvalidArgs(
+            "Instance suffix can only contain alphanumeric characters, hyphens, and underscores"
+                .into(),
+        ));
+    }
+    if args.suffix.starts_with('-') || args.suffix.starts_with('_') {
+        return Err(NodeError::InvalidArgs(
+            "Instance suffix cannot start with hyphen or underscore".into(),
+        ));
+    }
+
+    // Build the full instance name: base-suffix
+    let instance_name = format!("{}-{}", args.base_node, args.suffix);
+
+    // First, find the base node to get its path
+    let session = get_zenoh_session().await?;
+
+    // Query the daemon for the base node's path
+    let query_payload = serde_json::to_string(&serde_json::json!({
+        "command": "get_node",
+        "name": args.base_node,
+    }))?;
+
+    let replies = session
+        .get("bubbaloop/daemon/api/nodes")
+        .payload(query_payload)
+        .target(QueryTarget::BestMatching)
+        .timeout(std::time::Duration::from_secs(10))
+        .await
+        .map_err(|e| NodeError::Zenoh(e.to_string()))?;
+
+    let mut base_node_path: Option<String> = None;
+
+    for reply in replies {
+        if let Ok(sample) = reply.into_result() {
+            let data: NodeListResponse = serde_json::from_slice(&sample.payload().to_bytes())?;
+            // Find the base node (must have empty base_node field, meaning it's not an instance)
+            for node in data.nodes {
+                if node.name == args.base_node && node.base_node.is_empty() {
+                    base_node_path = Some(node.path.clone());
+                    break;
+                }
+            }
+        }
+    }
+
+    let base_path = base_node_path.ok_or_else(|| {
+        NodeError::NotFound(format!(
+            "Base node '{}' not found. Add it first with: bubbaloop node add <path>",
+            args.base_node
+        ))
+    })?;
+
+    // Handle config file
+    let config_path = if args.copy_config {
+        // Copy example config from base node's configs/ directory
+        let configs_dir = Path::new(&base_path).join("configs");
+        if !configs_dir.exists() {
+            return Err(NodeError::NotFound(format!(
+                "No configs/ directory found in base node at {}",
+                base_path
+            )));
+        }
+
+        // Look for an example config
+        let example_config = find_example_config(&configs_dir)?;
+
+        // Create ~/.bubbaloop/configs/ if needed
+        let dest_dir = dirs::home_dir()
+            .ok_or_else(|| NodeError::Io(std::io::Error::other("HOME not set")))?
+            .join(".bubbaloop")
+            .join("configs");
+        std::fs::create_dir_all(&dest_dir)?;
+
+        // Copy to ~/.bubbaloop/configs/<instance-name>.yaml
+        let dest_path = dest_dir.join(format!("{}.yaml", instance_name));
+        std::fs::copy(&example_config, &dest_path)?;
+
+        println!("Copied example config to: {}", dest_path.display());
+        println!("Edit this file to configure your instance before starting.");
+
+        Some(dest_path.to_string_lossy().to_string())
+    } else if let Some(ref config) = args.config {
+        // Validate config path exists
+        let config_path = Path::new(config);
+        if !config_path.exists() {
+            return Err(NodeError::NotFound(format!(
+                "Config file not found: {}",
+                config
+            )));
+        }
+        Some(config_path.canonicalize()?.to_string_lossy().to_string())
+    } else {
+        None
+    };
+
+    // Register the instance with the daemon
+    let add_payload = serde_json::to_string(&serde_json::json!({
+        "command": "add",
+        "node_path": base_path,
+        "name": instance_name,
+        "config": config_path,
+    }))?;
+
+    let replies = session
+        .get("bubbaloop/daemon/api/nodes/add")
+        .payload(add_payload)
+        .target(QueryTarget::BestMatching)
+        .timeout(std::time::Duration::from_secs(30))
+        .await
+        .map_err(|e| NodeError::Zenoh(e.to_string()))?;
+
+    let mut success = false;
+    for reply in replies {
+        if let Ok(sample) = reply.into_result() {
+            let data: CommandResponse = serde_json::from_slice(&sample.payload().to_bytes())?;
+            if data.success {
+                println!(
+                    "Created instance '{}' from base node '{}'",
+                    instance_name, args.base_node
+                );
+                success = true;
+            } else {
+                session
+                    .close()
+                    .await
+                    .map_err(|e| NodeError::Zenoh(e.to_string()))?;
+                return Err(NodeError::CommandFailed(data.message));
+            }
+        }
+    }
+
+    if !success {
+        session
+            .close()
+            .await
+            .map_err(|e| NodeError::Zenoh(e.to_string()))?;
+        return Err(NodeError::Zenoh("No response from daemon".into()));
+    }
+
+    // Close the session before send_command (which opens its own)
+    session
+        .close()
+        .await
+        .map_err(|e| NodeError::Zenoh(e.to_string()))?;
+
+    // Optional: install and/or start
+    if args.start || args.install {
+        println!("Installing instance as systemd service...");
+        send_command(&instance_name, "install").await?;
+    }
+
+    if args.start {
+        println!("Starting instance...");
+        send_command(&instance_name, "start").await?;
+    }
+
+    Ok(())
+}
+
+/// Find an example config file in the configs/ directory
+fn find_example_config(configs_dir: &Path) -> Result<PathBuf> {
+    let entries: Vec<_> = std::fs::read_dir(configs_dir)?
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            e.path()
+                .extension()
+                .map(|ext| ext == "yaml" || ext == "yml")
+                .unwrap_or(false)
+        })
+        .collect();
+
+    if entries.is_empty() {
+        return Err(NodeError::NotFound(format!(
+            "No .yaml config files found in {}",
+            configs_dir.display()
+        )));
+    }
+
+    // Return the first one found
+    Ok(entries[0].path())
 }
 
 fn normalize_git_url(source: &str) -> String {
@@ -981,61 +1232,41 @@ async fn remove_node(args: RemoveArgs) -> Result<()> {
 
 pub(crate) async fn send_command(name: &str, command: &str) -> Result<()> {
     let session = get_zenoh_session().await?;
-
-    let payload = serde_json::to_string(&serde_json::json!({
-        "command": command
-    }))?;
-
+    let payload = serde_json::to_string(&serde_json::json!({"command": command}))?;
     let key = format!("bubbaloop/daemon/api/nodes/{}/command", name);
 
-    // Retry up to 3 times with 1 second delay between retries
     let mut last_error = None;
-    let mut success = false;
 
     for attempt in 1..=3 {
-        let replies_result = session
+        if let Ok(replies) = session
             .get(&key)
             .payload(payload.clone())
             .target(QueryTarget::BestMatching)
             .timeout(std::time::Duration::from_secs(30))
-            .await;
-
-        match replies_result {
-            Ok(replies) => {
-                let replies: Vec<_> = replies.into_iter().collect();
-
-                for reply in replies {
-                    if let Ok(sample) = reply.into_result() {
-                        let data: CommandResponse =
-                            serde_json::from_slice(&sample.payload().to_bytes())?;
-                        if data.success {
-                            println!("{}", data.message);
-                            if !data.output.is_empty() {
-                                println!("{}", data.output);
-                            }
-                            success = true;
-                            break;
-                        } else {
-                            last_error = Some(NodeError::CommandFailed(data.message));
+            .await
+        {
+            for reply in replies {
+                if let Ok(sample) = reply.into_result() {
+                    let data: CommandResponse =
+                        serde_json::from_slice(&sample.payload().to_bytes())?;
+                    if data.success {
+                        println!("{}", data.message);
+                        if !data.output.is_empty() {
+                            println!("{}", data.output);
                         }
+                        session
+                            .close()
+                            .await
+                            .map_err(|e| NodeError::Zenoh(e.to_string()))?;
+                        return Ok(());
                     }
-                }
-
-                if success {
-                    break; // Success, exit retry loop
-                }
-
-                // Failed, retry
-                if attempt < 3 {
-                    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                    last_error = Some(NodeError::CommandFailed(data.message));
                 }
             }
-            Err(e) => {
-                last_error = Some(NodeError::Zenoh(e.to_string()));
-                if attempt < 3 {
-                    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-                }
-            }
+        }
+
+        if attempt < 3 {
+            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
         }
     }
 
@@ -1043,14 +1274,7 @@ pub(crate) async fn send_command(name: &str, command: &str) -> Result<()> {
         .close()
         .await
         .map_err(|e| NodeError::Zenoh(e.to_string()))?;
-
-    if !success {
-        if let Some(err) = last_error {
-            return Err(err);
-        }
-    }
-
-    Ok(())
+    Err(last_error.unwrap_or_else(|| NodeError::Zenoh("No response from daemon".into())))
 }
 
 /// Handle `node install`: if the node is already registered with the daemon,
@@ -1278,6 +1502,120 @@ fn search_nodes(args: SearchArgs) -> Result<()> {
     }
     println!();
     println!("Install with: bubbaloop node install <name>");
+
+    Ok(())
+}
+
+async fn discover_nodes(args: DiscoverArgs) -> Result<()> {
+    // Refresh marketplace cache
+    if let Err(e) = registry::refresh_cache() {
+        log::warn!("registry refresh failed: {}", e);
+        eprintln!("Warning: could not refresh registry (using cache): {}", e);
+    }
+    let all_marketplace = registry::load_cached_registry();
+
+    // Query daemon for registered nodes
+    let registered: Vec<NodeState> = match get_zenoh_session().await {
+        Ok(session) => {
+            let result = session
+                .get("bubbaloop/daemon/api/nodes")
+                .target(QueryTarget::BestMatching)
+                .timeout(std::time::Duration::from_secs(5))
+                .await;
+            let mut nodes = Vec::new();
+            if let Ok(replies) = result {
+                for reply in replies {
+                    if let Ok(sample) = reply.into_result() {
+                        if let Ok(data) =
+                            serde_json::from_slice::<NodeListResponse>(&sample.payload().to_bytes())
+                        {
+                            nodes = data.nodes;
+                            break;
+                        }
+                    }
+                }
+            }
+            let _ = session.close().await;
+            nodes
+        }
+        Err(_) => Vec::new(),
+    };
+
+    if all_marketplace.is_empty() {
+        println!(
+            "No nodes found in marketplace. The registry cache may not have been fetched yet."
+        );
+        return Ok(());
+    }
+
+    #[derive(serde::Serialize)]
+    struct DiscoverEntry {
+        name: String,
+        version: String,
+        node_type: String,
+        is_added: bool,
+        is_built: bool,
+        instance_count: usize,
+        repo: String,
+        description: String,
+    }
+
+    let entries: Vec<DiscoverEntry> = all_marketplace
+        .iter()
+        .map(|node| {
+            let reg = registered
+                .iter()
+                .find(|r| r.name == node.name && r.base_node.is_empty());
+            let is_added = reg.is_some();
+            let is_built = reg.map(|r| r.is_built).unwrap_or(false);
+            let instance_count = registered
+                .iter()
+                .filter(|r| r.base_node == node.name)
+                .count();
+            DiscoverEntry {
+                name: node.name.clone(),
+                version: node.version.clone(),
+                node_type: node.node_type.clone(),
+                is_added,
+                is_built,
+                instance_count,
+                repo: node.repo.clone(),
+                description: truncate(&node.description, 28),
+            }
+        })
+        .collect();
+
+    if args.format == "json" {
+        println!("{}", serde_json::to_string_pretty(&entries)?);
+    } else {
+        println!(
+            "{:<20} {:<10} {:<8} {:<6} {:<6} {:<5} {:<30} DESCRIPTION",
+            "NAME", "VERSION", "TYPE", "ADDED", "BUILT", "INST", "REPO"
+        );
+        println!("{}", "-".repeat(115));
+        for e in &entries {
+            let added = if e.is_added { "yes" } else { "-" };
+            let built = if e.is_added && e.is_built {
+                "yes"
+            } else if e.is_added {
+                "no"
+            } else {
+                "-"
+            };
+            let inst = if e.instance_count > 0 {
+                format!("{}", e.instance_count)
+            } else {
+                "-".to_string()
+            };
+            println!(
+                "{:<20} {:<10} {:<8} {:<6} {:<6} {:<5} {:<30} {}",
+                e.name, e.version, e.node_type, added, built, inst, e.repo, e.description
+            );
+        }
+        println!();
+        println!("Add with: bubbaloop node add <name>");
+        println!("Create instance: bubbaloop node add <path> --name <instance-name>");
+    }
 
     Ok(())
 }
@@ -1759,6 +2097,76 @@ mod tests {
     }
 
     #[test]
+    fn test_list_filter_base_only() {
+        let nodes = [
+            NodeState {
+                name: "rtsp-camera".to_string(),
+                path: "/path".to_string(),
+                status: "running".to_string(),
+                installed: true,
+                autostart_enabled: false,
+                version: "1.0.0".to_string(),
+                description: "Camera".to_string(),
+                node_type: "rust".to_string(),
+                is_built: true,
+                base_node: String::new(),
+            },
+            NodeState {
+                name: "rtsp-camera-terrace".to_string(),
+                path: "/path".to_string(),
+                status: "running".to_string(),
+                installed: true,
+                autostart_enabled: false,
+                version: "1.0.0".to_string(),
+                description: "Terrace cam".to_string(),
+                node_type: "rust".to_string(),
+                is_built: true,
+                base_node: "rtsp-camera".to_string(),
+            },
+            NodeState {
+                name: "openmeteo".to_string(),
+                path: "/path2".to_string(),
+                status: "stopped".to_string(),
+                installed: true,
+                autostart_enabled: false,
+                version: "1.0.0".to_string(),
+                description: "Weather".to_string(),
+                node_type: "rust".to_string(),
+                is_built: false,
+                base_node: String::new(),
+            },
+        ];
+
+        // --base filter: only base nodes (base_node is empty)
+        let base_only: Vec<_> = nodes.iter().filter(|n| n.base_node.is_empty()).collect();
+        assert_eq!(base_only.len(), 2);
+        assert_eq!(base_only[0].name, "rtsp-camera");
+        assert_eq!(base_only[1].name, "openmeteo");
+
+        // --instances filter: only instances (base_node is non-empty)
+        let instances_only: Vec<_> = nodes.iter().filter(|n| !n.base_node.is_empty()).collect();
+        assert_eq!(instances_only.len(), 1);
+        assert_eq!(instances_only[0].name, "rtsp-camera-terrace");
+        assert_eq!(instances_only[0].base_node, "rtsp-camera");
+    }
+
+    #[test]
+    fn test_instance_name_validation() {
+        // Valid instance names
+        assert!(is_valid_node_name("rtsp-camera-terrace"));
+        assert!(is_valid_node_name("rtsp-camera_1"));
+        assert!(is_valid_node_name("cam01"));
+
+        // Invalid: empty, starts with dash, special chars
+        assert!(!is_valid_node_name(""));
+        assert!(!is_valid_node_name("-starts-with-dash"));
+        assert!(!is_valid_node_name("has space"));
+        assert!(!is_valid_node_name("has;semicolon"));
+        assert!(!is_valid_node_name("../traversal"));
+        assert!(!is_valid_node_name(".hidden"));
+    }
+
+    #[test]
     fn test_discover_nodes_ignores_files() {
         let dir = tempfile::tempdir().unwrap();
         // Create a file named "node.yaml" at root (not a subdir)
@@ -1768,5 +2176,113 @@ mod tests {
 
         let nodes = discover_nodes_in_subdirs(dir.path());
         assert_eq!(nodes.len(), 0); // Only scans directories, not root
+    }
+
+    // ==================== Instance command tests ====================
+
+    /// Test that instance suffix validation rejects invalid characters
+    #[test]
+    fn test_instance_suffix_validation_valid() {
+        // Valid suffixes that should work
+        let valid_suffixes = ["terrace", "entrance", "cam01", "garden_1", "my-camera"];
+        for suffix in valid_suffixes {
+            assert!(
+                suffix
+                    .chars()
+                    .all(|c| c.is_alphanumeric() || c == '-' || c == '_'),
+                "Expected '{}' to be valid",
+                suffix
+            );
+            assert!(
+                !suffix.starts_with('-') && !suffix.starts_with('_'),
+                "Expected '{}' to not start with - or _",
+                suffix
+            );
+        }
+    }
+
+    #[test]
+    fn test_instance_suffix_validation_invalid() {
+        // Invalid suffixes that should be rejected
+        let invalid_suffixes = [
+            "",              // empty
+            "-terrace",      // starts with dash
+            "_terrace",      // starts with underscore
+            "terrace space", // contains space
+            "terrace/path",  // contains slash
+            "../traversal",  // path traversal
+            "terrace;cmd",   // shell metacharacter
+        ];
+        for suffix in invalid_suffixes {
+            let is_valid = !suffix.is_empty()
+                && suffix.len() <= 64
+                && suffix
+                    .chars()
+                    .all(|c| c.is_alphanumeric() || c == '-' || c == '_')
+                && !suffix.starts_with('-')
+                && !suffix.starts_with('_');
+            assert!(!is_valid, "Expected '{}' to be invalid", suffix);
+        }
+    }
+
+    /// Test that instance name is constructed correctly: base-suffix
+    #[test]
+    fn test_instance_name_construction() {
+        let base = "rtsp-camera";
+        let suffix = "terrace";
+        let instance_name = format!("{}-{}", base, suffix);
+        assert_eq!(instance_name, "rtsp-camera-terrace");
+
+        let base2 = "weather-node";
+        let suffix2 = "station_1";
+        let instance_name2 = format!("{}-{}", base2, suffix2);
+        assert_eq!(instance_name2, "weather-node-station_1");
+    }
+
+    /// Test find_example_config function
+    #[test]
+    fn test_find_example_config_finds_yaml() {
+        let dir = tempfile::tempdir().unwrap();
+        let configs_dir = dir.path().join("configs");
+        std::fs::create_dir(&configs_dir).unwrap();
+        std::fs::write(configs_dir.join("example.yaml"), "name: test").unwrap();
+
+        let result = find_example_config(&configs_dir);
+        assert!(result.is_ok());
+        assert!(result.unwrap().to_string_lossy().contains("example.yaml"));
+    }
+
+    #[test]
+    fn test_find_example_config_finds_yml() {
+        let dir = tempfile::tempdir().unwrap();
+        let configs_dir = dir.path().join("configs");
+        std::fs::create_dir(&configs_dir).unwrap();
+        std::fs::write(configs_dir.join("example.yml"), "name: test").unwrap();
+
+        let result = find_example_config(&configs_dir);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_find_example_config_empty_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let configs_dir = dir.path().join("configs");
+        std::fs::create_dir(&configs_dir).unwrap();
+
+        let result = find_example_config(&configs_dir);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("No .yaml config"));
+    }
+
+    #[test]
+    fn test_find_example_config_ignores_non_yaml() {
+        let dir = tempfile::tempdir().unwrap();
+        let configs_dir = dir.path().join("configs");
+        std::fs::create_dir(&configs_dir).unwrap();
+        std::fs::write(configs_dir.join("readme.txt"), "not a config").unwrap();
+        std::fs::write(configs_dir.join("config.json"), "{}").unwrap();
+
+        let result = find_example_config(&configs_dir);
+        assert!(result.is_err()); // Only .yaml/.yml files
     }
 }

--- a/crates/bubbaloop/src/cli/status.rs
+++ b/crates/bubbaloop/src/cli/status.rs
@@ -71,6 +71,9 @@ struct NodeState {
     is_built: bool,
     #[allow(dead_code)]
     build_output: Vec<String>,
+    #[serde(default)]
+    #[allow(dead_code)]
+    base_node: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/bubbaloop/src/daemon/zenoh_api.rs
+++ b/crates/bubbaloop/src/daemon/zenoh_api.rs
@@ -87,6 +87,8 @@ pub struct NodeStateResponse {
     pub is_built: bool,
     pub build_output: Vec<String>,
     pub base_node: String,
+    #[serde(default)]
+    pub config_override: String,
 }
 
 /// JSON response for node list
@@ -167,6 +169,7 @@ fn node_state_to_response(state: &crate::schemas::daemon::v1::NodeState) -> Node
         is_built: state.is_built,
         build_output: state.build_output.clone(),
         base_node: state.base_node.clone(),
+        config_override: state.config_override.clone(),
     }
 }
 

--- a/crates/bubbaloop/src/daemon/zenoh_api.rs
+++ b/crates/bubbaloop/src/daemon/zenoh_api.rs
@@ -86,6 +86,7 @@ pub struct NodeStateResponse {
     pub node_type: String,
     pub is_built: bool,
     pub build_output: Vec<String>,
+    pub base_node: String,
 }
 
 /// JSON response for node list
@@ -101,6 +102,12 @@ pub struct CommandRequest {
     pub command: String,
     #[serde(default)]
     pub node_path: String,
+    /// Instance name override (for multi-instance nodes)
+    #[serde(default)]
+    pub name: Option<String>,
+    /// Config file path override (for multi-instance nodes)
+    #[serde(default)]
+    pub config: Option<String>,
 }
 
 /// JSON response for commands
@@ -159,6 +166,7 @@ fn node_state_to_response(state: &crate::schemas::daemon::v1::NodeState) -> Node
         node_type: state.node_type.clone(),
         is_built: state.is_built,
         build_output: state.build_output.clone(),
+        base_node: state.base_node.clone(),
     }
 }
 
@@ -364,6 +372,8 @@ impl ZenohApiService {
             timestamp_ms: Self::now_ms(),
             source_machine: "api".to_string(), // API calls don't have a source machine
             target_machine: self.machine_id.clone(),
+            name_override: request.name.unwrap_or_default(),
+            config_override: request.config.unwrap_or_default(),
         };
 
         let result = self.node_manager.execute_command(cmd).await;
@@ -387,6 +397,8 @@ impl ZenohApiService {
             timestamp_ms: Self::now_ms(),
             source_machine: "api".to_string(),
             target_machine: self.machine_id.clone(),
+            name_override: String::new(),
+            config_override: String::new(),
         };
 
         let result = self.node_manager.execute_command(cmd).await;
@@ -532,6 +544,8 @@ impl ZenohApiService {
             timestamp_ms: Self::now_ms(),
             source_machine: "api".to_string(),
             target_machine: self.machine_id.clone(),
+            name_override: request.name.unwrap_or_default(),
+            config_override: request.config.unwrap_or_default(),
         };
 
         let result = self.node_manager.execute_command(cmd).await;

--- a/crates/bubbaloop/src/daemon/zenoh_service.rs
+++ b/crates/bubbaloop/src/daemon/zenoh_service.rs
@@ -451,6 +451,7 @@ mod tests {
             machine_hostname: "test-hostname".to_string(),
             machine_ips: vec!["192.168.1.100".to_string()],
             base_node: String::new(),
+            config_override: String::new(),
         };
 
         let bytes = ZenohService::encode_proto(&state);

--- a/crates/bubbaloop/src/daemon/zenoh_service.rs
+++ b/crates/bubbaloop/src/daemon/zenoh_service.rs
@@ -450,6 +450,7 @@ mod tests {
             machine_id: "test-machine".to_string(),
             machine_hostname: "test-hostname".to_string(),
             machine_ips: vec!["192.168.1.100".to_string()],
+            base_node: String::new(),
         };
 
         let bytes = ZenohService::encode_proto(&state);

--- a/crates/bubbaloop/src/tui/app.rs
+++ b/crates/bubbaloop/src/tui/app.rs
@@ -64,6 +64,7 @@ pub struct NodeInfo {
     pub status: String,
     pub is_built: bool,
     pub build_output: Vec<String>,
+    pub base_node: String,
 }
 
 /// Discoverable node
@@ -1343,6 +1344,7 @@ impl App {
                 status: "stopped".to_string(),
                 is_built: false,
                 build_output: Vec::new(),
+                base_node: String::new(),
             };
             self.nodes.push(new_node);
             self.nodes.sort_by(|a, b| a.name.cmp(&b.name));
@@ -1384,7 +1386,7 @@ impl App {
                 tokio::spawn(async move {
                     let exe = std::env::current_exe().unwrap_or_else(|_| "bubbaloop".into());
                     let mut cmd = tokio::process::Command::new(exe);
-                    cmd.args(["node", "add", &repo, "--subdir", &subdir, "--build"]);
+                    cmd.args(["node", "add", &repo, "--subdir", &subdir]);
 
                     match cmd.output().await {
                         Ok(output) if output.status.success() => {
@@ -1662,6 +1664,7 @@ impl App {
                     status: "stopped".to_string(),
                     is_built: false,
                     build_output: Vec::new(),
+                    base_node: String::new(),
                 };
                 self.nodes.push(new_node);
                 self.nodes.sort_by(|a, b| a.name.cmp(&b.name));

--- a/crates/bubbaloop/src/tui/config/registry.rs
+++ b/crates/bubbaloop/src/tui/config/registry.rs
@@ -503,6 +503,7 @@ nodes:
             status: "stopped".to_string(),
             is_built: false,
             build_output: Vec::new(),
+            base_node: String::new(),
         }];
 
         let discovered = registry.scan_discoverable_nodes(&registered);

--- a/crates/bubbaloop/src/tui/config/registry.rs
+++ b/crates/bubbaloop/src/tui/config/registry.rs
@@ -172,24 +172,30 @@ impl Registry {
 
     pub fn scan_discoverable_nodes(&self, registered_nodes: &[NodeInfo]) -> Vec<DiscoverableNode> {
         let mut discovered = Vec::new();
-        // Use name-based dedup so installed nodes don't re-appear from builtin sources
-        let registered_names: HashSet<_> =
-            registered_nodes.iter().map(|n| n.name.as_str()).collect();
-        let registered_paths: HashSet<_> = registered_nodes
-            .iter()
-            .map(|n| normalize_path(&n.path))
-            .collect();
         let mut discovered_names: HashSet<String> = HashSet::new();
         let mut discovered_paths: HashSet<String> = HashSet::new();
 
-        // Scan enabled sources (first, so configured sources win over local dev)
+        // Build lookup maps from registered nodes for status computation
+        let registered_by_name: std::collections::HashMap<&str, &NodeInfo> = registered_nodes
+            .iter()
+            .filter(|n| n.base_node.is_empty()) // Only base nodes
+            .map(|n| (n.name.as_str(), n))
+            .collect();
+
+        // Scan enabled sources — always return all marketplace nodes (no dedup filtering)
         for source in self.get_enabled_sources() {
             if source.source_type == OFFICIAL_SOURCE_TYPE {
-                // Parse official nodes from cached YAML (fetched from GitHub)
-                for node in self.load_builtin_nodes() {
-                    if !registered_names.contains(node.name.as_str())
-                        && !discovered_names.contains(&node.name)
-                    {
+                for mut node in self.load_builtin_nodes() {
+                    if !discovered_names.contains(&node.name) {
+                        // Compute status from registered nodes
+                        if let Some(reg) = registered_by_name.get(node.name.as_str()) {
+                            node.is_added = true;
+                            node.is_built = reg.is_built;
+                        }
+                        node.instance_count = registered_nodes
+                            .iter()
+                            .filter(|n| n.base_node == node.name)
+                            .count();
                         discovered_names.insert(node.name.clone());
                         discovered.push(node);
                     }
@@ -198,11 +204,18 @@ impl Registry {
                 let found = scan_for_nodes(&source.path);
                 for node in found {
                     let normalized = normalize_path(&node.path);
-                    if !registered_paths.contains(&normalized)
-                        && !discovered_paths.contains(&normalized)
-                        && !registered_names.contains(node.name.as_str())
+                    if !discovered_paths.contains(&normalized)
                         && !discovered_names.contains(&node.name)
                     {
+                        let is_added = registered_by_name.contains_key(node.name.as_str());
+                        let is_built = registered_by_name
+                            .get(node.name.as_str())
+                            .map(|n| n.is_built)
+                            .unwrap_or(false);
+                        let instance_count = registered_nodes
+                            .iter()
+                            .filter(|n| n.base_node == node.name)
+                            .count();
                         discovered_paths.insert(normalized);
                         discovered_names.insert(node.name.clone());
                         discovered.push(DiscoverableNode {
@@ -213,6 +226,9 @@ impl Registry {
                             description: node.description,
                             source: source.name.clone(),
                             source_type: source.source_type.clone(),
+                            is_added,
+                            is_built,
+                            instance_count,
                         });
                     }
                 }
@@ -245,6 +261,9 @@ impl Registry {
                     description: entry.description,
                     source: OFFICIAL_SOURCE_NAME.to_string(),
                     source_type: OFFICIAL_SOURCE_TYPE.to_string(),
+                    is_added: false,
+                    is_built: false,
+                    instance_count: 0,
                 }
             })
             .collect()
@@ -471,7 +490,7 @@ nodes:
     }
 
     #[test]
-    fn test_builtin_dedup_with_registered_nodes() {
+    fn test_scan_returns_all_nodes_with_status() {
         let dir = tempfile::tempdir().unwrap();
 
         // Write a cached nodes.yaml
@@ -494,6 +513,86 @@ nodes:
             },
         };
 
+        // rtsp-camera is registered (base node, built)
+        let registered = vec![
+            NodeInfo {
+                name: "rtsp-camera".to_string(),
+                path: "/some/local/path".to_string(),
+                version: "0.1.0".to_string(),
+                node_type: "rust".to_string(),
+                description: String::new(),
+                status: "stopped".to_string(),
+                is_built: true,
+                build_output: Vec::new(),
+                base_node: String::new(),
+                config_override: String::new(),
+            },
+            // An instance of rtsp-camera
+            NodeInfo {
+                name: "rtsp-camera-terrace".to_string(),
+                path: "/some/local/path".to_string(),
+                version: "0.1.0".to_string(),
+                node_type: "rust".to_string(),
+                description: String::new(),
+                status: "running".to_string(),
+                is_built: true,
+                build_output: Vec::new(),
+                base_node: "rtsp-camera".to_string(),
+                config_override: String::new(),
+            },
+        ];
+
+        let discovered = registry.scan_discoverable_nodes(&registered);
+
+        // All 3 marketplace nodes should be returned (no dedup filtering)
+        assert_eq!(discovered.len(), 3);
+
+        // rtsp-camera should be marked as added and built
+        let camera = discovered.iter().find(|n| n.name == "rtsp-camera").unwrap();
+        assert!(camera.is_added);
+        assert!(camera.is_built);
+        assert_eq!(camera.instance_count, 1); // one instance exists
+
+        // openmeteo should NOT be marked as added
+        let meteo = discovered.iter().find(|n| n.name == "openmeteo").unwrap();
+        assert!(!meteo.is_added);
+        assert!(!meteo.is_built);
+        assert_eq!(meteo.instance_count, 0);
+
+        // network-monitor should NOT be marked as added
+        let netmon = discovered
+            .iter()
+            .find(|n| n.name == "network-monitor")
+            .unwrap();
+        assert!(!netmon.is_added);
+        assert!(!netmon.is_built);
+        assert_eq!(netmon.instance_count, 0);
+    }
+
+    #[test]
+    fn test_scan_not_built_node() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let cache_dir = dir.path().join("cache");
+        let _ = fs::create_dir_all(&cache_dir);
+        let _ = fs::write(
+            cache_dir.join(shared_registry::OFFICIAL_NODES_CACHE),
+            TEST_NODES_YAML,
+        );
+
+        let registry = Registry {
+            config_dir: dir.path().to_path_buf(),
+            sources: SourcesRegistry {
+                sources: vec![SourceEntry {
+                    name: OFFICIAL_SOURCE_NAME.to_string(),
+                    path: OFFICIAL_SOURCE_PATH.to_string(),
+                    source_type: OFFICIAL_SOURCE_TYPE.to_string(),
+                    enabled: true,
+                }],
+            },
+        };
+
+        // rtsp-camera is registered but NOT built
         let registered = vec![NodeInfo {
             name: "rtsp-camera".to_string(),
             path: "/some/local/path".to_string(),
@@ -504,17 +603,73 @@ nodes:
             is_built: false,
             build_output: Vec::new(),
             base_node: String::new(),
+            config_override: String::new(),
         }];
 
         let discovered = registry.scan_discoverable_nodes(&registered);
-        assert!(
-            !discovered.iter().any(|n| n.name == "rtsp-camera"),
-            "rtsp-camera should be deduplicated"
+        let camera = discovered.iter().find(|n| n.name == "rtsp-camera").unwrap();
+        assert!(camera.is_added);
+        assert!(!camera.is_built); // Added but not built
+        assert_eq!(camera.instance_count, 0);
+    }
+
+    #[test]
+    fn test_scan_multiple_instances_counted() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let cache_dir = dir.path().join("cache");
+        let _ = fs::create_dir_all(&cache_dir);
+        let _ = fs::write(
+            cache_dir.join(shared_registry::OFFICIAL_NODES_CACHE),
+            TEST_NODES_YAML,
         );
-        assert!(
-            discovered.iter().any(|n| n.name == "openmeteo"),
-            "openmeteo should still be discoverable"
-        );
+
+        let registry = Registry {
+            config_dir: dir.path().to_path_buf(),
+            sources: SourcesRegistry {
+                sources: vec![SourceEntry {
+                    name: OFFICIAL_SOURCE_NAME.to_string(),
+                    path: OFFICIAL_SOURCE_PATH.to_string(),
+                    source_type: OFFICIAL_SOURCE_TYPE.to_string(),
+                    enabled: true,
+                }],
+            },
+        };
+
+        let make_instance = |name: &str, base: &str| NodeInfo {
+            name: name.to_string(),
+            path: "/path".to_string(),
+            version: "0.1.0".to_string(),
+            node_type: "rust".to_string(),
+            description: String::new(),
+            status: "running".to_string(),
+            is_built: true,
+            build_output: Vec::new(),
+            base_node: base.to_string(),
+            config_override: String::new(),
+        };
+
+        let registered = vec![
+            NodeInfo {
+                name: "rtsp-camera".to_string(),
+                path: "/path".to_string(),
+                version: "0.1.0".to_string(),
+                node_type: "rust".to_string(),
+                description: String::new(),
+                status: "stopped".to_string(),
+                is_built: true,
+                build_output: Vec::new(),
+                base_node: String::new(),
+                config_override: String::new(),
+            },
+            make_instance("rtsp-camera-terrace", "rtsp-camera"),
+            make_instance("rtsp-camera-garage", "rtsp-camera"),
+            make_instance("rtsp-camera-front", "rtsp-camera"),
+        ];
+
+        let discovered = registry.scan_discoverable_nodes(&registered);
+        let camera = discovered.iter().find(|n| n.name == "rtsp-camera").unwrap();
+        assert_eq!(camera.instance_count, 3);
     }
 
     #[test]

--- a/crates/bubbaloop/src/tui/daemon/client.rs
+++ b/crates/bubbaloop/src/tui/daemon/client.rs
@@ -40,6 +40,8 @@ struct NodeState {
     build_output: Vec<String>,
     #[serde(default)]
     base_node: String,
+    #[serde(default)]
+    config_override: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -53,6 +55,10 @@ struct NodeListResponse {
 struct CommandRequest {
     command: String,
     node_path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    config: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -94,6 +100,7 @@ fn decode_node_list(bytes: &[u8]) -> Result<Vec<NodeInfo>> {
             is_built: n.is_built,
             build_output: n.build_output,
             base_node: n.base_node,
+            config_override: n.config_override,
         })
         .collect())
 }
@@ -201,6 +208,7 @@ impl DaemonClient {
                 is_built: n.is_built,
                 build_output: n.build_output,
                 base_node: n.base_node,
+                config_override: n.config_override,
             })
             .collect())
     }
@@ -210,6 +218,8 @@ impl DaemonClient {
         let payload = serde_json::to_string(&CommandRequest {
             command: command.to_string(),
             node_path: String::new(),
+            name: None,
+            config: None,
         })?;
 
         let response: CommandResponse = self.query(&key_expr, Some(&payload)).await?;
@@ -252,6 +262,8 @@ impl DaemonClient {
         let payload = serde_json::to_string(&CommandRequest {
             command: command.to_string(),
             node_path: String::new(),
+            name: None,
+            config: None,
         })?;
         self.fire_and_forget(&key_expr, &payload).await
     }
@@ -261,14 +273,46 @@ impl DaemonClient {
         let payload = serde_json::to_string(&CommandRequest {
             command: "add".to_string(),
             node_path: path.to_string(),
+            name: None,
+            config: None,
         })?;
         self.fire_and_forget(API_NODES_ADD, &payload).await
+    }
+
+    /// Send an add_node command for a new instance (with name and optional config overrides).
+    pub async fn send_add_node_instance(
+        &self,
+        path: &str,
+        name_override: Option<String>,
+        config_override: Option<String>,
+    ) -> Result<()> {
+        let payload = serde_json::to_string(&CommandRequest {
+            command: "add".to_string(),
+            node_path: path.to_string(),
+            name: name_override,
+            config: config_override,
+        })?;
+        self.fire_and_forget(API_NODES_ADD, &payload).await
+    }
+
+    /// Send an update-config command to change the config path for a running instance.
+    pub async fn send_update_config(&self, node_name: &str, config_path: &str) -> Result<()> {
+        let key_expr = format!("{}/{}/command", API_NODES, node_name);
+        let payload = serde_json::to_string(&CommandRequest {
+            command: "update-config".to_string(),
+            node_path: String::new(),
+            name: None,
+            config: Some(config_path.to_string()),
+        })?;
+        self.fire_and_forget(&key_expr, &payload).await
     }
 
     pub async fn add_node(&self, path: &str) -> Result<()> {
         let payload = serde_json::to_string(&CommandRequest {
             command: "add".to_string(),
             node_path: path.to_string(),
+            name: None,
+            config: None,
         })?;
 
         let response: CommandResponse = self.query(API_NODES_ADD, Some(&payload)).await?;
@@ -409,6 +453,8 @@ mod tests {
         let request = CommandRequest {
             command: "start".to_string(),
             node_path: "/path/to/node".to_string(),
+            name: None,
+            config: None,
         };
 
         let json = serde_json::to_string(&request).unwrap();
@@ -416,6 +462,9 @@ mod tests {
         assert!(json.contains("\"start\""));
         assert!(json.contains("\"node_path\""));
         assert!(json.contains("/path/to/node"));
+        // name and config should be absent when None
+        assert!(!json.contains("\"name\""));
+        assert!(!json.contains("\"config\""));
     }
 
     #[test]
@@ -426,6 +475,8 @@ mod tests {
             let request = CommandRequest {
                 command: cmd.to_string(),
                 node_path: "/test".to_string(),
+                name: None,
+                config: None,
             };
             let json = serde_json::to_string(&request).unwrap();
             assert!(json.contains(cmd));
@@ -487,6 +538,7 @@ mod tests {
             is_built: true,
             build_output: vec![],
             base_node: "sensor-base".to_string(),
+            config_override: "/etc/sensor.yaml".to_string(),
         };
 
         let node_info = NodeInfo {
@@ -499,6 +551,7 @@ mod tests {
             is_built: node_state.is_built,
             build_output: node_state.build_output.clone(),
             base_node: node_state.base_node.clone(),
+            config_override: node_state.config_override.clone(),
         };
 
         assert_eq!(node_info.name, "sensor");
@@ -507,5 +560,68 @@ mod tests {
         assert_eq!(node_info.node_type, "python");
         assert!(node_info.is_built);
         assert_eq!(node_info.base_node, "sensor-base");
+    }
+
+    #[test]
+    fn test_command_request_with_name_and_config() {
+        let request = CommandRequest {
+            command: "add".to_string(),
+            node_path: "/path/to/node".to_string(),
+            name: Some("my-instance".to_string()),
+            config: Some("/path/to/config.yaml".to_string()),
+        };
+
+        let json = serde_json::to_string(&request).unwrap();
+        assert!(json.contains("\"name\""));
+        assert!(json.contains("my-instance"));
+        assert!(json.contains("\"config\""));
+        assert!(json.contains("/path/to/config.yaml"));
+    }
+
+    #[test]
+    fn test_command_request_skip_serializing_none_fields() {
+        let request = CommandRequest {
+            command: "start".to_string(),
+            node_path: "/test".to_string(),
+            name: None,
+            config: None,
+        };
+
+        let json = serde_json::to_string(&request).unwrap();
+        assert!(!json.contains("\"name\""), "None name should be skipped");
+        assert!(
+            !json.contains("\"config\""),
+            "None config should be skipped"
+        );
+
+        // With only name set
+        let request = CommandRequest {
+            command: "add".to_string(),
+            node_path: "/test".to_string(),
+            name: Some("inst-1".to_string()),
+            config: None,
+        };
+
+        let json = serde_json::to_string(&request).unwrap();
+        assert!(json.contains("\"name\""));
+        assert!(!json.contains("\"config\""));
+    }
+
+    #[test]
+    fn test_command_request_round_trip_with_optional_fields() {
+        let original = CommandRequest {
+            command: "add".to_string(),
+            node_path: "/path".to_string(),
+            name: Some("instance-1".to_string()),
+            config: Some("/etc/config.yaml".to_string()),
+        };
+
+        let json = serde_json::to_string(&original).unwrap();
+        let deserialized: CommandRequest = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(deserialized.command, "add");
+        assert_eq!(deserialized.node_path, "/path");
+        assert_eq!(deserialized.name, Some("instance-1".to_string()));
+        assert_eq!(deserialized.config, Some("/etc/config.yaml".to_string()));
     }
 }

--- a/crates/bubbaloop/src/tui/daemon/client.rs
+++ b/crates/bubbaloop/src/tui/daemon/client.rs
@@ -38,6 +38,8 @@ struct NodeState {
     node_type: String,
     is_built: bool,
     build_output: Vec<String>,
+    #[serde(default)]
+    base_node: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -91,6 +93,7 @@ fn decode_node_list(bytes: &[u8]) -> Result<Vec<NodeInfo>> {
             status: proto_status_to_string(n.status),
             is_built: n.is_built,
             build_output: n.build_output,
+            base_node: n.base_node,
         })
         .collect())
 }
@@ -197,6 +200,7 @@ impl DaemonClient {
                 status: n.status,
                 is_built: n.is_built,
                 build_output: n.build_output,
+                base_node: n.base_node,
             })
             .collect())
     }
@@ -482,6 +486,7 @@ mod tests {
             node_type: "python".to_string(),
             is_built: true,
             build_output: vec![],
+            base_node: "sensor-base".to_string(),
         };
 
         let node_info = NodeInfo {
@@ -493,6 +498,7 @@ mod tests {
             status: node_state.status.clone(),
             is_built: node_state.is_built,
             build_output: node_state.build_output.clone(),
+            base_node: node_state.base_node.clone(),
         };
 
         assert_eq!(node_info.name, "sensor");
@@ -500,5 +506,6 @@ mod tests {
         assert_eq!(node_info.status, "active");
         assert_eq!(node_info.node_type, "python");
         assert!(node_info.is_built);
+        assert_eq!(node_info.base_node, "sensor-base");
     }
 }

--- a/dashboard/src/components/NodesView.tsx
+++ b/dashboard/src/components/NodesView.tsx
@@ -21,6 +21,7 @@ interface NodeState {
   machine_id?: string;
   machine_hostname?: string;
   machine_ips?: string[];
+  base_node?: string;
   stale?: boolean;
 }
 
@@ -104,6 +105,7 @@ export function NodesViewPanel({
           machine_id: n.machineId || listMachineId,
           machine_hostname: n.machineHostname,
           machine_ips: n.machineIps || [],
+          base_node: n.baseNode || '',
         }));
         setDaemonConnected(true);
         setError(null);
@@ -420,6 +422,7 @@ export function NodesViewPanel({
       ips: n.machine_ips || [],
       nodeType: n.node_type,
       version: n.version,
+      baseNode: n.base_node || '',
     })));
   }, [nodes, reportNodes]);
 

--- a/dashboard/src/contexts/FleetContext.tsx
+++ b/dashboard/src/contexts/FleetContext.tsx
@@ -17,6 +17,7 @@ export interface FleetNodeInfo {
   ips: string[];
   nodeType: string;
   version: string;
+  baseNode: string;
 }
 
 interface FleetContextValue {

--- a/dashboard/src/proto/daemon.ts
+++ b/dashboard/src/proto/daemon.ts
@@ -30,6 +30,7 @@ export interface NodeState {
   machineId: string;
   machineHostname: string;
   machineIps: string[];
+  baseNode: string;
 }
 
 export interface NodeList {
@@ -93,6 +94,7 @@ function decodeNodeState(msg: unknown): NodeState | null {
     machineId: (m.machineId as string) ?? '',
     machineHostname: (m.machineHostname as string) ?? '',
     machineIps: (m.machineIps as string[]) ?? [],
+    baseNode: (m.baseNode as string) ?? '',
   };
 }
 

--- a/docs/guides/node-marketplace.md
+++ b/docs/guides/node-marketplace.md
@@ -81,10 +81,11 @@ nodes:
 - Test that `pixi run build` succeeds from a clean checkout
 - Pin dependency versions for reproducible builds (commit `Cargo.lock`)
 
-## Future: Node Search
+## Node Search
+
+Search for nodes by name, category, or tag:
 
 ```bash
-# Coming soon
 bubbaloop node search camera
 bubbaloop node search --category weather
 bubbaloop node search --tag gstreamer

--- a/templates/python-node/pixi.toml.template
+++ b/templates/python-node/pixi.toml.template
@@ -1,4 +1,4 @@
-[project]
+[workspace]
 name = "{{node_name}}"
 version = "0.1.0"
 description = "{{description}}"
@@ -7,7 +7,6 @@ platforms = ["linux-64", "linux-aarch64"]
 
 [tasks]
 run = "python main.py -c config.yaml"
-dev = "python main.py -c config.yaml"
 
 [dependencies]
 python = ">=3.10"

--- a/templates/rust-node/pixi.toml.template
+++ b/templates/rust-node/pixi.toml.template
@@ -1,4 +1,4 @@
-[project]
+[workspace]
 name = "{{node_name}}"
 version = "0.1.0"
 description = "{{description}}"


### PR DESCRIPTION
### **User description**
## Summary

- Add `bubbaloop launch <node> <file.yaml>` command to spawn multiple instances of the same base node with different configurations (e.g., multiple cameras from one `rtsp-camera` node definition)
- Extend proto schema with `base_node`, `name_override`, and `config_override` fields in `NodeState`
- Add `--name`/`--config` flags to `node add` for inline instance customization without a launch file

## Changes

| Area | Files | What |
|------|-------|------|
| Proto | `daemon.proto` | New `base_node`, `name_override`, `config_override` fields |
| CLI (new) | `cli/launch.rs` | Launch command with YAML parsing and instance name generation |
| CLI | `bubbaloop.rs`, `cli/mod.rs`, `cli/node.rs`, `cli/status.rs` | Wire launch subcommand, add `--name`/`--config` to `node add` |
| Daemon | `node_manager.rs`, `registry.rs`, `zenoh_api.rs`, `zenoh_service.rs` | Instance tracking by effective name, override support |
| TUI | `app.rs`, `config/registry.rs`, `daemon/client.rs` | Display `base_node` info |
| Dashboard | `NodesView.tsx`, `FleetContext.tsx`, `daemon.ts` | Show `baseNode` field in UI |

16 files changed, +979/-102 lines.

## Test plan

- [ ] `bubbaloop launch rtsp-camera cameras.yaml` creates multiple camera instances
- [ ] `bubbaloop node add . --name my-cam --config rtsp_url=rtsp://...` creates a named instance
- [ ] `bubbaloop status` shows launched instances with base node info
- [ ] Dashboard nodes view displays `baseNode` for launched instances
- [ ] Stopping/removing an instance does not affect the base node or other instances
- [ ] `pixi run check` compiles cleanly
- [ ] `pixi run clippy` passes with zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Add `bubbaloop launch` command for spawning multi-instance nodes from YAML files

- Extend proto schema with `base_node`, `name_override`, `config_override` fields

- Support instance name and config overrides in node registration and management

- Display `base_node` info in CLI, TUI, and dashboard for launched instances


___

### Diagram Walkthrough


```mermaid
flowchart LR
  LaunchYAML["Launch YAML<br/>name + config"] -->|parse| LaunchCmd["Launch Command<br/>resolve node path"]
  LaunchCmd -->|register| Registry["Registry<br/>name_override<br/>config_override"]
  Registry -->|track by<br/>effective_name| NodeMgr["Node Manager<br/>CachedNode"]
  NodeMgr -->|proto with<br/>base_node| Proto["Proto NodeState<br/>base_node field"]
  Proto -->|display| UI["CLI/TUI/Dashboard<br/>show base_node"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>14 files</summary><table>
<tr>
  <td><strong>launch.rs</strong><dd><code>New launch command with YAML parsing and instance registration</code></dd></td>
  <td><a href="https://github.com/kornia/bubbaloop/pull/29/files#diff-e3fa152def138f925f007fdeb668a00715d3aa04c01a4b10bc526493ae9d7b61">+364/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>bubbaloop.rs</strong><dd><code>Wire launch subcommand into main CLI dispatcher</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/kornia/bubbaloop/pull/29/files#diff-4bbd52ce103763166e154d17cb77a629e573daa7714c27cef605d8696d32e4ba">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>mod.rs</strong><dd><code>Export new launch module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/kornia/bubbaloop/pull/29/files#diff-72bc37e8a33b503617c8bbded334852032289b4e723f9d664c61a5abbd86f7f3">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>node.rs</strong><dd><code>Add --name and --config flags to node add command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/kornia/bubbaloop/pull/29/files#diff-afc97216036569d366bb5d2ccb90777a5c9822a125432038c202572c17c92f63">+79/-20</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>node_manager.rs</strong><dd><code>Track instance overrides and compute effective names</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/kornia/bubbaloop/pull/29/files#diff-0f2da4742e4c2c0924a72c1f0f70e2edba1aac823cf745a90f73c9d53dd234b2">+285/-49</a></td>

</tr>

<tr>
  <td><strong>registry.rs</strong><dd><code>Store name_override and config_override in registry entries</code></dd></td>
  <td><a href="https://github.com/kornia/bubbaloop/pull/29/files#diff-592d723113671ae4d823369d266a2a898fd432c655482fc84f9229351525228a">+199/-32</a></td>

</tr>

<tr>
  <td><strong>zenoh_api.rs</strong><dd><code>Add name and config fields to command request/response</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/kornia/bubbaloop/pull/29/files#diff-3b85a466794fd3ebb2ebca0bba086fefccec3e057d12f3d74c2a780a42a2e4e4">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>status.rs</strong><dd><code>Add base_node field to node state deserialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/kornia/bubbaloop/pull/29/files#diff-7b86285c71bcd68df9a99937120cb6293882e7de70b6556b1ae3f56f5c8e9d3d">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>app.rs</strong><dd><code>Add base_node field to NodeInfo struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/kornia/bubbaloop/pull/29/files#diff-cc7bbd23c04207be8382f28ea21b56f9a9123883b7c938ca4effbef018fc3895">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>client.rs</strong><dd><code>Decode and propagate base_node from daemon responses</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/kornia/bubbaloop/pull/29/files#diff-37b4bd2760c69f5de75c3ca35963c310836d97c3f8f6711076b840383b6224ce">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>daemon.proto</strong><dd><code>Add base_node, name_override, config_override proto fields</code></dd></td>
  <td><a href="https://github.com/kornia/bubbaloop/pull/29/files#diff-56ab215628e82da8a5918d9bbd681ec9f8406b1bbb919422a05c2c752416c5eb">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>daemon.ts</strong><dd><code>Add baseNode field to TypeScript NodeState interface</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/kornia/bubbaloop/pull/29/files#diff-d5ec839b38f5f95c7cab6eaa1cc0a4cfdc0378e0ac22d021d97f3a7d900ff478">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>NodesView.tsx</strong><dd><code>Display baseNode in nodes view and fleet reporting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/kornia/bubbaloop/pull/29/files#diff-dde64de7040d72c41fa78b5d47772ede99e1df9a855fa117f539371f71f62de2">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>FleetContext.tsx</strong><dd><code>Add baseNode to FleetNodeInfo interface</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/kornia/bubbaloop/pull/29/files#diff-415c56b6882786f10e646de1c3f6833a6ed64966b2a266a153ef708aa638d9d6">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>zenoh_service.rs</strong><dd><code>Update test fixtures with base_node field</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/kornia/bubbaloop/pull/29/files#diff-4d569a6adb0b705a34121a5b782eca103e7a2990e5628186df6800067fad95c2">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>registry.rs</strong><dd><code>Update test fixtures with base_node field</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/kornia/bubbaloop/pull/29/files#diff-d218bc6d81fe256e4bcb2b5ad981f3d394f37c37733fd88bae372f19a1cf7711">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

