### PR TITLE
fix(dashboard): camera topic auto-detection, build warnings, and proto header

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -22,6 +22,8 @@ const ZENOH_ENDPOINT = getZenohEndpoint();
 // ros-z key format: {domain_id}/{topic_with_%_encoding}/{type_info}
 // Topic paths in ros-z use % encoding: /camera/entrance/compressed -> camera%entrance%compressed
 // Use wildcard pattern to match the type_info suffix
+// Note: CameraView automatically adds a glob prefix (*) to match machine-specific prefixes
+// (e.g., bubbaloop%local%nvidia_orin00%camera%terrace%compressed)
 const DEFAULT_CAMERAS = [
   { name: 'entrance', topic: '0/camera%entrance%compressed/**' },
   { name: 'terrace', topic: '0/camera%terrace%compressed/**' },

--- a/dashboard/src/components/CameraView.tsx
+++ b/dashboard/src/components/CameraView.tsx
@@ -6,6 +6,7 @@ import { useFleetContext } from '../contexts/FleetContext';
 import { MachineBadge } from './MachineBadge';
 import { H264Decoder } from '../lib/h264-decoder';
 import { decodeCompressedImage, Header } from '../proto/camera';
+import { normalizeTopicPattern } from '../lib/subscription-manager';
 
 interface DragHandleProps {
   [key: string]: unknown;
@@ -138,6 +139,52 @@ export function CameraView({
       console.error('[CameraView] Failed to process sample:', e);
     }
   }, []);
+
+  // Auto-detect correct topic from discovered topics.
+  // Camera topics may have machine-specific prefixes (e.g.,
+  //   0/bubbaloop%local%nvidia_orin00%camera%terrace%compressed/...)
+  // that don't match the default patterns (e.g., 0/camera%terrace%compressed/**).
+  // When topic discovery finds the real topic, switch the subscription.
+  const autoDetectedRef = useRef(false);
+  useEffect(() => {
+    if (autoDetectedRef.current || !onTopicChange || availableTopics.length === 0) return;
+
+    // Extract camera name hint from current topic
+    // e.g., "0/camera%terrace%compressed/**" -> decode % to / -> find "terrace"
+    const currentBase = topic.replace(/\/?\*\*$/, '').replace(/\/?\*$/, '');
+    const decoded = currentBase.replace(/%/g, '/');
+    const segments = decoded.split('/').filter(Boolean);
+    const cameraIdx = segments.indexOf('camera');
+    const compressedIdx = segments.indexOf('compressed');
+    const cameraHint = cameraIdx >= 0 && compressedIdx > cameraIdx
+      ? segments.slice(cameraIdx + 1, compressedIdx).join('/')
+      : null;
+
+    if (!cameraHint) return;
+
+    // Check if current topic already receives data (subscription manager matched it)
+    // by looking for it in availableTopics
+    const alreadyMatches = availableTopics.some(t => {
+      const normalized = normalizeTopicPattern(t);
+      return normalized === currentBase;
+    });
+    if (alreadyMatches) return;
+
+    // Find a discovered topic containing the camera name
+    for (const discoveredTopic of availableTopics) {
+      const decodedDiscovered = discoveredTopic.replace(/%/g, '/');
+      if (decodedDiscovered.includes(`camera/${cameraHint}/compressed`)) {
+        const normalized = normalizeTopicPattern(discoveredTopic);
+        const newTopic = normalized + '/**';
+        if (newTopic !== topic) {
+          autoDetectedRef.current = true;
+          console.log(`[CameraView] Auto-detected topic for "${cameraHint}": ${topic} -> ${newTopic}`);
+          onTopicChange(newTopic);
+        }
+        return;
+      }
+    }
+  }, [availableTopics, topic, onTopicChange]);
 
   // Subscribe to camera topic
   useZenohSubscription(topic, handleSample);

--- a/dashboard/src/components/JsonView.tsx
+++ b/dashboard/src/components/JsonView.tsx
@@ -93,6 +93,8 @@ function decodePayload(payload: Uint8Array, topic: string): { data: unknown; sch
             pubTime: msg.header.pubTime.toString(),
             sequence: msg.header.sequence,
             frameId: msg.header.frameId,
+            machineId: msg.header.machineId,
+            scope: msg.header.scope,
           };
           if (msg.header.acqTime > 0n && msg.header.pubTime > 0n) {
             const latencyNs = msg.header.pubTime - msg.header.acqTime;

--- a/dashboard/src/lib/h264-decoder.ts
+++ b/dashboard/src/lib/h264-decoder.ts
@@ -4,9 +4,9 @@
  * WebCodecs provides hardware-accelerated video decoding directly in the browser.
  * Decodes H264 NAL units frame-by-frame and renders to canvas.
  *
- * Important: This decoder handles Annex B format (with start codes) as received
- * from GStreamer. WebCodecs can decode Annex B directly, but we need to provide
- * SPS/PPS as 'description' in AVCC format for reliable initialization.
+ * Supports both Annex B format (start codes, from GStreamer) and
+ * AVCC format (length-prefixed, from MP4/RTSP extractors).
+ * Format is auto-detected from the first keyframe.
  */
 
 export type FrameCallback = (frame: VideoFrame) => void;
@@ -24,6 +24,14 @@ interface SPSInfo {
   ppsData?: Uint8Array;
 }
 
+type NalFormat = 'unknown' | 'annexb' | 'avcc';
+
+interface NalUnit {
+  type: number;
+  data: Uint8Array;
+  offset: number;
+}
+
 export class H264Decoder {
   private decoder: VideoDecoder | null = null;
   private options: H264DecoderOptions;
@@ -32,6 +40,9 @@ export class H264Decoder {
   private spsInfo: SPSInfo | null = null;
   private errorCount = 0;
   private maxErrors = 3;
+  private nalFormat: NalFormat = 'unknown';
+  private framesReceived = 0;
+  private lastDiagnosticLog = 0;
 
   constructor(options: H264DecoderOptions) {
     this.options = options;
@@ -45,14 +56,40 @@ export class H264Decoder {
   }
 
   /**
-   * Parse NAL units from Annex B format
-   * Returns array of { type, data } for each NAL unit
+   * Detect whether data is Annex B (start codes) or AVCC (length-prefixed).
    */
-  private parseNalUnits(data: Uint8Array): Array<{ type: number; data: Uint8Array; offset: number }> {
-    const nalUnits: Array<{ type: number; data: Uint8Array; offset: number }> = [];
+  private detectFormat(data: Uint8Array): NalFormat {
+    if (data.length < 5) return 'unknown';
+
+    // Check for Annex B start codes
+    if (data[0] === 0 && data[1] === 0) {
+      if (data[2] === 1) return 'annexb'; // 3-byte start code
+      if (data[2] === 0 && data[3] === 1) return 'annexb'; // 4-byte start code
+    }
+
+    // Check for AVCC: first 4 bytes are big-endian NAL length
+    const nalLen = (data[0] << 24) | (data[1] << 16) | (data[2] << 8) | data[3];
+    if (nalLen > 0 && nalLen <= data.length - 4) {
+      // Verify the NAL header byte after the length looks valid
+      const nalHeader = data[4];
+      const forbiddenBit = (nalHeader >> 7) & 1;
+      const nalType = nalHeader & 0x1f;
+      if (forbiddenBit === 0 && nalType > 0 && nalType <= 23) {
+        return 'avcc';
+      }
+    }
+
+    return 'unknown';
+  }
+
+  /**
+   * Parse NAL units from Annex B format (start code delimited).
+   */
+  private parseNalUnitsAnnexB(data: Uint8Array): NalUnit[] {
+    const nalUnits: NalUnit[] = [];
     let i = 0;
 
-    while (i < data.length - 4) {
+    while (i < data.length - 2) {
       // Find start code (0x00 0x00 0x01 or 0x00 0x00 0x00 0x01)
       if (data[i] === 0 && data[i + 1] === 0) {
         let nalStart = -1;
@@ -66,8 +103,8 @@ export class H264Decoder {
         if (nalStart >= 0 && nalStart < data.length) {
           // Find the end of this NAL (next start code or end of data)
           let nalEnd = data.length;
-          for (let j = nalStart; j < data.length - 3; j++) {
-            if (data[j] === 0 && data[j + 1] === 0 && (data[j + 2] === 1 || (data[j + 2] === 0 && data[j + 3] === 1))) {
+          for (let j = nalStart + 1; j < data.length - 2; j++) {
+            if (data[j] === 0 && data[j + 1] === 0 && (data[j + 2] === 1 || (data[j + 2] === 0 && j + 3 < data.length && data[j + 3] === 1))) {
               nalEnd = j;
               break;
             }
@@ -88,6 +125,119 @@ export class H264Decoder {
     }
 
     return nalUnits;
+  }
+
+  /**
+   * Parse NAL units from AVCC format (4-byte big-endian length prefixed).
+   */
+  private parseNalUnitsAVCC(data: Uint8Array): NalUnit[] {
+    const nalUnits: NalUnit[] = [];
+    let i = 0;
+
+    while (i + 4 < data.length) {
+      const nalLen = (data[i] << 24) | (data[i + 1] << 16) | (data[i + 2] << 8) | data[i + 3];
+
+      if (nalLen <= 0 || nalLen > data.length - i - 4) {
+        break; // Invalid length
+      }
+
+      const nalStart = i + 4;
+      const nalEnd = nalStart + nalLen;
+      const nalType = data[nalStart] & 0x1f;
+
+      nalUnits.push({
+        type: nalType,
+        data: data.slice(nalStart, nalEnd),
+        offset: i,
+      });
+
+      i = nalEnd;
+    }
+
+    return nalUnits;
+  }
+
+  /**
+   * Parse NAL units, auto-detecting format on first successful parse.
+   */
+  private parseNalUnits(data: Uint8Array): NalUnit[] {
+    // Use cached format if already detected
+    if (this.nalFormat === 'annexb') {
+      return this.parseNalUnitsAnnexB(data);
+    }
+    if (this.nalFormat === 'avcc') {
+      return this.parseNalUnitsAVCC(data);
+    }
+
+    // Auto-detect format
+    const detected = this.detectFormat(data);
+
+    if (detected === 'annexb') {
+      const units = this.parseNalUnitsAnnexB(data);
+      if (units.length > 0) {
+        this.nalFormat = 'annexb';
+        console.log(`[H264Decoder] Detected Annex B format (start code delimited)`);
+        return units;
+      }
+    }
+
+    if (detected === 'avcc') {
+      const units = this.parseNalUnitsAVCC(data);
+      if (units.length > 0) {
+        this.nalFormat = 'avcc';
+        console.log(`[H264Decoder] Detected AVCC format (length-prefixed)`);
+        return units;
+      }
+    }
+
+    // Try both parsers as fallback
+    const annexB = this.parseNalUnitsAnnexB(data);
+    if (annexB.length > 0) {
+      this.nalFormat = 'annexb';
+      console.log(`[H264Decoder] Detected Annex B format (fallback)`);
+      return annexB;
+    }
+
+    const avcc = this.parseNalUnitsAVCC(data);
+    if (avcc.length > 0) {
+      this.nalFormat = 'avcc';
+      console.log(`[H264Decoder] Detected AVCC format (fallback)`);
+      return avcc;
+    }
+
+    return [];
+  }
+
+  /**
+   * Convert AVCC data to Annex B by replacing length prefixes with start codes.
+   * WebCodecs in Annex B mode (no description) expects start codes.
+   */
+  private avccToAnnexB(data: Uint8Array): Uint8Array {
+    const nalUnits = this.parseNalUnitsAVCC(data);
+    if (nalUnits.length === 0) return data;
+
+    // Calculate output size: each NAL gets a 4-byte start code + its data
+    let totalSize = 0;
+    for (const nal of nalUnits) {
+      totalSize += 4 + nal.data.length;
+    }
+
+    const output = new Uint8Array(totalSize);
+    let offset = 0;
+
+    for (const nal of nalUnits) {
+      // Write 4-byte start code
+      output[offset] = 0;
+      output[offset + 1] = 0;
+      output[offset + 2] = 0;
+      output[offset + 3] = 1;
+      offset += 4;
+      // Write NAL data
+      output.set(nal.data, offset);
+      offset += nal.data.length;
+    }
+
+    return output;
   }
 
   /**
@@ -153,7 +303,10 @@ export class H264Decoder {
     this.initialized = true;
     this.waitingForKeyframe = true;
     this.spsInfo = null;
+    this.nalFormat = 'unknown';
     this.errorCount = 0;
+    this.framesReceived = 0;
+    this.lastDiagnosticLog = 0;
 
     console.log('[H264Decoder] Decoder created, waiting for SPS/PPS');
   }
@@ -210,14 +363,45 @@ export class H264Decoder {
   }
 
   /**
+   * Log diagnostic info when stuck waiting for keyframe
+   */
+  private logDiagnostic(data: Uint8Array): void {
+    const now = Date.now();
+    // Log at most every 3 seconds
+    if (now - this.lastDiagnosticLog < 3000) return;
+    this.lastDiagnosticLog = now;
+
+    const first16 = Array.from(data.slice(0, 16))
+      .map(b => b.toString(16).padStart(2, '0'))
+      .join(' ');
+
+    // Try to parse with both formats to diagnose
+    const annexBNals = this.parseNalUnitsAnnexB(data);
+    const avccNals = this.parseNalUnitsAVCC(data);
+
+    const annexBTypes = annexBNals.map(n => n.type);
+    const avccTypes = avccNals.map(n => n.type);
+
+    console.warn(
+      `[H264Decoder] Waiting for keyframe — received ${this.framesReceived} frames, ` +
+      `last: ${data.length} bytes, format: ${this.nalFormat}, ` +
+      `first16: [${first16}], ` +
+      `annexB NALs: [${annexBTypes.join(',')}], ` +
+      `avcc NALs: [${avccTypes.join(',')}]`
+    );
+  }
+
+  /**
    * Decode H264 data
-   * @param data - H264 NAL units in Annex B format
+   * @param data - H264 NAL units in Annex B or AVCC format (auto-detected)
    * @param timestamp - Timestamp in microseconds
    */
   async decode(data: Uint8Array, timestamp: number): Promise<void> {
     if (!this.decoder || !this.initialized) {
       return;
     }
+
+    this.framesReceived++;
 
     // Check if decoder is in a bad state
     if (this.decoder.state === 'closed') {
@@ -231,10 +415,11 @@ export class H264Decoder {
     // Wait for a keyframe to start decoding
     if (this.waitingForKeyframe) {
       if (!isKeyframe) {
+        this.logDiagnostic(data);
         return;
       }
 
-      console.log(`[H264Decoder] Keyframe received (${data.length} bytes)`);
+      console.log(`[H264Decoder] Keyframe received (${data.length} bytes, format: ${this.nalFormat})`);
 
       // Extract SPS/PPS and configure decoder
       const spsInfo = this.extractParameterSets(data);
@@ -266,11 +451,14 @@ export class H264Decoder {
       return;
     }
 
+    // Convert AVCC to Annex B if needed (WebCodecs without description expects Annex B)
+    const decodeData = this.nalFormat === 'avcc' ? this.avccToAnnexB(data) : data;
+
     try {
       const chunk = new EncodedVideoChunk({
         type: isKeyframe ? 'key' : 'delta',
         timestamp,
-        data,
+        data: decodeData,
       });
 
       this.decoder.decode(chunk);
@@ -284,6 +472,7 @@ export class H264Decoder {
           isKeyframe,
           timestamp,
           dataLength: data.length,
+          format: this.nalFormat,
           first16Bytes: Array.from(data.slice(0, 16)).map(b => b.toString(16).padStart(2, '0')).join(' '),
         });
       }
@@ -346,7 +535,9 @@ export class H264Decoder {
     this.initialized = false;
     this.waitingForKeyframe = true;
     this.spsInfo = null;
+    this.nalFormat = 'unknown';
     this.errorCount = 0;
+    this.framesReceived = 0;
   }
 
   get isInitialized(): boolean {

--- a/dashboard/src/proto/camera.ts
+++ b/dashboard/src/proto/camera.ts
@@ -12,6 +12,8 @@ export interface Header {
   pubTime: bigint;
   sequence: number;
   frameId: string;
+  machineId: string;
+  scope: string;
 }
 
 export interface CompressedImage {
@@ -44,6 +46,8 @@ export function decodeCompressedImage(data: Uint8Array): CompressedImage {
       pubTime: toLongBigInt(message.header.pubTime as Long | number),
       sequence: message.header.sequence ?? 0,
       frameId: message.header.frameId ?? '',
+      machineId: message.header.machineId ?? '',
+      scope: message.header.scope ?? '',
     } : undefined;
 
     return {

--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -158,5 +158,21 @@ export default defineConfig({
       // Transform CommonJS to ESM
       transformMixedEsModules: true,
     },
+    rollupOptions: {
+      onwarn(warning, defaultHandler) {
+        // Suppress eval warning from protobufjs (third-party, cannot fix)
+        if (warning.code === 'EVAL' && warning.id?.includes('@protobufjs')) return;
+        defaultHandler(warning);
+      },
+      output: {
+        manualChunks: {
+          'vendor-react': ['react', 'react-dom'],
+          'vendor-zenoh': ['@eclipse-zenoh/zenoh-ts', 'channel-ts'],
+          'vendor-proto': ['protobufjs/minimal', 'long'],
+          'vendor-dnd': ['@dnd-kit/core', '@dnd-kit/sortable'],
+          'vendor-json-view': ['react18-json-view'],
+        },
+      },
+    },
   },
 });


### PR DESCRIPTION
### **User description**
## Summary

- **Camera auto-detection**: CameraView now automatically detects machine-prefixed topics from Zenoh topic discovery and switches subscriptions, fixing camera images not displaying when ros-z publishes with full machine paths (e.g., `bubbaloop%local%nvidia_orin00%camera%terrace%compressed`)
- **Build warnings eliminated**: Suppressed protobufjs eval warning, split vendor chunks (react, zenoh, proto, dnd, json-view) to stay under 500KB limit
- **Proto header updated**: Added `machineId` and `scope` fields to the `Header` TypeScript interface and decoder to match current `header.proto` schema; raw data panel now displays the full header
- **H264 AVCC support**: H264 decoder auto-detects Annex B vs AVCC NAL format, with diagnostic logging when waiting for keyframes
- **NodesView cleanup**: Replaced dynamic proto imports with module-level imports for `NodeCommandProto`, `CommandResultProto`, and `CommandType`

## Test plan

- [ ] Run `npx vite build` in `dashboard/` — should produce zero warnings
- [ ] Start dashboard with camera node publishing via ros-z — camera panel should auto-detect and display the stream
- [ ] Open raw data panel for a camera topic — header should show all 6 fields (`acqTime`, `pubTime`, `sequence`, `frameId`, `machineId`, `scope`)
- [ ] Verify node commands (start/stop/logs) still work in NodesView panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Auto-detect machine-prefixed camera topics from Zenoh discovery
  - Switches subscriptions when default patterns don't match published topics

- Add AVCC format support to H264 decoder with auto-detection
  - Converts AVCC to Annex B for WebCodecs compatibility
  - Includes diagnostic logging when waiting for keyframes

- Extend Header proto with machineId and scope fields
  - Updates TypeScript interface, decoder, and raw data panel display

- Eliminate build warnings via protobufjs suppression and vendor chunk splitting
  - Splits react, zenoh, proto, dnd, json-view into separate chunks under 500KB

- Refactor NodesView to use module-level proto imports
  - Replaces dynamic imports with static imports for better performance


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Camera Topic Pattern<br/>0/camera%terrace%compressed/**"] -->|"Auto-detect from<br/>discovered topics"| B["Machine-prefixed Topic<br/>0/bubbaloop%local%nvidia_orin00%camera%terrace%compressed/**"]
  B -->|"Subscribe"| C["CameraView"]
  C -->|"Receive H264 data"| D["H264Decoder"]
  D -->|"Detect format<br/>Annex B or AVCC"| E["Parse NAL Units"]
  E -->|"Convert AVCC<br/>to Annex B if needed"| F["WebCodecs Decoder"]
  F -->|"Render"| G["Canvas"]
  H["Header Proto<br/>acqTime, pubTime,<br/>sequence, frameId"] -->|"Add machineId,<br/>scope fields"| I["Extended Header<br/>6 fields total"]
  I -->|"Display in<br/>raw data panel"| J["JsonView"]
  K["Build Config"] -->|"Suppress EVAL warning<br/>Split vendor chunks"| L["Zero warnings<br/>All chunks &lt;500KB"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>h264-decoder.ts</strong><dd><code>H264 decoder AVCC format support and auto-detection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dashboard/src/lib/h264-decoder.ts

<ul><li>Add format auto-detection for Annex B (start codes) vs AVCC <br>(length-prefixed) NAL formats<br> <li> Implement separate parsers for each format with fallback detection <br>logic<br> <li> Add AVCC to Annex B conversion for WebCodecs compatibility<br> <li> Add diagnostic logging when waiting for keyframes with frame count and <br>NAL type info<br> <li> Track frames received and last diagnostic log timestamp for throttled <br>logging</ul>


</details>


  </td>
  <td><a href="https://github.com/kornia/bubbaloop/pull/30/files#diff-c6a5ade95127b40e6710eee033ddb1d4a41dc0c5779c606f8893042becc2b1ae">+204/-13</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>camera.ts</strong><dd><code>Extend Header interface with machine and scope fields</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dashboard/src/proto/camera.ts

<ul><li>Add <code>machineId</code> and <code>scope</code> fields to Header interface<br> <li> Update decoder to extract and populate new fields from proto message</ul>


</details>


  </td>
  <td><a href="https://github.com/kornia/bubbaloop/pull/30/files#diff-fa142be475e49daeabd534c612c11278d3ded970fa37772a298751ccbadd5373">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CameraView.tsx</strong><dd><code>Auto-detect and switch to machine-prefixed camera topics</code>&nbsp; </dd></summary>
<hr>

dashboard/src/components/CameraView.tsx

<ul><li>Implement auto-detection logic to find machine-prefixed topics from <br>discovered topics<br> <li> Extract camera name hint from current topic pattern and match against <br>discovered topics<br> <li> Switch subscription when real topic is found that matches the camera <br>hint<br> <li> Add normalizeTopicPattern utility import for topic comparison</ul>


</details>


  </td>
  <td><a href="https://github.com/kornia/bubbaloop/pull/30/files#diff-ef433d3415ccda8d7abe2d6543870b1d87ad3c3fe31dab3e406d00636ed8483f">+47/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>JsonView.tsx</strong><dd><code>Display machineId and scope in raw data panel</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dashboard/src/components/JsonView.tsx

<ul><li>Add machineId and scope fields to header display in raw data panel<br> <li> Display new fields alongside existing header fields (acqTime, pubTime, <br>sequence, frameId)</ul>


</details>


  </td>
  <td><a href="https://github.com/kornia/bubbaloop/pull/30/files#diff-fb6cc0d55e7238e58b4f4cfc64686ca762f52d62fa61447ce723fb780b0b288c">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>NodesView.tsx</strong><dd><code>Refactor to use module-level proto imports</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dashboard/src/components/NodesView.tsx

<ul><li>Replace dynamic proto imports with module-level imports for <br>NodeCommandProto, CommandResultProto, CommandType<br> <li> Remove async import calls in executeCommand and fetchLogs functions<br> <li> Use imported proto classes directly instead of accessing via bubbaloop <br>namespace</ul>


</details>


  </td>
  <td><a href="https://github.com/kornia/bubbaloop/pull/30/files#diff-dde64de7040d72c41fa78b5d47772ede99e1df9a855fa117f539371f71f62de2">+7/-18</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vite.config.ts</strong><dd><code>Configure build to eliminate warnings and split chunks</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dashboard/vite.config.ts

<ul><li>Add rollupOptions to suppress protobufjs EVAL warning<br> <li> Implement manualChunks to split vendor dependencies into separate <br>bundles<br> <li> Split react, zenoh, proto, dnd, and json-view into individual vendor <br>chunks</ul>


</details>


  </td>
  <td><a href="https://github.com/kornia/bubbaloop/pull/30/files#diff-2dff8f693803d85fe93013a36ece84f7fef1ccfddf9f6c473caf051e4deeac7e">+16/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>App.tsx</strong><dd><code>Document camera topic auto-detection behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dashboard/src/App.tsx

<ul><li>Add comment explaining CameraView auto-detection of machine-specific <br>topic prefixes<br> <li> Document glob prefix matching behavior for ros-z topics</ul>


</details>


  </td>
  <td><a href="https://github.com/kornia/bubbaloop/pull/30/files#diff-a55633d330003a77c3c0d08667db3da7cee2f90404fc82e51c45029ee6855db5">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

