### PR TITLE
feat: contract enforcement with self-describing nodes

### DIFF
--- a/.claude/skills/doctor.md
+++ b/.claude/skills/doctor.md
@@ -1,0 +1,282 @@
+# Doctor — System Health Check
+
+Comprehensive health check and troubleshooter for the bubbaloop system. Verifies the full pipeline: services → ports → bridge → proxy → zenoh routing → schemas → decode. Use this BEFORE debugging individual issues.
+
+## Usage
+```
+/doctor              # Full system health check
+/doctor --fix        # Auto-fix common issues (restart services, regenerate configs)
+/doctor --services   # Check services only
+```
+
+## Checks
+
+### Step 1: Service Health
+Check all required services are running:
+```bash
+systemctl --user list-units 'bubbaloop-*' --no-pager --plain
+```
+
+Required services:
+- `bubbaloop-zenohd` — Zenoh router (port 7447)
+- `bubbaloop-bridge` — WebSocket bridge (port 10001)
+- `bubbaloop-daemon` — Daemon (Zenoh API)
+- Node services — at least one node should be running
+
+If `--fix`: restart any failed services with `systemctl --user restart <service>`.
+
+### Step 2: Port Connectivity
+Verify all ports are listening:
+```bash
+ss -tlnp | grep -E '(7447|10001|5173)'
+```
+
+Required:
+- `7447` — zenohd (localhost only)
+- `10001` — zenoh-bridge-remote-api (WebSocket)
+- `5173` — Vite dashboard (or production server)
+
+### Step 3: Duplicate Process Detection
+Check for duplicate bridge or router processes (common after manual restarts):
+```bash
+echo "Bridge processes: $(pgrep -c -f 'zenoh-bridge-remote' 2>/dev/null || echo 0) (expected: 1)"
+echo "Zenohd processes: $(pgrep -c zenohd 2>/dev/null || echo 0) (expected: 1)"
+```
+
+If duplicates exist:
+- If `--fix`: Kill stale processes and restart services
+- Duplicates can cause port conflicts and connection instability
+
+### Step 4: Service File Consistency
+Check that all node service files have required env vars:
+```bash
+for f in ~/.config/systemd/user/bubbaloop-*.service; do
+  name=$(basename "$f" .service)
+  has_machine_id=$(grep -c 'BUBBALOOP_MACHINE_ID' "$f" 2>/dev/null || echo 0)
+  has_scope=$(grep -c 'BUBBALOOP_SCOPE' "$f" 2>/dev/null || echo 0)
+  echo "$name: MACHINE_ID=$has_machine_id SCOPE=$has_scope"
+done
+```
+
+Node services MUST have `BUBBALOOP_MACHINE_ID` and `BUBBALOOP_SCOPE`. If missing:
+- If `--fix`: add them (get machine_id from `hostname | tr '-' '_'`, scope defaults to `local`)
+- Otherwise: warn and show the fix command
+
+### Step 5: Zenoh Router TCP Connections
+Verify all components are connected to the router:
+```bash
+ss -tnp | grep 7447 | awk '{print $5, $6}' | sort
+```
+
+Expected connections (each node has 1-2 TCP connections to :7447):
+- `zenoh-bridge-re` — bridge to router
+- `system_telemetr` — system-telemetry node
+- `rtsp_camera_nod` — camera node
+- `openmeteo_node` — weather node
+- `python` — network-monitor (Python node)
+- `bubbaloop` — daemon
+
+If a node is "active running" but has no TCP connection to :7447, the node may be stuck.
+
+### Step 6: WebSocket Connectivity Chain
+Test the FULL WebSocket path (bridge → Vite proxy):
+```bash
+# Direct to bridge
+python3 -c "
+import websocket, ssl, time
+ws = websocket.WebSocket()
+try:
+    ws.connect('ws://127.0.0.1:10001', timeout=3)
+    print('Direct bridge: OK')
+    ws.close()
+except Exception as e:
+    print(f'Direct bridge: FAIL - {e}')
+
+# Through Vite HTTPS proxy
+ws2 = websocket.WebSocket(sslopt={'cert_reqs': ssl.CERT_NONE})
+try:
+    ws2.connect('wss://localhost:5173/zenoh', timeout=5)
+    time.sleep(1)
+    if ws2.connected:
+        print('Vite WSS proxy: OK (stable 1s)')
+    else:
+        print('Vite WSS proxy: FAIL (dropped)')
+    ws2.close()
+except Exception as e:
+    print(f'Vite WSS proxy: FAIL - {e}')
+"
+```
+
+Common failures:
+- **Direct fails**: Bridge not running or port conflict from duplicate process
+- **Proxy fails, direct OK**: Vite dev server not running or proxy config broken
+- **Both OK but dashboard disconnects**: Check zenoh-ts vs bridge version match
+
+### Step 7: Version Compatibility
+Check zenoh-ts and bridge versions match:
+```bash
+echo "Bridge: $(/home/nvidia/.bubbaloop/bin/zenoh-bridge-remote-api --version 2>&1 | grep -oP 'v[\d.]+')"
+echo "zenoh-ts: $(cat /home/nvidia/bubbaloop/dashboard/node_modules/@eclipse-zenoh/zenoh-ts/package.json | grep '"version"' | grep -oP '[\d.]+')"
+```
+
+Versions MUST match (both v1.7.x). Mismatched versions cause protocol errors and immediate disconnects.
+
+### Step 8: Topic Publishing
+Verify nodes are actually publishing data:
+```bash
+for svc in $(systemctl --user list-units 'bubbaloop-*' --no-pager --plain | grep 'active running' | awk '{print $1}' | grep -v 'zenohd\|bridge\|daemon\|dashboard'); do
+  echo "=== $svc ==="
+  systemctl --user status "$svc" --no-pager | tail -5
+done
+```
+
+Look for:
+- system-telemetry: "Publishing metrics" at regular intervals
+- openmeteo: "Current weather" messages with temperature
+- rtsp-camera: "Compressed task started" and frame activity
+- network-monitor: data publishing
+
+If logs show ONLY startup messages but no ongoing publishing, the node may be stalled.
+
+### Step 9: ros-z Topic Compatibility
+Check for hyphens in topic names AND machine IDs (ros-z rejects hyphens in path components):
+```bash
+# Check config files for hyphenated topics
+for cfg in ~/.bubbaloop/nodes/*/config.yaml ~/.bubbaloop/nodes/*/*/config.yaml; do
+  [ -f "$cfg" ] || continue
+  if grep -qP 'publish_topic:.*-' "$cfg" 2>/dev/null; then
+    echo "WARNING: $cfg has hyphenated topic (ros-z will reject)"
+  fi
+done
+
+# Check service files for unhyphenated machine IDs
+for f in ~/.config/systemd/user/bubbaloop-*.service; do
+  mid=$(grep 'BUBBALOOP_MACHINE_ID=' "$f" 2>/dev/null | grep -oP '=\K.*')
+  if [ -n "$mid" ] && echo "$mid" | grep -q '-'; then
+    echo "WARNING: $f has hyphenated MACHINE_ID=$mid (ros-z will reject)"
+  fi
+done
+```
+
+If `--fix`: replace hyphens with underscores in topic names and machine IDs.
+
+### Step 10: Schema Key Consistency
+Check that each node's schema queryable key prefix matches its data topic prefix:
+```bash
+for svc in $(systemctl --user list-units 'bubbaloop-*' --no-pager --plain | grep 'active running' | awk '{print $1}' | grep -v 'zenohd\|bridge\|daemon\|dashboard'); do
+  logs=$(systemctl --user status "$svc" --no-pager 2>/dev/null)
+  # Extract data topic and schema key from logs
+  data_topic=$(echo "$logs" | grep -oP "(?:Publishing to|Data topic|pub_build; topic=)\K[^\s]+|(?:topic=)[^\s]+" | head -1)
+  schema_key=$(echo "$logs" | grep -oP "(?:Schema queryable|schema_key): \K[^\s]+" | head -1)
+  if [ -n "$data_topic" ] && [ -n "$schema_key" ]; then
+    # Extract the node-name segment from each
+    data_seg=$(echo "$data_topic" | awk -F/ '{print $4}')
+    schema_seg=$(echo "$schema_key" | awk -F/ '{print $4}')
+    if [ "$data_seg" != "$schema_seg" ]; then
+      echo "MISMATCH in $svc: data='$data_seg' vs schema='$schema_seg'"
+      echo "  Data topic:  $data_topic"
+      echo "  Schema key:  $schema_key"
+    fi
+  fi
+done
+```
+
+Data topics use underscores (ros-z requirement) but schema queryables might use hyphens.
+This mismatch prevents `discoverSchemaForTopic()` from mapping topics to schemas.
+If `--fix`: update node code to use consistent naming (prefer underscores for both).
+
+### Step 11: Schema Queryable Verification
+Check that nodes serve schema queryables. For Rust nodes:
+```bash
+for node_dir in ~/.bubbaloop/nodes/*/; do
+  [ -d "$node_dir/src" ] || continue
+  name=$(basename "$node_dir")
+  has_descriptor=$(grep -rl 'DESCRIPTOR' "$node_dir/src/" 2>/dev/null | head -1)
+  has_queryable=$(grep -rl 'schema.*queryable\|declare_queryable.*schema' "$node_dir/src/" 2>/dev/null | head -1)
+  echo "$name: DESCRIPTOR=${has_descriptor:+YES} QUERYABLE=${has_queryable:+YES}"
+done
+# For Python nodes:
+for node_dir in ~/.bubbaloop/nodes/*/; do
+  [ -f "$node_dir/main.py" ] || continue
+  name=$(basename "$node_dir")
+  has_descriptor=$(grep -l 'descriptor\|DESCRIPTOR\|descriptor.bin' "$node_dir/"*.py 2>/dev/null | head -1)
+  has_queryable=$(grep -l 'declare_queryable\|schema' "$node_dir/"*.py 2>/dev/null | head -1)
+  echo "$name (Python): DESCRIPTOR=${has_descriptor:+YES} QUERYABLE=${has_queryable:+YES}"
+done
+```
+
+Nodes without schema queryable won't have their protobuf messages decoded in the dashboard.
+
+### Step 12: Camera RTSP Source
+If camera node is running, verify RTSP source connectivity:
+```bash
+for cfg in ~/.bubbaloop/nodes/*/configs/*.yaml ~/.bubbaloop/nodes/*/*/configs/*.yaml; do
+  [ -f "$cfg" ] || continue
+  url=$(grep -oP 'url:\s*"\K[^"]+' "$cfg" 2>/dev/null)
+  if [ -n "$url" ]; then
+    host=$(echo "$url" | grep -oP '(?<=@)[^:]+|(?<=//)[^:@]+')
+    if [ -n "$host" ]; then
+      echo -n "Camera $(basename $cfg .yaml) → $host: "
+      timeout 3 ping -c 1 -W 2 "$host" 2>/dev/null | grep -oP '[\d.]+ms' || echo "UNREACHABLE"
+    fi
+  fi
+done
+```
+
+High latency (>500ms) or unreachable source means no camera frames will be published.
+
+### Step 13: Journal Storage
+Check if journald is storing logs (needed for debugging):
+```bash
+journalctl --user --disk-usage 2>&1
+```
+
+If "No journal files were found":
+- Logs exist only in volatile memory (systemctl status can still show recent lines)
+- For persistent logs: `sudo mkdir -p /var/log/journal && sudo systemd-tmpfiles --create --prefix /var/log/journal`
+- Then restart journald: `sudo systemctl restart systemd-journald`
+
+### Step 14: Dashboard HTTPS
+Verify the dashboard is accessible:
+```bash
+curl -sk -o /dev/null -w "HTTP %{http_code}" https://localhost:5173/ && echo " OK" || echo " FAIL"
+```
+
+If empty or error: restart Vite dev server:
+```bash
+cd /home/nvidia/bubbaloop/dashboard && npx vite --host &
+```
+
+### Step 15: Summary Report
+Output a table:
+
+| Component | Status | Details |
+|-----------|--------|---------|
+| zenohd | OK/FAIL | port 7447 |
+| bridge | OK/FAIL | port 10001, no duplicates |
+| daemon | OK/FAIL | |
+| dashboard | OK/FAIL | port 5173, HTTPS |
+| WS direct | OK/FAIL | ws://127.0.0.1:10001 |
+| WS proxy | OK/FAIL | wss://localhost:5173/zenoh |
+| version match | OK/FAIL | bridge vs zenoh-ts |
+| router connections | N clients | list node names |
+| nodes | N running | list names |
+| service files | OK/WARN | missing env vars |
+| topic names | OK/WARN | hyphen issues |
+| schema keys | OK/WARN | data vs schema mismatch |
+| schema queryables | N/M nodes | which missing |
+| camera source | OK/WARN | latency or unreachable |
+| journal storage | OK/WARN | persistent or volatile |
+
+### Common Fixes (--fix mode)
+1. **Service not running**: `systemctl --user restart <service>`
+2. **Duplicate processes**: Kill stale PIDs, restart services
+3. **Missing MACHINE_ID**: Add `Environment=BUBBALOOP_MACHINE_ID=$(hostname | tr '-' '_')` to service file
+4. **Missing SCOPE**: Add `Environment=BUBBALOOP_SCOPE=local` to service file
+5. **Hyphenated topics/machine IDs**: Edit config.yaml and service files to use underscores
+6. **Schema key mismatch**: Update node code to use consistent underscore naming for both data topics and schema keys
+7. **Bridge disconnecting**: Kill duplicates, restart bridge, check version match
+8. **Dashboard empty**: Refresh browser after bridge/Vite restart
+9. **Schema not decoded**: Node needs DESCRIPTOR constant + schema queryable (see ARCHITECTURE.md)
+10. **No journal storage**: Create `/var/log/journal/` and restart journald
+11. **Camera no frames**: Check RTSP source connectivity, verify URL in config.yaml

--- a/.claude/skills/gemini-review.md
+++ b/.claude/skills/gemini-review.md
@@ -1,0 +1,112 @@
+# Gemini Review — Second AI Opinion
+
+Get a second opinion from Gemini CLI on code changes, architecture decisions, or debugging hypotheses.
+
+## Usage
+```
+/gemini-review                    # Review all uncommitted changes
+/gemini-review --staged           # Review only staged changes
+/gemini-review --file <path>      # Review a specific file
+/gemini-review --question "<q>"   # Ask Gemini a specific question about the codebase
+/gemini-review --diff <base>      # Review diff against a branch (e.g., main)
+```
+
+## How It Works
+
+Uses the Gemini CLI (`gemini -p`) in non-interactive headless mode. Pipes context (diffs, files, questions) via stdin and captures the response.
+
+**Important**: Always use `NODE_OPTIONS="--max-old-space-size=4096"` on Jetson to avoid OOM.
+
+## Steps
+
+### Step 1: Gather Context
+
+Based on the mode:
+
+**Default (uncommitted changes)**:
+```bash
+git diff HEAD -- ':!*.lock' ':!package-lock.json' ':!dist/' ':!target/' > /tmp/gemini-review-diff.txt
+echo "Files changed: $(git diff HEAD --name-only | wc -l)"
+```
+
+**--staged**:
+```bash
+git diff --cached -- ':!*.lock' ':!package-lock.json' > /tmp/gemini-review-diff.txt
+```
+
+**--file <path>**:
+```bash
+cat <path> > /tmp/gemini-review-context.txt
+```
+
+**--diff <base>**:
+```bash
+git diff <base>...HEAD -- ':!*.lock' ':!package-lock.json' ':!dist/' ':!target/' > /tmp/gemini-review-diff.txt
+```
+
+### Step 2: Build the Prompt
+
+Construct a focused review prompt based on the mode. For diffs:
+
+```
+Review this code diff for a Rust + TypeScript robotics project (bubbaloop).
+Focus on:
+1. Correctness bugs (logic errors, off-by-one, race conditions)
+2. API misuse (wrong function signatures, missing error handling)
+3. Security issues (injection, unsafe patterns)
+4. Zenoh/ros-z specific issues (topic naming, session lifecycle)
+
+For each finding, categorize as:
+- CRITICAL: Must fix before merge
+- WARNING: Should fix but not blocking
+- INFO: Style/improvement suggestion
+
+Be concise. Skip obvious things. Only flag real issues.
+```
+
+For questions, pass the question directly with relevant file context.
+
+### Step 3: Call Gemini CLI
+
+```bash
+NODE_OPTIONS="--max-old-space-size=4096" cat /tmp/gemini-review-diff.txt | gemini -p "<prompt>" --sandbox false 2>/dev/null
+```
+
+If the diff is too large (>50KB), split into chunks by file and review each separately:
+```bash
+for file in $(git diff HEAD --name-only); do
+  echo "=== Reviewing: $file ==="
+  git diff HEAD -- "$file" | NODE_OPTIONS="--max-old-space-size=4096" gemini -p "Review this diff for $file. Flag only real bugs, categorize as CRITICAL/WARNING/INFO." --sandbox false 2>/dev/null
+done
+```
+
+### Step 4: Parse and Present Results
+
+Present Gemini's findings in a structured table:
+
+| # | Severity | File | Finding | Action |
+|---|----------|------|---------|--------|
+| 1 | CRITICAL | foo.rs | Race condition in... | FIX |
+| 2 | WARNING | bar.ts | Missing null check... | FIX |
+| 3 | INFO | baz.rs | Could simplify... | DEFER |
+
+### Step 5: Act on Findings
+
+- **CRITICAL**: Fix immediately, delegate to executor agent
+- **WARNING**: Fix if quick (<5 min), otherwise note for follow-up
+- **INFO**: Skip unless user specifically requests
+- **FALSE POSITIVE**: Ignore — Gemini sometimes flags correct patterns as issues
+
+### Tips
+
+- Gemini is good at spotting API misuse and logic errors but sometimes hallucinates Rust borrow checker issues
+- For Zenoh-specific questions, provide the zenoh version context (v1.7.x)
+- For architecture decisions, include relevant sections from ARCHITECTURE.md as context
+- If Gemini CLI hangs (>60s), kill it and retry — it occasionally gets stuck on large inputs
+- The `--sandbox false` flag is needed to allow file reads if Gemini needs additional context
+
+### Constraints (Jetson ARM64)
+
+- Always use `NODE_OPTIONS="--max-old-space-size=4096"` to prevent OOM
+- Do NOT run Gemini in parallel with cargo builds — too much memory pressure
+- Timeout after 120 seconds per review chunk

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,7 @@ pixi run build     # cargo build --release (slow on ARM64)
 
 ## Zenoh API Rules (templates & nodes)
 
+- **ALL nodes MUST use `mode: "client"`** — peer mode doesn't route through zenohd router
 - **NEVER** use `.complete(true)` on queryables — blocks wildcard queries like `bubbaloop/**/schema`
 - **Python**: `query.key_expr` is a **property** NOT a method — NEVER use `query.key_expr()`
 - **Python**: `query.reply(query.key_expr, payload_bytes)` — correct reply pattern
@@ -94,5 +95,5 @@ Exception: views with their own fallback decode chain (like JsonView) don't need
 - Proto changes require rebuilding both `bubbaloop-schemas/` and `bubbaloop` (descriptor.bin is compiled in)
 - Dashboard deps (`axum`, `rust-embed`) are behind `dashboard` feature flag
 - Logs must go to stderr to avoid corrupting TUI
-- Zenoh session: `"peer"` mode, check `BUBBALOOP_ZENOH_ENDPOINT` env var
+- Zenoh session: MUST use `"client"` mode for router routing; check `BUBBALOOP_ZENOH_ENDPOINT` env var
 - Dashboard schema race: subscriptions start before schemas load — always use `useSchemaReady()` gating

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,16 @@ Conventional: `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `test:`
 Never commit: `target/`, `node_modules/`, `dist/`, `.pixi/`
 Always commit: `Cargo.lock`, `pixi.lock`, `package-lock.json`
 
+## Dashboard View Components
+
+New view components that decode protobuf MUST gate their subscription callback on schema readiness:
+```ts
+const schemaReady = useSchemaReady();  // from hooks/useSchemaReady
+useZenohSubscription(topic, schemaReady ? handleSample : undefined);
+```
+This prevents the race where Zenoh delivers messages before `fetchSchemas()` completes.
+Exception: views with their own fallback decode chain (like JsonView) don't need gating.
+
 ## Pitfalls
 
 - OAuth token lacks `workflow` scope — use SSH for workflow files
@@ -85,3 +95,4 @@ Always commit: `Cargo.lock`, `pixi.lock`, `package-lock.json`
 - Dashboard deps (`axum`, `rust-embed`) are behind `dashboard` feature flag
 - Logs must go to stderr to avoid corrupting TUI
 - Zenoh session: `"peer"` mode, check `BUBBALOOP_ZENOH_ENDPOINT` env var
+- Dashboard schema race: subscriptions start before schemas load — always use `useSchemaReady()` gating

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,10 +41,12 @@ Before adding any new process/skill/automation, ask:
 1. Define component + test strategy
 2. Write tests FIRST (vitest + jsdom) — test behavior, not implementation
 3. Designer agent builds UI (React + TypeScript + Tailwind)
-4. All 210+ tests must pass (NO test deletion)
+4. All 490+ tests must pass (NO test deletion)
 5. Live verification (data flows to browser)
 
 **Test-first is non-negotiable**. Dashboard test count only goes up.
+
+**Schema-ready gating**: New view components that decode protobuf MUST use `useSchemaReady()` to gate their `useZenohSubscription` callback. Pass `schemaReady ? handleSample : undefined` to avoid dropping messages during schema loading. See `CameraView.tsx` for reference pattern.
 
 ### 3. CLI Command: Check argh conventions → write + test → `cargo test` → `/qa-tester` (tmux) → `clippy`
 
@@ -120,7 +122,7 @@ Run these at the right time to avoid wasted cycles:
 |---------|------|-----|
 | `pixi run check` | After every Rust change | Fast compilation check |
 | `cargo test --lib -p bubbaloop` | Before commits | 240+ Rust tests must pass |
-| `cd dashboard && npm test` | After dashboard changes | 210+ tests, no deletions allowed |
+| `cd dashboard && npm test -- --run` | After dashboard changes | 490+ tests, no deletions allowed |
 | `pixi run clippy` | Before PRs | Zero warnings enforced (`-D warnings`) |
 | `./scripts/validate.sh` | Before final commit | Full system check (10 phases) |
 | `./scripts/validate.sh --gemini` | Before PR submission | AI cross-review |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
+name = "advisory-lock"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6caee7d48f930f9ad3fc9546f8cbf843365da0c5b0ca4eee1d1ac3dd12d8f93"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -418,6 +428,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "buddy_system_allocator"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7913f22349ffcfc6ca0ca9a656ec26cfbba538ed49c31a273dff2c5d1ea83d9"
+dependencies = [
+ "spin 0.9.8",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -463,30 +482,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cdr"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9617422bf43fde9280707a7e90f8f7494389c182f5c70b0f67592d0f06d41dfa"
-dependencies = [
- "byteorder",
- "serde",
-]
-
-[[package]]
-name = "cdr-encoding"
-version = "0.10.2"
-source = "git+https://github.com/YuanYuYuan/cdr-encoding?branch=feat%2Fbyte-buf#ef25d97d6a02e327bc9ec66755701d5db71392b1"
-dependencies = [
- "byteorder",
- "log",
- "paste",
- "serde",
- "serde_repr",
- "static_assertions",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "cesu8"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -497,6 +492,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "cfg_aliases"
@@ -1061,6 +1062,12 @@ checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
 ]
+
+[[package]]
+name = "dtoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
 
 [[package]]
 name = "dyn-clone"
@@ -2277,7 +2284,7 @@ checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
  "bitflags 2.10.0",
  "cfg-if",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "libc",
  "memoffset",
 ]
@@ -2290,7 +2297,7 @@ checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
  "bitflags 2.10.0",
  "cfg-if",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "libc",
 ]
 
@@ -2860,6 +2867,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus-client"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4500adecd7af8e0e9f4dbce15cfee07ce913fbf6ad605cc468b83f2d531ee94"
+dependencies = [
+ "dtoa",
+ "itoa",
+ "parking_lot",
+ "prometheus-client-derive-encode",
+]
+
+[[package]]
+name = "prometheus-client-derive-encode"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9adf1691c04c0a5ff46ff8f262b58beb07b0dbb61f96f9f54f6cbd82106ed87f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "prost"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2928,7 +2958,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
 dependencies = [
  "bytes",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
@@ -2970,7 +3000,7 @@ version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
 dependencies = [
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
  "socket2 0.6.1",
@@ -3262,20 +3292,22 @@ dependencies = [
 [[package]]
 name = "ros-z"
 version = "0.1.0"
-source = "git+https://github.com/ZettaScaleLabs/ros-z.git?branch=main#a312c63e581581743d001bc3c93735b95097e043"
+source = "git+https://github.com/ZettaScaleLabs/ros-z.git?branch=main#a39b145bd77ec3c44268c40a762fe189f9b33e39"
 dependencies = [
  "byteorder",
- "cdr",
- "cdr-encoding",
  "clap",
  "csv",
  "dashmap",
+ "event-listener",
  "flume",
  "json5",
  "parking_lot",
  "paste",
  "prost",
  "prost-build",
+ "ros-z-cdr",
+ "ros-z-protocol",
+ "ros-z-schema",
  "serde",
  "serde_json",
  "sha2",
@@ -3286,7 +3318,38 @@ dependencies = [
  "tracing",
  "uuid",
  "zenoh",
+ "zenoh-buffers",
  "zenoh-ext",
+]
+
+[[package]]
+name = "ros-z-cdr"
+version = "0.1.0"
+source = "git+https://github.com/ZettaScaleLabs/ros-z.git?branch=main#a39b145bd77ec3c44268c40a762fe189f9b33e39"
+dependencies = [
+ "byteorder",
+ "serde",
+ "thiserror 1.0.69",
+ "zenoh-buffers",
+]
+
+[[package]]
+name = "ros-z-protocol"
+version = "0.1.0"
+source = "git+https://github.com/ZettaScaleLabs/ros-z.git?branch=main#a39b145bd77ec3c44268c40a762fe189f9b33e39"
+dependencies = [
+ "zenoh",
+]
+
+[[package]]
+name = "ros-z-schema"
+version = "0.1.0"
+source = "git+https://github.com/ZettaScaleLabs/ros-z.git?branch=main#a39b145bd77ec3c44268c40a762fe189f9b33e39"
+dependencies = [
+ "hex",
+ "serde",
+ "serde_json",
+ "sha2",
 ]
 
 [[package]]
@@ -3966,6 +4029,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "static_init"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bae1df58c5fea7502e8e352ec26b5579f6178e1fdb311e088580c980dee25ed"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg_aliases 0.2.1",
+ "libc",
+ "parking_lot",
+ "parking_lot_core",
+ "static_init_macro",
+ "winapi",
+]
+
+[[package]]
+name = "static_init_macro"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1389c88ddd739ec6d3f8f83343764a0e944cd23cfbf126a9796a714b0b6edd6f"
+dependencies = [
+ "cfg_aliases 0.1.1",
+ "memchr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4036,6 +4127,12 @@ dependencies = [
  "quote",
  "syn 2.0.111",
 ]
+
+[[package]]
+name = "talc"
+version = "4.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3ae828aa394de34c7de08f522d1b86bd1c182c668d27da69caadda00590f26d"
 
 [[package]]
 name = "tempfile"
@@ -4151,6 +4248,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.111",
+]
+
+[[package]]
+name = "thread-priority"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe075d7053dae61ac5413a34ea7d4913b6e6207844fd726bdd858b37ff72bf5"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "winapi",
 ]
 
 [[package]]
@@ -4946,6 +5057,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "win-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b7b128a98c1cfa201b09eb49ba285887deb3cbe7466a98850eb1adabb452be5"
+dependencies = [
+ "windows",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4975,6 +5095,19 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45296b64204227616fdbf2614cefa4c236b98ee64dfaaaa435207ed99fe7829f"
+dependencies = [
+ "windows_aarch64_msvc 0.34.0",
+ "windows_i686_gnu 0.34.0",
+ "windows_i686_msvc 0.34.0",
+ "windows_x86_64_gnu 0.34.0",
+ "windows_x86_64_msvc 0.34.0",
+]
 
 [[package]]
 name = "windows-core"
@@ -5139,6 +5272,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17cffbe740121affb56fad0fc0e421804adf0ae00891205213b5cecd30db881d"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
@@ -5154,6 +5293,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2564fde759adb79129d9b4f54be42b32c89970c18ebf93124ca8870a498688ed"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5187,6 +5332,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cd9d32ba70453522332c14d38814bceeb747d80b3958676007acadd7e166956"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
@@ -5202,6 +5353,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfce6deae227ee8d356d19effc141a509cc503dfd1f850622ec4b0f84428e1f4"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5238,6 +5395,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d19538ccc21819d01deaf88d6a17eae6596a12e9aafdbb97916fb49896d89de9"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -5389,9 +5552,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e2df46d36ba8d173f18e9cce5011117fed81a90a22bc3cfe8bbcfaf66b54114"
+checksum = "0f9ff8cb89f5267b8486a69466bc42f240f1ee2d5089e72395a23094e7b74f21"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -5433,6 +5596,7 @@ dependencies = [
  "zenoh-protocol",
  "zenoh-result",
  "zenoh-runtime",
+ "zenoh-shm",
  "zenoh-sync",
  "zenoh-task",
  "zenoh-transport",
@@ -5441,39 +5605,40 @@ dependencies = [
 
 [[package]]
 name = "zenoh-buffers"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82d610eaa2099c16844b092c2b16605d115f354e332eb1d37e9af46e5430ecac"
+checksum = "bd9216c3d6c84b56f3e3be634e52365022038e1ac1b9f662f10d425cbf6c0fa8"
 dependencies = [
  "zenoh-collections",
 ]
 
 [[package]]
 name = "zenoh-codec"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f1cff28c30bca3d07e7b84f71f1c9b81d505449f6fec36a023cc8b601c01150"
+checksum = "14bc6747664aa9ecf17becd6e9a29282e535a350cd7c6bd8de7bf2dc662fb93d"
 dependencies = [
  "tracing",
  "uhlc",
  "zenoh-buffers",
  "zenoh-protocol",
+ "zenoh-shm",
 ]
 
 [[package]]
 name = "zenoh-collections"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a72cac7d4bbe99e41ef46c175e0dd2933e883b17cef3e60151e4461b5a088ad3"
+checksum = "0d642ecfe0d85f0cd846be9bc92805d926c092a6e6c7a575b6346752f8c3ae16"
 dependencies = [
  "ahash",
 ]
 
 [[package]]
 name = "zenoh-config"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df65e4ab337079d897aaaa6d01474b4f8683daaa05a8671b18db34e71a872af7"
+checksum = "39765a5f9975aba204c99f2f65308db4952dbea8e5ac79c78ac1eaf5711e970a"
 dependencies = [
  "json5",
  "nonempty-collections",
@@ -5496,9 +5661,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-core"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "869deb22305e8f7a6aa324142ab6717f0cc979be8e4a2de646e8f31313224a1c"
+checksum = "85c0c1388dccf287aec4e9d5e638630dc9d536db9f1da3522889b42697723b9b"
 dependencies = [
  "lazy_static",
  "tokio",
@@ -5508,9 +5673,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-crypto"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f5b09559108c9e11128730d5a6f551dbcc226adfd82423439ad7eeed024c736"
+checksum = "b433e08df3b03f2af2d23bd29a32aa5f5522c52e66d63e3d135bfa66373736dd"
 dependencies = [
  "aes",
  "hmac",
@@ -5522,9 +5687,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-ext"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e717f9553e299e6645b4d76d3dcceed188cd860365f10356a65a3f2a704b46fb"
+checksum = "0fddc96d0b206af968465ca8497cd2f8bab9639bb028391f354b057fc9a1d6b0"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5542,9 +5707,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-keyexpr"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8b754ea6460c4c3c5dd67e6a8c62bfc076c16f8b794898fb3ea6f0039a5939e"
+checksum = "19a3c47c89cb55ea45a1b3fe7d1fe8682ea93530b1fc5245257812db14b55b3d"
 dependencies = [
  "getrandom 0.2.16",
  "hashbrown 0.16.1",
@@ -5558,9 +5723,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d0c04d554b67600967cb520061ef9f635caf7704978357334e66cd7179a204a"
+checksum = "6218cecab58435f31fb8b2e185f74f35af8aedd96e8bdd3557b333206b1acfda"
 dependencies = [
  "zenoh-config",
  "zenoh-link-commons",
@@ -5578,9 +5743,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-commons"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1c652a706da1da46eae54a65c4b658153cdebfa213f061beea3bef71088f2"
+checksum = "b98adc618f7edb570b9333ce583934a7c63e3a619cb49666515bfc06a000d7b6"
 dependencies = [
  "async-trait",
  "base64",
@@ -5612,9 +5777,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-quic"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0069d889388d06e56eb86139021a1af12b9846222847aeabaa05eb92fc2ee108"
+checksum = "2d0c25d681db958b7714370d5e1d72a523129633d9262b098e18d44824d39893"
 dependencies = [
  "async-trait",
  "base64",
@@ -5638,9 +5803,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-quic_datagram"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc81e512b51cf9b6ab479ba11be70e7a4ce072c0e985271e09c88e4bbff591b3"
+checksum = "30cfb427adbc8d367505b9a62a6614c9d7802e420f03466d98644bb7bf24516f"
 dependencies = [
  "async-trait",
  "quinn",
@@ -5659,9 +5824,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-serial"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0178ad0007ed1869c2ebc9ef8e773e5b41a7771d362c32108f4982d4aff217b9"
+checksum = "8ee91f2e7f7ea44e10e3cdffcda728fcbfcd1d1f9111420164dbfab4c3872c28"
 dependencies = [
  "async-trait",
  "tokio",
@@ -5678,9 +5843,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-tcp"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "279ff42ab4a65508069596045ab8a3c6fb03f94343c290a9b75f9568c49094e4"
+checksum = "c0f23bd5d06a0014ce5a205961d6d47c8e8d792d9fd050ae9d0c9b609a187995"
 dependencies = [
  "async-trait",
  "socket2 0.5.10",
@@ -5696,9 +5861,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-tls"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3172615126b64456beb0c537351eb9c715f20f641e37ae8f84cb209816d205a"
+checksum = "17544cde682dbcd2a712114786feee14295c28a9f66fc1021637355511e32fa9"
 dependencies = [
  "async-trait",
  "base64",
@@ -5726,9 +5891,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-udp"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11006545a887167d431e8c3f2867ad386e7d678ee8babd3df4a7537b168e47de"
+checksum = "587ca1de1caa0b444106d31c26801f4e87b354293d2d37afd8f70d9e793fe35e"
 dependencies = [
  "async-trait",
  "libc",
@@ -5748,9 +5913,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-unixsock_stream"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab57f1a899f869dea28168d6ab46a820b0d94e025e1db8cf8e686fc08b4f5de3"
+checksum = "ac46470a17af5861e07ed9d2440277e7a3dea55109b0988866b635f7daf29ac4"
 dependencies = [
  "async-trait",
  "nix 0.29.0",
@@ -5767,9 +5932,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-ws"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41c398aaee46ce19ca01c709ea38985da7da6b4ffb803c6b5c07a56e8a31f8b4"
+checksum = "e4be09c3e32d510cdddf3289bc333d53471883198fca51d58248458a20df3d51"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -5788,9 +5953,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-macros"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21df1681ca014a4bd69db91d356bcf699d346f854ff8a6b73123cee75f5073cd"
+checksum = "b760a458cd906ac888b37fd1abdb21a0f58ecc64cc3882f83a976cb5ca8e0632"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5800,9 +5965,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-plugin-trait"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4651bc51951eb004e71bba71583f9ea60240bdd11351b61dbd6956e906088567"
+checksum = "7325b773c43a86a94f800cb971ab7e4b7e01ce76819c9c100ea783a47c3a25e4"
 dependencies = [
  "git-version",
  "libloading",
@@ -5818,9 +5983,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-protocol"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab17d39b24f6fbd0a24e03a5ab96c236d3d5ebb5071978338c9bc3fe1ccff626"
+checksum = "9b4d3dad7aeeea780495692b195cd56515569c32b76b9dd077cc408c3ebca03f"
 dependencies = [
  "const_format",
  "rand 0.8.5",
@@ -5833,18 +5998,18 @@ dependencies = [
 
 [[package]]
 name = "zenoh-result"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b7d23a2f69c4b96ae95ac2f80808cce5f2ed9697ba37e769a75428fb6806a57"
+checksum = "0b4dbfea68b947a790d5525bcf061e91e2fdc2798bce619851919b353a8580fa"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "zenoh-runtime"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a71f356bb63c1c9d37cb4bc89112e83a9fd6079458d1440232d67ca41a52c687"
+checksum = "760a1f7880f98427ad849d600257d1455a18afe981681f362684a3f91042537e"
 dependencies = [
  "lazy_static",
  "ron",
@@ -5856,10 +6021,54 @@ dependencies = [
 ]
 
 [[package]]
-name = "zenoh-sync"
-version = "1.7.1"
+name = "zenoh-shm"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b1113111e247d6b1ebd5d406b43e23e78faca2c7525dca22a2a075c64787bd"
+checksum = "42184ae820d64d40814c0dd3b48f748c55a3ff5591c524f1bde36f21ccfda488"
+dependencies = [
+ "advisory-lock",
+ "async-trait",
+ "buddy_system_allocator",
+ "cfg_aliases 0.2.1",
+ "crossbeam-channel",
+ "crossbeam-queue",
+ "nix 0.29.0",
+ "num-traits",
+ "rand 0.8.5",
+ "stabby",
+ "static_assertions",
+ "static_init",
+ "talc",
+ "thread-priority",
+ "tokio",
+ "tracing",
+ "win-sys",
+ "winapi",
+ "zenoh-buffers",
+ "zenoh-core",
+ "zenoh-macros",
+ "zenoh-result",
+]
+
+[[package]]
+name = "zenoh-stats"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8954c79580ed3365580d86f40657f2cd6bf4b4c72dd463de936368df8c709c65"
+dependencies = [
+ "ahash",
+ "prometheus-client",
+ "serde_json",
+ "smallvec",
+ "zenoh-keyexpr",
+ "zenoh-protocol",
+]
+
+[[package]]
+name = "zenoh-sync"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98f132137bb003f10b7fff086cb18addf8e8273b9c0d2722a53b5074c8a79965"
 dependencies = [
  "arc-swap",
  "event-listener",
@@ -5872,9 +6081,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-task"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a1f690f81704b1e934b9fb7a63ce544af73521ca9d11b5a439cdfc74108dd28"
+checksum = "1b17d10136fdabec7e21a3fcef568c210ee6a2d71cde6adcde99e9236584f3a1"
 dependencies = [
  "futures",
  "tokio",
@@ -5886,9 +6095,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-transport"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cdc4dcb4a68161afe25e44871a66a5c3c347d86a77628ab101d859a9518db9"
+checksum = "50739b4c45e0963df8377abddb74701a4b708b178590eae92f27a604e25daf44"
 dependencies = [
  "async-trait",
  "crossbeam-utils",
@@ -5913,6 +6122,8 @@ dependencies = [
  "zenoh-protocol",
  "zenoh-result",
  "zenoh-runtime",
+ "zenoh-shm",
+ "zenoh-stats",
  "zenoh-sync",
  "zenoh-task",
  "zenoh-util",
@@ -5920,9 +6131,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-util"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea9b52e8beceffc0deca01e10ca726c604286a1ac475f95acdd87ee55f18b120"
+checksum = "9512987c13925d32d3331507c8807853d5b682ea8da94d0ba6534c7a8ace48aa"
 dependencies = [
  "async-trait",
  "const_format",

--- a/configs/zenoh/acl-example.json5
+++ b/configs/zenoh/acl-example.json5
@@ -1,0 +1,63 @@
+// Zenoh ACL configuration example for bubbaloop
+//
+// This file demonstrates access control rules for node isolation.
+// Each node only gets publish access to its own key prefix.
+// The dashboard gets read-only access to all bubbaloop/** keys.
+//
+// Generate per-deployment configs with: bubbaloop doctor -c security
+//
+// See: https://zenoh.io/docs/manual/access-control/
+{
+  access_control: {
+    enabled: true,
+    default_permission: "deny",
+    rules: [
+      {
+        // Daemon can publish/subscribe to all bubbaloop/** keys
+        id: "daemon-full-access",
+        permission: "allow",
+        messages: ["put", "get", "declare_subscriber", "declare_queryable"],
+        flows: ["egress", "ingress"],
+        key_exprs: ["bubbaloop/**"],
+      },
+      {
+        // Dashboard gets read-only access to all bubbaloop/** keys
+        id: "dashboard-read-only",
+        permission: "allow",
+        messages: ["get", "declare_subscriber"],
+        flows: ["egress", "ingress"],
+        key_exprs: ["bubbaloop/**"],
+      },
+      // Per-node rules are generated from manifest acl_prefix.
+      // Example for a camera node on machine "jetson_1":
+      //
+      // {
+      //   id: "camera-publish",
+      //   permission: "allow",
+      //   messages: ["put", "declare_queryable"],
+      //   flows: ["egress", "ingress"],
+      //   key_exprs: ["bubbaloop/*/jetson_1/camera/**"],
+      // },
+    ],
+    subjects: [
+      {
+        id: "daemon",
+        cert_common_names: ["bubbaloop-daemon"],
+      },
+      {
+        id: "dashboard",
+        cert_common_names: ["bubbaloop-dashboard"],
+      },
+    ],
+    policies: [
+      {
+        rules: ["daemon-full-access"],
+        subjects: ["daemon"],
+      },
+      {
+        rules: ["dashboard-read-only"],
+        subjects: ["dashboard"],
+      },
+    ],
+  },
+}

--- a/configs/zenoh/tls-example.json5
+++ b/configs/zenoh/tls-example.json5
@@ -1,0 +1,43 @@
+// Zenoh TLS/mTLS configuration example for multi-machine deployments
+//
+// This config enables transport encryption between bubbaloop nodes.
+// mTLS (mutual TLS) ensures both client and server authenticate.
+//
+// Certificate generation:
+//   bubbaloop init-tls    # Prints step-by-step cert generation guide
+//
+// File layout:
+//   ~/.bubbaloop/certs/
+//     ca.pem              # CA certificate (shared across machines)
+//     server-cert.pem     # This machine's server certificate
+//     server-key.pem      # This machine's private key
+//
+// See: https://zenoh.io/docs/manual/tls/
+{
+  mode: "router",
+  listen: {
+    endpoints: ["tls/0.0.0.0:7447"],
+  },
+  transport: {
+    link: {
+      tls: {
+        // Server certificate signed by the CA
+        server_certificate: "/home/user/.bubbaloop/certs/server-cert.pem",
+        // Server private key
+        server_private_key: "/home/user/.bubbaloop/certs/server-key.pem",
+        // CA certificate for verifying clients (mTLS)
+        root_ca_certificate: "/home/user/.bubbaloop/certs/ca.pem",
+        // Require client certificates (mTLS)
+        client_auth: true,
+      },
+    },
+  },
+  scouting: {
+    multicast: {
+      enabled: false,
+    },
+    gossip: {
+      enabled: false,
+    },
+  },
+}

--- a/crates/bubbaloop-schemas/protos/daemon.proto
+++ b/crates/bubbaloop-schemas/protos/daemon.proto
@@ -3,6 +3,9 @@ syntax = "proto3";
 package bubbaloop.daemon.v1;
 
 // Node runtime status
+//
+// CONTRACT: When adding values, update zenoh_api.rs::status_to_string(),
+// NodesView.tsx::STATUS_MAP, and proto/daemon.ts::statusToString().
 enum NodeStatus {
   NODE_STATUS_UNKNOWN = 0;
   NODE_STATUS_STOPPED = 1;

--- a/crates/bubbaloop/src/cli/node.rs
+++ b/crates/bubbaloop/src/cli/node.rs
@@ -35,6 +35,26 @@ pub enum NodeError {
 
 pub type Result<T> = std::result::Result<T, NodeError>;
 
+/// Copy canonical header.proto to a node's protos/ directory if it exists.
+/// This ensures nodes use the correct version of header.proto.
+fn copy_canonical_header_proto(node_path: &Path) {
+    let protos_dir = node_path.join("protos");
+    if !protos_dir.exists() {
+        return;
+    }
+
+    let dest = protos_dir.join("header.proto");
+    if let Err(e) = std::fs::write(&dest, crate::HEADER_PROTO) {
+        log::warn!(
+            "Could not copy canonical header.proto to {}: {}",
+            dest.display(),
+            e
+        );
+    } else {
+        log::info!("Copied canonical header.proto to {}", dest.display());
+    }
+}
+
 /// Node management commands
 #[derive(FromArgs)]
 #[argh(subcommand, name = "node")]
@@ -477,6 +497,9 @@ fn init_node(args: InitArgs) -> Result<()> {
         &output_dir,
     )
     .map_err(|e| NodeError::CommandFailed(e.to_string()))?;
+
+    // Copy canonical header.proto if protos/ directory exists
+    copy_canonical_header_proto(&output_dir);
 
     let abs_path = output_dir.canonicalize().unwrap_or(output_dir.clone());
 
@@ -1632,6 +1655,9 @@ async fn handle_install(args: InstallArgs) -> Result<()> {
     // Resolve subdir
     let node_path = resolve_node_path(&base_path, Some(&entry.subdir))?;
 
+    // Copy canonical header.proto if protos/ directory exists
+    copy_canonical_header_proto(Path::new(&node_path));
+
     // Register with daemon
     let session = get_zenoh_session().await?;
 
@@ -2676,5 +2702,74 @@ mod tests {
         let result = try_download_precompiled(&entry);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("Not a Rust node"));
+    }
+
+    #[test]
+    fn test_copy_canonical_header_proto_creates_file() {
+        use tempfile::tempdir;
+
+        let tmp = tempdir().unwrap();
+        let node_path = tmp.path();
+        let protos_dir = node_path.join("protos");
+        std::fs::create_dir_all(&protos_dir).unwrap();
+
+        // Call the function
+        copy_canonical_header_proto(node_path);
+
+        // Verify header.proto was created
+        let header_path = protos_dir.join("header.proto");
+        assert!(header_path.exists(), "header.proto should be created");
+
+        // Verify content matches the embedded canonical version
+        let written = std::fs::read(&header_path).unwrap();
+        assert_eq!(
+            written,
+            crate::HEADER_PROTO,
+            "Written header.proto should match canonical version"
+        );
+    }
+
+    #[test]
+    fn test_copy_canonical_header_proto_no_protos_dir() {
+        use tempfile::tempdir;
+
+        let tmp = tempdir().unwrap();
+        let node_path = tmp.path();
+
+        // Don't create protos/ dir
+        copy_canonical_header_proto(node_path);
+
+        // Should not panic, just silently skip
+        let header_path = node_path.join("protos").join("header.proto");
+        assert!(
+            !header_path.exists(),
+            "Should not create header.proto without protos/ dir"
+        );
+    }
+
+    #[test]
+    fn test_copy_canonical_header_proto_overwrites_existing() {
+        use tempfile::tempdir;
+
+        let tmp = tempdir().unwrap();
+        let node_path = tmp.path();
+        let protos_dir = node_path.join("protos");
+        std::fs::create_dir_all(&protos_dir).unwrap();
+
+        // Create an old/different header.proto
+        let header_path = protos_dir.join("header.proto");
+        std::fs::write(&header_path, b"old header content").unwrap();
+
+        // Call the function
+        copy_canonical_header_proto(node_path);
+
+        // Verify it was overwritten with canonical version
+        let written = std::fs::read(&header_path).unwrap();
+        assert_eq!(
+            written,
+            crate::HEADER_PROTO,
+            "Should overwrite old header.proto with canonical version"
+        );
+        assert_ne!(written, b"old header content");
     }
 }

--- a/crates/bubbaloop/src/cli/node.rs
+++ b/crates/bubbaloop/src/cli/node.rs
@@ -482,6 +482,24 @@ pub(crate) async fn get_zenoh_session() -> Result<zenoh::Session> {
 }
 
 fn init_node(args: InitArgs) -> Result<()> {
+    // Validate node name before creating any files
+    if args.name.is_empty() || args.name.len() > 64 {
+        return Err(NodeError::CommandFailed(format!(
+            "Node name must be 1-64 characters, got '{}'",
+            args.name
+        )));
+    }
+    if !args
+        .name
+        .chars()
+        .all(|c| c.is_alphanumeric() || c == '-' || c == '_')
+    {
+        return Err(NodeError::CommandFailed(format!(
+            "Node name '{}' contains invalid characters (only alphanumeric, hyphens, and underscores allowed)",
+            args.name
+        )));
+    }
+
     // Determine output directory (default: ./<name> in current directory)
     let output_dir = args
         .output

--- a/crates/bubbaloop/src/daemon/mod.rs
+++ b/crates/bubbaloop/src/daemon/mod.rs
@@ -14,6 +14,7 @@
 pub mod node_manager;
 pub mod registry;
 pub mod systemd;
+pub mod util;
 pub mod zenoh_api;
 pub mod zenoh_service;
 

--- a/crates/bubbaloop/src/daemon/node_manager.rs
+++ b/crates/bubbaloop/src/daemon/node_manager.rs
@@ -182,15 +182,7 @@ impl NodeManager {
         let systemd = SystemdClient::new().await?;
         let (event_tx, _) = broadcast::channel(100);
 
-        // Get machine ID from environment or hostname.
-        // Sanitize hyphens to underscores for Zenoh topic compatibility (matching node convention).
-        let machine_id = std::env::var("BUBBALOOP_MACHINE_ID")
-            .unwrap_or_else(|_| {
-                hostname::get()
-                    .map(|h| h.to_string_lossy().to_string())
-                    .unwrap_or_else(|_| "unknown".to_string())
-            })
-            .replace('-', "_");
+        let machine_id = super::util::get_machine_id();
 
         // Get machine hostname
         let machine_hostname = hostname::get()

--- a/crates/bubbaloop/src/daemon/util.rs
+++ b/crates/bubbaloop/src/daemon/util.rs
@@ -1,0 +1,81 @@
+//! Shared daemon utilities.
+
+/// Get machine ID from environment or hostname.
+///
+/// Resolution order:
+/// 1. `BUBBALOOP_MACHINE_ID` env var (used as-is)
+/// 2. System hostname with hyphens replaced by underscores
+/// 3. `"unknown"` fallback
+///
+/// Hyphens are sanitized to underscores for Zenoh topic compatibility,
+/// matching the convention used by external nodes.
+pub fn get_machine_id() -> String {
+    std::env::var("BUBBALOOP_MACHINE_ID")
+        .unwrap_or_else(|_| {
+            hostname::get()
+                .map(|h| h.to_string_lossy().to_string())
+                .unwrap_or_else(|_| "unknown".to_string())
+        })
+        .replace('-', "_")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    // Env var tests must run serially since they mutate shared process state
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn test_get_machine_id_from_env() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let prev = std::env::var("BUBBALOOP_MACHINE_ID").ok();
+        std::env::set_var("BUBBALOOP_MACHINE_ID", "my_jetson_01");
+
+        let id = get_machine_id();
+        assert_eq!(id, "my_jetson_01");
+
+        if let Some(v) = prev {
+            std::env::set_var("BUBBALOOP_MACHINE_ID", v);
+        } else {
+            std::env::remove_var("BUBBALOOP_MACHINE_ID");
+        }
+    }
+
+    #[test]
+    fn test_get_machine_id_sanitizes_hyphens() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let prev = std::env::var("BUBBALOOP_MACHINE_ID").ok();
+        std::env::set_var("BUBBALOOP_MACHINE_ID", "jetson-orin-nano");
+
+        let id = get_machine_id();
+        assert_eq!(id, "jetson_orin_nano");
+
+        if let Some(v) = prev {
+            std::env::set_var("BUBBALOOP_MACHINE_ID", v);
+        } else {
+            std::env::remove_var("BUBBALOOP_MACHINE_ID");
+        }
+    }
+
+    #[test]
+    fn test_get_machine_id_falls_back_to_hostname() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let prev = std::env::var("BUBBALOOP_MACHINE_ID").ok();
+        std::env::remove_var("BUBBALOOP_MACHINE_ID");
+
+        let id = get_machine_id();
+        // Should return a non-empty string (hostname or "unknown")
+        assert!(!id.is_empty());
+        // Should not contain hyphens (they get sanitized)
+        assert!(
+            !id.contains('-'),
+            "machine_id should not contain hyphens: {id}"
+        );
+
+        if let Some(v) = prev {
+            std::env::set_var("BUBBALOOP_MACHINE_ID", v);
+        }
+    }
+}

--- a/crates/bubbaloop/src/daemon/zenoh_api.rs
+++ b/crates/bubbaloop/src/daemon/zenoh_api.rs
@@ -151,25 +151,25 @@ pub struct ErrorResponse {
     pub code: u16,
 }
 
-fn status_to_string(status: i32) -> String {
+fn status_to_string(status: i32) -> &'static str {
     match status {
-        0 => "unknown".to_string(),
-        1 => "stopped".to_string(),
-        2 => "running".to_string(),
-        3 => "failed".to_string(),
-        4 => "installing".to_string(),
-        5 => "building".to_string(),
-        6 => "not-installed".to_string(),
-        _ => "unknown".to_string(),
+        0 => "unknown",
+        1 => "stopped",
+        2 => "running",
+        3 => "failed",
+        4 => "installing",
+        5 => "building",
+        6 => "not-installed",
+        _ => "unknown",
     }
 }
 
-fn health_status_to_string(health_status: i32) -> String {
+fn health_status_to_string(health_status: i32) -> &'static str {
     match health_status {
-        0 => "unknown".to_string(),
-        1 => "healthy".to_string(),
-        2 => "unhealthy".to_string(),
-        _ => "unknown".to_string(),
+        0 => "unknown",
+        1 => "healthy",
+        2 => "unhealthy",
+        _ => "unknown",
     }
 }
 
@@ -177,7 +177,7 @@ fn node_state_to_response(state: &crate::schemas::daemon::v1::NodeState) -> Node
     NodeStateResponse {
         name: state.name.clone(),
         path: state.path.clone(),
-        status: status_to_string(state.status),
+        status: status_to_string(state.status).to_string(),
         installed: state.installed,
         autostart_enabled: state.autostart_enabled,
         version: state.version.clone(),
@@ -188,7 +188,7 @@ fn node_state_to_response(state: &crate::schemas::daemon::v1::NodeState) -> Node
         base_node: state.base_node.clone(),
         config_override: state.config_override.clone(),
         last_updated_ms: state.last_updated_ms,
-        health_status: health_status_to_string(state.health_status),
+        health_status: health_status_to_string(state.health_status).to_string(),
         last_health_check_ms: state.last_health_check_ms,
         machine_id: state.machine_id.clone(),
         machine_hostname: state.machine_hostname.clone(),
@@ -196,22 +196,24 @@ fn node_state_to_response(state: &crate::schemas::daemon::v1::NodeState) -> Node
     }
 }
 
-fn parse_command(cmd: &str) -> CommandType {
+fn parse_command(cmd: &str) -> Option<CommandType> {
     match cmd.to_lowercase().as_str() {
-        "start" => CommandType::Start,
-        "stop" => CommandType::Stop,
-        "restart" => CommandType::Restart,
-        "install" => CommandType::Install,
-        "uninstall" => CommandType::Uninstall,
-        "build" => CommandType::Build,
-        "clean" => CommandType::Clean,
-        "enable" | "enable_autostart" | "enable-autostart" => CommandType::EnableAutostart,
-        "disable" | "disable_autostart" | "disable-autostart" => CommandType::DisableAutostart,
-        "add" | "add_node" => CommandType::AddNode,
-        "remove" | "remove_node" => CommandType::RemoveNode,
-        "refresh" => CommandType::Refresh,
-        "logs" | "get_logs" | "get-logs" => CommandType::GetLogs,
-        _ => CommandType::Refresh,
+        "start" => Some(CommandType::Start),
+        "stop" => Some(CommandType::Stop),
+        "restart" => Some(CommandType::Restart),
+        "install" => Some(CommandType::Install),
+        "uninstall" => Some(CommandType::Uninstall),
+        "build" => Some(CommandType::Build),
+        "clean" => Some(CommandType::Clean),
+        "enable" | "enable_autostart" | "enable-autostart" => Some(CommandType::EnableAutostart),
+        "disable" | "disable_autostart" | "disable-autostart" => {
+            Some(CommandType::DisableAutostart)
+        }
+        "add" | "add_node" => Some(CommandType::AddNode),
+        "remove" | "remove_node" => Some(CommandType::RemoveNode),
+        "refresh" => Some(CommandType::Refresh),
+        "logs" | "get_logs" | "get-logs" => Some(CommandType::GetLogs),
+        _ => None,
     }
 }
 
@@ -551,8 +553,19 @@ impl ZenohApiService {
             }
         };
 
+        let command_type = match parse_command(&request.command) {
+            Some(ct) => ct,
+            None => {
+                return serde_json::to_string(&ErrorResponse {
+                    error: format!("Unknown command: '{}'. Valid commands: start, stop, restart, install, uninstall, build, clean, enable, disable, add, remove, refresh, logs", request.command),
+                    code: 400,
+                })
+                .unwrap_or_else(|_| r#"{"error":"Unknown command","code":400}"#.to_string())
+            }
+        };
+
         let cmd = NodeCommand {
-            command: parse_command(&request.command) as i32,
+            command: command_type as i32,
             node_name: name.to_string(),
             node_path: request.node_path,
             request_id: uuid::Uuid::new_v4().to_string(),
@@ -616,6 +629,8 @@ mod tests {
         assert_eq!(status_to_string(4), "installing");
         assert_eq!(status_to_string(5), "building");
         assert_eq!(status_to_string(6), "not-installed");
+        // Guard: catches proto enum additions
+        assert_eq!(NodeStatus::NotInstalled as i32, 6);
     }
 
     #[test]
@@ -626,86 +641,59 @@ mod tests {
     }
 
     // parse_command tests
+    fn assert_cmd(input: &str, expected: CommandType) {
+        assert_eq!(
+            parse_command(input).unwrap() as i32,
+            expected as i32,
+            "parse_command({input:?})"
+        );
+    }
+
     #[test]
     fn test_parse_command_basic() {
-        assert_eq!(parse_command("start") as i32, CommandType::Start as i32);
-        assert_eq!(parse_command("stop") as i32, CommandType::Stop as i32);
-        assert_eq!(parse_command("restart") as i32, CommandType::Restart as i32);
-        assert_eq!(parse_command("install") as i32, CommandType::Install as i32);
-        assert_eq!(
-            parse_command("uninstall") as i32,
-            CommandType::Uninstall as i32
-        );
-        assert_eq!(parse_command("build") as i32, CommandType::Build as i32);
-        assert_eq!(parse_command("clean") as i32, CommandType::Clean as i32);
-        assert_eq!(parse_command("refresh") as i32, CommandType::Refresh as i32);
+        assert_cmd("start", CommandType::Start);
+        assert_cmd("stop", CommandType::Stop);
+        assert_cmd("restart", CommandType::Restart);
+        assert_cmd("install", CommandType::Install);
+        assert_cmd("uninstall", CommandType::Uninstall);
+        assert_cmd("build", CommandType::Build);
+        assert_cmd("clean", CommandType::Clean);
+        assert_cmd("refresh", CommandType::Refresh);
     }
 
     #[test]
     fn test_parse_command_case_insensitive() {
-        assert_eq!(parse_command("START") as i32, CommandType::Start as i32);
-        assert_eq!(parse_command("Start") as i32, CommandType::Start as i32);
-        assert_eq!(parse_command("sTaRt") as i32, CommandType::Start as i32);
-        assert_eq!(parse_command("STOP") as i32, CommandType::Stop as i32);
-        assert_eq!(parse_command("ReStArT") as i32, CommandType::Restart as i32);
+        for input in ["START", "Start", "sTaRt"] {
+            assert_cmd(input, CommandType::Start);
+        }
+        assert_cmd("STOP", CommandType::Stop);
+        assert_cmd("ReStArT", CommandType::Restart);
     }
 
     #[test]
     fn test_parse_command_aliases() {
-        // Enable autostart aliases
-        assert_eq!(
-            parse_command("enable") as i32,
-            CommandType::EnableAutostart as i32
-        );
-        assert_eq!(
-            parse_command("enable_autostart") as i32,
-            CommandType::EnableAutostart as i32
-        );
-        assert_eq!(
-            parse_command("enable-autostart") as i32,
-            CommandType::EnableAutostart as i32
-        );
-        // Disable aliases
-        assert_eq!(
-            parse_command("disable") as i32,
-            CommandType::DisableAutostart as i32
-        );
-        assert_eq!(
-            parse_command("disable_autostart") as i32,
-            CommandType::DisableAutostart as i32
-        );
-        assert_eq!(
-            parse_command("disable-autostart") as i32,
-            CommandType::DisableAutostart as i32
-        );
-        // Add/Remove aliases
-        assert_eq!(parse_command("add") as i32, CommandType::AddNode as i32);
-        assert_eq!(
-            parse_command("add_node") as i32,
-            CommandType::AddNode as i32
-        );
-        assert_eq!(
-            parse_command("remove") as i32,
-            CommandType::RemoveNode as i32
-        );
-        assert_eq!(
-            parse_command("remove_node") as i32,
-            CommandType::RemoveNode as i32
-        );
+        for input in ["enable", "enable_autostart", "enable-autostart"] {
+            assert_cmd(input, CommandType::EnableAutostart);
+        }
+        for input in ["disable", "disable_autostart", "disable-autostart"] {
+            assert_cmd(input, CommandType::DisableAutostart);
+        }
+        for input in ["add", "add_node"] {
+            assert_cmd(input, CommandType::AddNode);
+        }
+        for input in ["remove", "remove_node"] {
+            assert_cmd(input, CommandType::RemoveNode);
+        }
     }
 
     #[test]
-    fn test_parse_command_unknown_defaults_to_refresh() {
-        assert_eq!(
-            parse_command("unknown_command") as i32,
-            CommandType::Refresh as i32
-        );
-        assert_eq!(parse_command("foo") as i32, CommandType::Refresh as i32);
-        assert_eq!(parse_command("") as i32, CommandType::Refresh as i32);
-        assert_eq!(
-            parse_command("arbitrary-string") as i32,
-            CommandType::Refresh as i32
-        );
+    fn test_parse_command_unknown_returns_none() {
+        for input in ["unknown_command", "foo", "", "arbitrary-string"] {
+            assert!(
+                parse_command(input).is_none(),
+                "expected None for {input:?}"
+            );
+        }
     }
 
     // node_state_to_response tests
@@ -815,23 +803,11 @@ mod tests {
         );
     }
 
-    // parse_command: GetLogs aliases
     #[test]
     fn test_parse_command_logs_aliases() {
-        assert_eq!(parse_command("logs") as i32, CommandType::GetLogs as i32);
-        assert_eq!(
-            parse_command("get_logs") as i32,
-            CommandType::GetLogs as i32
-        );
-        assert_eq!(
-            parse_command("get-logs") as i32,
-            CommandType::GetLogs as i32
-        );
-        assert_eq!(parse_command("LOGS") as i32, CommandType::GetLogs as i32);
-        assert_eq!(
-            parse_command("Get-Logs") as i32,
-            CommandType::GetLogs as i32
-        );
+        for input in ["logs", "get_logs", "get-logs", "LOGS", "Get-Logs"] {
+            assert_cmd(input, CommandType::GetLogs);
+        }
     }
 
     // Serde round-trip tests
@@ -981,40 +957,5 @@ mod tests {
         let deser: ErrorResponse = serde_json::from_str(&json).unwrap();
         assert_eq!(deser.error, "Not found");
         assert_eq!(deser.code, 404);
-    }
-
-    // Status enum consistency test (CONTRACT: dashboard sync required)
-    #[test]
-    fn test_status_enum_consistency() {
-        // Verify all proto NodeStatus enum values (0-6) are handled
-        assert_eq!(status_to_string(NodeStatus::Unknown as i32), "unknown");
-        assert_eq!(status_to_string(NodeStatus::Stopped as i32), "stopped");
-        assert_eq!(status_to_string(NodeStatus::Running as i32), "running");
-        assert_eq!(status_to_string(NodeStatus::Failed as i32), "failed");
-        assert_eq!(
-            status_to_string(NodeStatus::Installing as i32),
-            "installing"
-        );
-        assert_eq!(status_to_string(NodeStatus::Building as i32), "building");
-        assert_eq!(
-            status_to_string(NodeStatus::NotInstalled as i32),
-            "not-installed"
-        );
-
-        // No status should map to empty string
-        for i in 0..=6 {
-            assert!(
-                !status_to_string(i).is_empty(),
-                "Status {} maps to empty string",
-                i
-            );
-        }
-
-        // Verify max enum value is 6 (catches additions)
-        assert_eq!(
-            NodeStatus::NotInstalled as i32,
-            6,
-            "Max NodeStatus enum value changed — update status_to_string()"
-        );
     }
 }

--- a/crates/bubbaloop/src/daemon/zenoh_service.rs
+++ b/crates/bubbaloop/src/daemon/zenoh_service.rs
@@ -26,21 +26,11 @@ pub enum ZenohServiceError {
 
 pub type Result<T> = std::result::Result<T, ZenohServiceError>;
 
-/// Get machine ID from environment or hostname.
-/// Sanitizes hyphens to underscores for Zenoh topic compatibility (matching node convention).
-fn get_machine_id() -> String {
-    std::env::var("BUBBALOOP_MACHINE_ID")
-        .unwrap_or_else(|_| {
-            hostname::get()
-                .map(|h| h.to_string_lossy().to_string())
-                .unwrap_or_else(|_| "unknown".to_string())
-        })
-        .replace('-', "_")
-}
+use crate::daemon::util::get_machine_id;
 
 /// Key expressions for daemon topics
 pub mod keys {
-    use super::get_machine_id;
+    use crate::daemon::util::get_machine_id;
 
     // Legacy keys (for backward compatibility)
     /// Full node list (legacy, no machine_id)

--- a/crates/bubbaloop/src/lib.rs
+++ b/crates/bubbaloop/src/lib.rs
@@ -49,6 +49,10 @@ pub use schemas::Header;
 /// Contains the complete schema definitions for all protobuf messages
 pub const DESCRIPTOR: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/descriptor.bin"));
 
+/// Canonical header.proto content, embedded at compile time.
+/// This is used to ensure nodes always use the correct version of header.proto.
+pub const HEADER_PROTO: &[u8] = include_bytes!("../../bubbaloop-schemas/protos/header.proto");
+
 /// Descriptor information for a protobuf message type
 #[derive(Debug, Clone)]
 pub struct MessageDescriptor {

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -1,24 +1,29 @@
-import { useMemo, useState } from 'react';
-import { useZenohSession, useZenohTopicDiscovery, ConnectionStatus } from './lib/zenoh';
-import { ZenohSubscriptionProvider } from './contexts/ZenohSubscriptionContext';
-import { FleetProvider } from './contexts/FleetContext';
-import { SchemaRegistryProvider } from './contexts/SchemaRegistryContext';
-import { Dashboard } from './components/Dashboard';
-import { FleetBar } from './components/FleetBar';
-import { MeshView } from './components/MeshView';
-import { H264Decoder } from './lib/h264-decoder';
+import { useMemo, useState } from "react";
+import {
+  useZenohSession,
+  useZenohTopicDiscovery,
+  ConnectionStatus,
+} from "./lib/zenoh";
+import { ZenohSubscriptionProvider } from "./contexts/ZenohSubscriptionContext";
+import { FleetProvider } from "./contexts/FleetContext";
+import { SchemaRegistryProvider } from "./contexts/SchemaRegistryContext";
+import { NodeDiscoveryProvider } from "./contexts/NodeDiscoveryContext";
+import { Dashboard } from "./components/Dashboard";
+import { FleetBar } from "./components/FleetBar";
+import { MeshView } from "./components/MeshView";
+import { H264Decoder } from "./lib/h264-decoder";
 
-type AppView = 'dashboard' | 'loop';
+type AppView = "dashboard" | "loop";
 
 // Zenoh endpoint resolution:
 // 1. ?zenoh=ws://host:port URL parameter override
 // 2. /zenoh proxy path (works with both Vite dev server and serve.mjs)
 function getZenohEndpoint(): string {
   const params = new URLSearchParams(window.location.search);
-  const override = params.get('zenoh');
+  const override = params.get("zenoh");
   if (override) return override;
 
-  const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
+  const protocol = window.location.protocol === "https:" ? "wss" : "ws";
   return `${protocol}://${window.location.host}/zenoh`;
 }
 
@@ -27,27 +32,39 @@ const ZENOH_ENDPOINT = getZenohEndpoint();
 // Default camera configuration - modify these to match your setup
 // Default cameras — topic starts empty; CameraView auto-detects the correct
 // scoped topic from discovered topics using the camera name as a hint.
-const DEFAULT_CAMERAS = [
-  { name: 'entrance', topic: '' },
-];
+const DEFAULT_CAMERAS = [{ name: "entrance", topic: "" }];
 
-function StatusIndicator({ status, endpoint, onReconnect }: { status: ConnectionStatus; endpoint: string; onReconnect: () => void }) {
+function StatusIndicator({
+  status,
+  endpoint,
+  onReconnect,
+}: {
+  status: ConnectionStatus;
+  endpoint: string;
+  onReconnect: () => void;
+}) {
   const statusConfig = {
-    disconnected: { color: 'var(--text-muted)', label: 'Disconnected' },
-    connecting: { color: 'var(--warning)', label: 'Connecting...' },
-    connected: { color: 'var(--success)', label: 'Connected' },
-    error: { color: 'var(--error)', label: 'Error' },
+    disconnected: { color: "var(--text-muted)", label: "Disconnected" },
+    connecting: { color: "var(--warning)", label: "Connecting..." },
+    connected: { color: "var(--success)", label: "Connected" },
+    error: { color: "var(--error)", label: "Error" },
   };
 
   const config = statusConfig[status];
 
   return (
     <div className="status-indicator">
-      <span className="status-endpoint" title={endpoint}>{endpoint}</span>
+      <span className="status-endpoint" title={endpoint}>
+        {endpoint}
+      </span>
       <span className="status-dot" style={{ backgroundColor: config.color }} />
       <span className="status-label">{config.label}</span>
-      {(status === 'error' || status === 'disconnected') && (
-        <button className="reconnect-btn" onClick={onReconnect} title="Reconnect">
+      {(status === "error" || status === "disconnected") && (
+        <button
+          className="reconnect-btn"
+          onClick={onReconnect}
+          title="Reconnect"
+        >
           ↻
         </button>
       )}
@@ -72,7 +89,7 @@ function StatusIndicator({ status, endpoint, onReconnect }: { status: Connection
           width: 8px;
           height: 8px;
           border-radius: 50%;
-          animation: ${status === 'connecting' ? 'pulse 1s infinite' : 'none'};
+          animation: ${status === "connecting" ? "pulse 1s infinite" : "none"};
         }
 
         .status-label {
@@ -125,7 +142,6 @@ function StatusIndicator({ status, endpoint, onReconnect }: { status: Connection
   );
 }
 
-
 function BrowserCheck() {
   const isSupported = H264Decoder.isSupported();
   const isSecureContext = window.isSecureContext;
@@ -144,12 +160,20 @@ function BrowserCheck() {
           <strong>WebCodecs not supported</strong>
           {needsSecureContext ? (
             <>
-              <p>WebCodecs requires a <strong>secure context</strong> (localhost or HTTPS).</p>
-              <p>Access via <code>https://{window.location.host}</code> or <code>http://localhost:5173</code></p>
+              <p>
+                WebCodecs requires a <strong>secure context</strong> (localhost
+                or HTTPS).
+              </p>
+              <p>
+                Access via <code>https://{window.location.host}</code> or{" "}
+                <code>http://localhost:5173</code>
+              </p>
             </>
           ) : (
             <>
-              <p>Your browser doesn't support WebCodecs API for H264 decoding.</p>
+              <p>
+                Your browser doesn't support WebCodecs API for H264 decoding.
+              </p>
               <p>Please use Chrome 94+, Edge 94+, or Safari 16.4+.</p>
             </>
           )}
@@ -198,8 +222,8 @@ function BrowserCheck() {
 export default function App() {
   const zenohConfig = useMemo(() => ({ endpoint: ZENOH_ENDPOINT }), []);
   const { session, status, error, reconnect } = useZenohSession(zenohConfig);
-  const { topics: availableTopics } = useZenohTopicDiscovery(session, '**');
-  const [currentView, setCurrentView] = useState<AppView>('dashboard');
+  const { topics: availableTopics } = useZenohTopicDiscovery(session, "**");
+  const [currentView, setCurrentView] = useState<AppView>("dashboard");
 
   return (
     <div className="app">
@@ -208,10 +232,17 @@ export default function App() {
           <h1>Bubbaloop</h1>
           <div className="view-switcher">
             <button
-              className={`view-tab ${currentView === 'dashboard' ? 'active' : ''}`}
-              onClick={() => setCurrentView('dashboard')}
+              className={`view-tab ${currentView === "dashboard" ? "active" : ""}`}
+              onClick={() => setCurrentView("dashboard")}
             >
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+              >
                 <rect x="3" y="3" width="7" height="7" rx="1" />
                 <rect x="14" y="3" width="7" height="7" rx="1" />
                 <rect x="3" y="14" width="7" height="7" rx="1" />
@@ -220,10 +251,17 @@ export default function App() {
               Dashboard
             </button>
             <button
-              className={`view-tab ${currentView === 'loop' ? 'active' : ''}`}
-              onClick={() => setCurrentView('loop')}
+              className={`view-tab ${currentView === "loop" ? "active" : ""}`}
+              onClick={() => setCurrentView("loop")}
             >
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+              >
                 <circle cx="12" cy="12" r="3" />
                 <circle cx="5" cy="6" r="2" />
                 <circle cx="19" cy="6" r="2" />
@@ -238,7 +276,11 @@ export default function App() {
             </button>
           </div>
         </div>
-        <StatusIndicator status={status} endpoint={ZENOH_ENDPOINT} onReconnect={reconnect} />
+        <StatusIndicator
+          status={status}
+          endpoint={ZENOH_ENDPOINT}
+          onReconnect={reconnect}
+        />
       </header>
 
       <BrowserCheck />
@@ -251,31 +293,43 @@ export default function App() {
 
       {session ? (
         <FleetProvider>
-          <SchemaRegistryProvider session={session}>
-            <ZenohSubscriptionProvider session={session}>
-              <FleetBar />
-              {currentView === 'dashboard' ? (
-                <Dashboard cameras={DEFAULT_CAMERAS} availableTopics={availableTopics} />
-              ) : (
-                <MeshView availableTopics={availableTopics} zenohEndpoint={ZENOH_ENDPOINT} connectionStatus={status} />
-              )}
-            </ZenohSubscriptionProvider>
-          </SchemaRegistryProvider>
+          <NodeDiscoveryProvider session={session}>
+            <SchemaRegistryProvider session={session}>
+              <ZenohSubscriptionProvider session={session}>
+                <FleetBar />
+                {currentView === "dashboard" ? (
+                  <Dashboard
+                    cameras={DEFAULT_CAMERAS}
+                    availableTopics={availableTopics}
+                  />
+                ) : (
+                  <MeshView
+                    availableTopics={availableTopics}
+                    zenohEndpoint={ZENOH_ENDPOINT}
+                    connectionStatus={status}
+                  />
+                )}
+              </ZenohSubscriptionProvider>
+            </SchemaRegistryProvider>
+          </NodeDiscoveryProvider>
         </FleetProvider>
       ) : (
         <div className="connecting-placeholder">
           <div className="placeholder-content">
-            {status === 'connecting' ? (
+            {status === "connecting" ? (
               <>
                 <div className="spinner" />
                 <p>Connecting to Zenoh...</p>
                 <p className="hint">{ZENOH_ENDPOINT}</p>
               </>
-            ) : status === 'error' ? (
+            ) : status === "error" ? (
               <>
                 <span className="error-icon">❌</span>
                 <p>Failed to connect to {ZENOH_ENDPOINT}</p>
-                <p className="hint">Check that zenoh-bridge-remote-api is running (proxied via Vite)</p>
+                <p className="hint">
+                  Check that zenoh-bridge-remote-api is running (proxied via
+                  Vite)
+                </p>
               </>
             ) : (
               <>

--- a/dashboard/src/components/SystemTelemetryView.tsx
+++ b/dashboard/src/components/SystemTelemetryView.tsx
@@ -116,8 +116,8 @@ export function SystemTelemetryViewPanel({
     return () => clearInterval(timer);
   }, []);
 
-  // Match any machine/scope: */*/TypeName/* (ros-z key format: domain/topic%encoded/type/hash)
-  const telemetryTopic = '*/*/bubbaloop.system_telemetry.v1.SystemMetrics/*';
+  // Match any machine/scope: **/TypeName/* (works with new ros-z format: 0/bubbaloop/scope/machine/node/resource/type/hash)
+  const telemetryTopic = '**/bubbaloop.system_telemetry.v1.SystemMetrics/*';
 
   const handleSample = useCallback((sample: Sample) => {
     try {

--- a/dashboard/src/components/WeatherView.tsx
+++ b/dashboard/src/components/WeatherView.tsx
@@ -133,10 +133,10 @@ export function WeatherViewPanel({
   const [isSendingLocation, setIsSendingLocation] = useState(false);
   const [locationUpdateStatus, setLocationUpdateStatus] = useState<'idle' | 'sent' | 'error'>('idle');
 
-  // Match any machine/scope: */*/TypeName/* (ros-z key format: domain/topic%encoded/type/hash)
-  const currentTopic = '*/*/bubbaloop.weather.v1.CurrentWeather/*';
-  const hourlyTopic = '*/*/bubbaloop.weather.v1.HourlyForecast/*';
-  const dailyTopic = '*/*/bubbaloop.weather.v1.DailyForecast/*';
+  // Match any machine/scope: **/TypeName/* (works with new ros-z format: 0/bubbaloop/scope/machine/node/resource/type/hash)
+  const currentTopic = '**/bubbaloop.weather.v1.CurrentWeather/*';
+  const hourlyTopic = '**/bubbaloop.weather.v1.HourlyForecast/*';
+  const dailyTopic = '**/bubbaloop.weather.v1.DailyForecast/*';
 
   // Handle current weather samples
   const handleCurrentSample = useCallback((sample: Sample) => {

--- a/dashboard/src/components/__tests__/SystemTelemetryView.test.tsx
+++ b/dashboard/src/components/__tests__/SystemTelemetryView.test.tsx
@@ -7,6 +7,12 @@ vi.mock('../../hooks/useZenohSubscription', () => ({
   useAllTopicStats: vi.fn(() => new Map()),
 }));
 
+const _schemaReadyState = vi.hoisted(() => ({ ready: false }));
+
+vi.mock('../../hooks/useSchemaReady', () => ({
+  useSchemaReady: vi.fn(() => _schemaReadyState.ready),
+}));
+
 vi.mock('../../contexts/FleetContext', () => ({
   useFleetContext: vi.fn(() => ({
     machines: [],
@@ -55,10 +61,12 @@ vi.mock('./MachineBadge', () => ({
 }));
 
 import { SystemTelemetryViewPanel } from '../SystemTelemetryView';
+import { useZenohSubscription } from '../../hooks/useZenohSubscription';
 
 describe('SystemTelemetryViewPanel', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    _schemaReadyState.ready = false;
   });
 
   it('renders TELEMETRY badge in header', () => {
@@ -87,5 +95,25 @@ describe('SystemTelemetryViewPanel', () => {
   it('does not render remove button when onRemove is not provided', () => {
     render(<SystemTelemetryViewPanel />);
     expect(screen.queryByTitle('Remove panel')).not.toBeInTheDocument();
+  });
+
+  describe('schema-ready gating', () => {
+    it('does not pass callback when schemas are not ready', () => {
+      _schemaReadyState.ready = false;
+      render(<SystemTelemetryViewPanel />);
+
+      const mockSub = vi.mocked(useZenohSubscription);
+      expect(mockSub).toHaveBeenCalledTimes(1);
+      expect(mockSub.mock.calls[0][1]).toBeUndefined();
+    });
+
+    it('passes callback when schemas are ready', () => {
+      _schemaReadyState.ready = true;
+      render(<SystemTelemetryViewPanel />);
+
+      const mockSub = vi.mocked(useZenohSubscription);
+      expect(mockSub).toHaveBeenCalledTimes(1);
+      expect(typeof mockSub.mock.calls[0][1]).toBe('function');
+    });
   });
 });

--- a/dashboard/src/components/__tests__/schema-ready-gating.test.tsx
+++ b/dashboard/src/components/__tests__/schema-ready-gating.test.tsx
@@ -1,0 +1,240 @@
+/**
+ * End-to-end integration tests for the schema-ready gating pattern.
+ *
+ * Verifies that ALL protobuf-dependent view components gate their subscription
+ * callbacks on schema readiness, while views with fallback decode chains (JsonView)
+ * do NOT gate.
+ *
+ * This prevents the race condition where Zenoh subscriptions deliver messages
+ * before fetchSchemas() completes, causing silent data loss.
+ */
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import React from 'react';
+import { render } from '@testing-library/react';
+
+// --- Shared mock state ---
+
+const _schemaReadyState = vi.hoisted(() => ({ ready: false }));
+
+const _h264State = vi.hoisted(() => ({
+  isSupported: true,
+  initResolves: true,
+}));
+
+// --- Mock all shared dependencies ---
+
+vi.mock('../../hooks/useZenohSubscription', () => ({
+  useZenohSubscription: vi.fn(() => ({ messageCount: 0, fps: 0, instantFps: 0 })),
+  useAllTopicStats: vi.fn(() => new Map()),
+}));
+
+vi.mock('../../hooks/useSchemaReady', () => ({
+  useSchemaReady: vi.fn(() => _schemaReadyState.ready),
+}));
+
+vi.mock('../../lib/h264-decoder', () => {
+  class MockH264Decoder {
+    static isSupported() { return _h264State.isSupported; }
+    init() { return _h264State.initResolves ? Promise.resolve() : new Promise<void>(() => {}); }
+    close() {}
+    decode() { return Promise.resolve(); }
+  }
+  return { H264Decoder: MockH264Decoder };
+});
+
+vi.mock('../../contexts/FleetContext', () => ({
+  useFleetContext: vi.fn(() => ({
+    machines: [],
+    reportMachines: vi.fn(),
+    nodes: [],
+    reportNodes: vi.fn(),
+    selectedMachineId: null,
+    setSelectedMachineId: vi.fn(),
+  })),
+  FleetProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock('../../contexts/SchemaRegistryContext', () => ({
+  useSchemaRegistry: vi.fn(() => ({
+    registry: { lookupType: vi.fn(() => null), tryDecodeForTopic: vi.fn(() => null), decode: vi.fn(() => null) },
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+    decode: vi.fn(() => null),
+    discoverForTopic: vi.fn(),
+    schemaVersion: 0,
+  })),
+}));
+
+vi.mock('../../contexts/ZenohSubscriptionContext', () => ({
+  useZenohSubscriptionContext: vi.fn(() => ({
+    manager: {},
+    getSession: vi.fn(() => null),
+    subscribe: vi.fn(() => 'listener_1'),
+    unsubscribe: vi.fn(),
+    getTopicStats: vi.fn(() => null),
+    getAllStats: vi.fn(() => new Map()),
+    getAllMonitoredStats: vi.fn(() => new Map()),
+    getActiveSubscriptions: vi.fn(() => []),
+    getDiscoveredTopics: vi.fn(() => []),
+    addRemoteEndpoint: vi.fn(),
+    removeEndpoint: vi.fn(),
+    startMonitoring: vi.fn(async () => {}),
+    stopMonitoring: vi.fn(async () => {}),
+    isMonitoringEnabled: vi.fn(() => false),
+  })),
+}));
+
+vi.mock('../../lib/subscription-manager', () => ({
+  normalizeTopicPattern: vi.fn((key: string) => key),
+}));
+
+vi.mock('../../lib/zenoh', () => ({
+  getSamplePayload: vi.fn(() => new Uint8Array()),
+  extractMachineId: vi.fn(() => null),
+}));
+
+vi.mock('../../proto/daemon', () => ({
+  decodeNodeList: vi.fn(() => null),
+  decodeNodeEvent: vi.fn(() => null),
+}));
+
+vi.mock('../MachineBadge', () => ({
+  MachineBadge: () => null,
+}));
+
+vi.mock('react18-json-view', () => ({
+  default: () => React.createElement('div', { 'data-testid': 'json-view' }),
+}));
+vi.mock('react18-json-view/src/style.css', () => ({}));
+
+// --- Import components and mock ---
+
+import { useZenohSubscription } from '../../hooks/useZenohSubscription';
+import { CameraView } from '../CameraView';
+import { WeatherViewPanel } from '../WeatherView';
+import { SystemTelemetryViewPanel } from '../SystemTelemetryView';
+import { NetworkMonitorViewPanel } from '../NetworkMonitorView';
+import { RawDataViewPanel } from '../JsonView';
+
+// Helper: get all subscription callbacks from mock calls
+function getSubscriptionCallbacks(): Array<unknown> {
+  const mockSub = vi.mocked(useZenohSubscription);
+  return mockSub.mock.calls.map(call => call[1]);
+}
+
+describe('Schema-Ready Gating (end-to-end)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _schemaReadyState.ready = false;
+    _h264State.isSupported = true;
+    _h264State.initResolves = true;
+  });
+
+  describe('when schemas are NOT ready (schemaVersion === 0)', () => {
+    beforeEach(() => {
+      _schemaReadyState.ready = false;
+    });
+
+    it('CameraView does not pass callback to subscription', () => {
+      render(<CameraView cameraName="test" topic="camera/test/**" />);
+      const callbacks = getSubscriptionCallbacks();
+      expect(callbacks).toHaveLength(1);
+      expect(callbacks[0]).toBeUndefined();
+    });
+
+    it('WeatherView does not pass any callbacks to subscriptions', () => {
+      render(<WeatherViewPanel />);
+      const callbacks = getSubscriptionCallbacks();
+      // WeatherView has 3 subscriptions: current, hourly, daily
+      expect(callbacks).toHaveLength(3);
+      expect(callbacks.every(cb => cb === undefined)).toBe(true);
+    });
+
+    it('SystemTelemetryView does not pass callback to subscription', () => {
+      render(<SystemTelemetryViewPanel />);
+      const callbacks = getSubscriptionCallbacks();
+      expect(callbacks).toHaveLength(1);
+      expect(callbacks[0]).toBeUndefined();
+    });
+
+    it('NetworkMonitorView does not pass callback to subscription', () => {
+      render(<NetworkMonitorViewPanel />);
+      const callbacks = getSubscriptionCallbacks();
+      expect(callbacks).toHaveLength(1);
+      expect(callbacks[0]).toBeUndefined();
+    });
+
+    it('JsonView ALWAYS passes callback (has own fallback decode chain)', () => {
+      render(<RawDataViewPanel topic="some/topic/**" />);
+      const callbacks = getSubscriptionCallbacks();
+      expect(callbacks).toHaveLength(1);
+      expect(typeof callbacks[0]).toBe('function');
+    });
+  });
+
+  describe('when schemas ARE ready (schemaVersion > 0)', () => {
+    beforeEach(() => {
+      _schemaReadyState.ready = true;
+    });
+
+    it('CameraView passes callback to subscription', () => {
+      render(<CameraView cameraName="test" topic="camera/test/**" />);
+      const callbacks = getSubscriptionCallbacks();
+      expect(callbacks).toHaveLength(1);
+      expect(typeof callbacks[0]).toBe('function');
+    });
+
+    it('WeatherView passes all 3 callbacks to subscriptions', () => {
+      render(<WeatherViewPanel />);
+      const callbacks = getSubscriptionCallbacks();
+      expect(callbacks).toHaveLength(3);
+      expect(callbacks.every(cb => typeof cb === 'function')).toBe(true);
+    });
+
+    it('SystemTelemetryView passes callback to subscription', () => {
+      render(<SystemTelemetryViewPanel />);
+      const callbacks = getSubscriptionCallbacks();
+      expect(callbacks).toHaveLength(1);
+      expect(typeof callbacks[0]).toBe('function');
+    });
+
+    it('NetworkMonitorView passes callback to subscription', () => {
+      render(<NetworkMonitorViewPanel />);
+      const callbacks = getSubscriptionCallbacks();
+      expect(callbacks).toHaveLength(1);
+      expect(typeof callbacks[0]).toBe('function');
+    });
+
+    it('JsonView still passes callback (unchanged behavior)', () => {
+      render(<RawDataViewPanel topic="some/topic/**" />);
+      const callbacks = getSubscriptionCallbacks();
+      expect(callbacks).toHaveLength(1);
+      expect(typeof callbacks[0]).toBe('function');
+    });
+  });
+
+  describe('subscription topics are always registered (even when gated)', () => {
+    it('all views register their topics regardless of schema readiness', () => {
+      _schemaReadyState.ready = false;
+      const mockSub = vi.mocked(useZenohSubscription);
+
+      // Render all protobuf-dependent views
+      const { unmount: u1 } = render(<CameraView cameraName="test" topic="camera/test/**" />);
+      const { unmount: u2 } = render(<WeatherViewPanel />);
+      const { unmount: u3 } = render(<SystemTelemetryViewPanel />);
+      const { unmount: u4 } = render(<NetworkMonitorViewPanel />);
+
+      // All should have called useZenohSubscription with a topic (first arg)
+      // even though callbacks are undefined
+      const topics = mockSub.mock.calls.map(call => call[0]);
+      expect(topics).toHaveLength(6); // 1 + 3 + 1 + 1
+      for (const topic of topics) {
+        expect(typeof topic).toBe('string');
+        expect(topic.length).toBeGreaterThan(0);
+      }
+
+      u1(); u2(); u3(); u4();
+    });
+  });
+});

--- a/dashboard/src/contexts/NodeDiscoveryContext.tsx
+++ b/dashboard/src/contexts/NodeDiscoveryContext.tsx
@@ -1,0 +1,638 @@
+/**
+ * NodeDiscoveryContext — Hybrid node discovery via daemon API + direct manifest queries.
+ *
+ * Two independent discovery loops:
+ * 1. Manifest discovery: queries `bubbaloop/** /manifest` (every 10s, backs off to 30s)
+ *    Each running node responds with its JSON manifest.
+ * 2. Daemon polling: queries `bubbaloop/daemon/nodes` (every 3s) for protobuf NodeList.
+ *
+ * Results are merged: manifest provides rich metadata, daemon provides runtime state.
+ * When daemon is down, nodes discovered via manifest still appear (status = 'unknown').
+ */
+
+import {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  useCallback,
+  useRef,
+  useMemo,
+  type ReactNode,
+} from "react";
+import { Session, Reply, ReplyError, Sample } from "@eclipse-zenoh/zenoh-ts";
+import { useFleetContext } from "./FleetContext";
+import { decodeNodeList } from "../proto/daemon";
+import { getSamplePayload } from "../lib/zenoh";
+import { Duration } from "typed-duration";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface NodeManifest {
+  name: string;
+  version: string;
+  language: string;
+  description: string;
+  machine_id: string;
+  scope: string;
+  capabilities: string[];
+  requires_hardware: string[];
+  publishes: Array<{
+    topic_suffix: string;
+    full_topic: string;
+    rate_hz: number;
+  }>;
+  subscribes: string[];
+  schema_key: string;
+  health_key: string;
+  config_key: string;
+  security: {
+    acl_prefix: string;
+    data_classification: string;
+  };
+  time: {
+    clock_source: string;
+    timestamp_field: string;
+    timestamp_unit: string;
+  };
+}
+
+export interface DiscoveredNode {
+  // Core identity
+  name: string;
+  machine_id: string;
+
+  // From manifest (available when discovered via manifest)
+  manifest?: NodeManifest;
+
+  // From daemon (available when daemon is online)
+  path: string;
+  status:
+    | "unknown"
+    | "stopped"
+    | "running"
+    | "failed"
+    | "installing"
+    | "building"
+    | "not-installed";
+  installed: boolean;
+  autostart_enabled: boolean;
+  version: string;
+  description: string;
+  node_type: string;
+  is_built: boolean;
+  build_output: string[];
+  machine_hostname: string;
+  machine_ips: string[];
+  base_node: string;
+
+  // Discovery metadata
+  discoveredVia: "manifest" | "daemon" | "both";
+  stale: boolean;
+  lastSeen: number;
+}
+
+export interface NodeDiscoveryContextValue {
+  nodes: DiscoveredNode[];
+  loading: boolean;
+  error: string | null;
+  daemonConnected: boolean;
+  manifestDiscoveryActive: boolean;
+  refresh: () => void;
+}
+
+const NodeDiscoveryContext = createContext<NodeDiscoveryContextValue>({
+  nodes: [],
+  loading: true,
+  error: null,
+  daemonConnected: false,
+  manifestDiscoveryActive: false,
+  refresh: () => {},
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Map protobuf status number to string. */
+function statusNumberToString(status: number): DiscoveredNode["status"] {
+  const map: Record<number, DiscoveredNode["status"]> = {
+    1: "stopped",
+    2: "running",
+    3: "failed",
+    4: "installing",
+    5: "building",
+    6: "not-installed",
+  };
+  return map[status] ?? "unknown";
+}
+
+/** Unique key for a node across machines. */
+function nodeKey(machineId: string, name: string): string {
+  return `${machineId || "local"}::${name}`;
+}
+
+/** Create a default DiscoveredNode (manifest-only, no daemon info). */
+function manifestOnlyNode(manifest: NodeManifest, now: number): DiscoveredNode {
+  return {
+    name: manifest.name,
+    machine_id: manifest.machine_id || "local",
+    manifest,
+    path: "",
+    status: "unknown",
+    installed: false,
+    autostart_enabled: false,
+    version: manifest.version || "",
+    description: manifest.description || "",
+    node_type: manifest.language || "",
+    is_built: false,
+    build_output: [],
+    machine_hostname: "",
+    machine_ips: [],
+    base_node: "",
+    discoveredVia: "manifest",
+    stale: false,
+    lastSeen: now,
+  };
+}
+
+/** Parse a JSON payload into a NodeManifest, returning null on failure. */
+function parseManifest(data: Uint8Array): NodeManifest | null {
+  try {
+    const text = new TextDecoder().decode(data);
+    const obj = JSON.parse(text);
+    if (!obj || typeof obj !== "object" || !obj.name) return null;
+    return {
+      name: obj.name ?? "",
+      version: obj.version ?? "",
+      language: obj.language ?? "",
+      description: obj.description ?? "",
+      machine_id: obj.machine_id ?? "",
+      scope: obj.scope ?? "",
+      capabilities: Array.isArray(obj.capabilities) ? obj.capabilities : [],
+      requires_hardware: Array.isArray(obj.requires_hardware)
+        ? obj.requires_hardware
+        : [],
+      publishes: Array.isArray(obj.publishes) ? obj.publishes : [],
+      subscribes: Array.isArray(obj.subscribes) ? obj.subscribes : [],
+      schema_key: obj.schema_key ?? "",
+      health_key: obj.health_key ?? "",
+      config_key: obj.config_key ?? "",
+      security: {
+        acl_prefix: obj.security?.acl_prefix ?? "",
+        data_classification: obj.security?.data_classification ?? "",
+      },
+      time: {
+        clock_source: obj.time?.clock_source ?? "",
+        timestamp_field: obj.time?.timestamp_field ?? "",
+        timestamp_unit: obj.time?.timestamp_unit ?? "",
+      },
+    };
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+interface NodeDiscoveryProviderProps {
+  session: Session | null;
+  children: ReactNode;
+}
+
+export function NodeDiscoveryProvider({
+  session,
+  children,
+}: NodeDiscoveryProviderProps) {
+  const sessionRef = useRef<Session | null>(null);
+  sessionRef.current = session;
+
+  // State exposed via context
+  const [nodes, setNodes] = useState<DiscoveredNode[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [daemonConnected, setDaemonConnected] = useState(false);
+  const [manifestDiscoveryActive, setManifestDiscoveryActive] = useState(false);
+
+  // Internal tracking
+  const hasReceivedDaemonDataRef = useRef(false);
+
+  // Daemon: track per-machine last-seen and last-known nodes for stale detection
+  const machineLastSeenRef = useRef(new Map<string, number>());
+  const prevDaemonNodesRef = useRef(new Map<string, DiscoveredNode[]>());
+
+  // Manifest: keyed by nodeKey
+  const manifestMapRef = useRef(new Map<string, NodeManifest>());
+  const manifestLastSeenRef = useRef(new Map<string, number>());
+
+  // Version counter to track refreshes
+  const refreshCounterRef = useRef(0);
+
+  const STALE_THRESHOLD_MS = 15_000;
+
+  // -----------------------------------------------------------------------
+  // Daemon polling (every 3s)
+  // -----------------------------------------------------------------------
+  const pollDaemon = useCallback(async (): Promise<DiscoveredNode[]> => {
+    const currentSession = sessionRef.current;
+    if (!currentSession) return [];
+
+    try {
+      const receiver = await currentSession.get("bubbaloop/daemon/nodes", {
+        timeout: Duration.milliseconds.of(5000),
+      });
+
+      const allNodes = new Map<string, DiscoveredNode[]>();
+
+      if (receiver) {
+        for await (const replyItem of receiver) {
+          if (replyItem instanceof Reply) {
+            let sample: Sample;
+            try {
+              const result = replyItem.result();
+              if (result instanceof ReplyError) continue;
+              sample = result as Sample;
+            } catch {
+              continue;
+            }
+
+            const payload = getSamplePayload(sample);
+            const nodeList = decodeNodeList(payload);
+            if (!nodeList || nodeList.nodes.length === 0) continue;
+
+            const listMachineId = nodeList.machineId || "";
+            const mapped: DiscoveredNode[] = nodeList.nodes.map((n) => ({
+              name: n.name,
+              machine_id: n.machineId || listMachineId,
+              path: n.path,
+              status: statusNumberToString(n.status),
+              installed: n.installed,
+              autostart_enabled: n.autostartEnabled,
+              version: n.version,
+              description: n.description,
+              node_type: n.nodeType,
+              is_built: n.isBuilt,
+              build_output: n.buildOutput,
+              machine_hostname: n.machineHostname,
+              machine_ips: n.machineIps || [],
+              base_node: n.baseNode || "",
+              discoveredVia: "daemon" as const,
+              stale: false,
+              lastSeen: Date.now(),
+            }));
+
+            allNodes.set(listMachineId, mapped);
+            machineLastSeenRef.current.set(listMachineId, Date.now());
+
+            if (!hasReceivedDaemonDataRef.current) {
+              hasReceivedDaemonDataRef.current = true;
+              setDaemonConnected(true);
+              setError(null);
+              setLoading(false);
+            }
+          }
+        }
+      }
+
+      // Build merged daemon nodes (fresh + stale from offline machines)
+      const now = Date.now();
+      const mergedDaemonNodes: DiscoveredNode[] = [];
+
+      // Update prevDaemonNodes with fresh replies
+      for (const [mid, machineNodes] of allNodes.entries()) {
+        prevDaemonNodesRef.current.set(mid, machineNodes);
+      }
+
+      // Fresh nodes
+      for (const machineNodes of allNodes.values()) {
+        mergedDaemonNodes.push(...machineNodes);
+      }
+
+      // Stale nodes from machines that did not reply
+      for (const [mid, lastSeen] of machineLastSeenRef.current.entries()) {
+        if (!allNodes.has(mid)) {
+          if (now - lastSeen <= STALE_THRESHOLD_MS) {
+            const lastKnown = prevDaemonNodesRef.current.get(mid);
+            if (lastKnown) {
+              mergedDaemonNodes.push(
+                ...lastKnown.map((n) => ({ ...n, stale: true })),
+              );
+            }
+          } else {
+            prevDaemonNodesRef.current.delete(mid);
+            machineLastSeenRef.current.delete(mid);
+          }
+        }
+      }
+
+      if (mergedDaemonNodes.length > 0) {
+        setDaemonConnected(true);
+      }
+
+      return mergedDaemonNodes;
+    } catch (err) {
+      console.warn("[NodeDiscovery] Daemon poll failed:", err);
+      return [];
+    }
+  }, []);
+
+  // -----------------------------------------------------------------------
+  // Manifest discovery (every 10s, backs off to 30s)
+  // -----------------------------------------------------------------------
+  const discoverManifests = useCallback(async (): Promise<
+    Map<string, NodeManifest>
+  > => {
+    const currentSession = sessionRef.current;
+    if (!currentSession) return manifestMapRef.current;
+
+    try {
+      setManifestDiscoveryActive(true);
+
+      const receiver = await currentSession.get("bubbaloop/**/manifest", {
+        timeout: Duration.milliseconds.of(5000),
+      });
+
+      if (receiver) {
+        const now = Date.now();
+        for await (const replyItem of receiver) {
+          if (replyItem instanceof Reply) {
+            let sample: Sample;
+            try {
+              const result = replyItem.result();
+              if (result instanceof ReplyError) continue;
+              sample = result as Sample;
+            } catch {
+              continue;
+            }
+
+            const payload = getSamplePayload(sample);
+            const manifest = parseManifest(payload);
+            if (manifest) {
+              const key = nodeKey(manifest.machine_id, manifest.name);
+              manifestMapRef.current.set(key, manifest);
+              manifestLastSeenRef.current.set(key, now);
+            }
+          }
+        }
+      }
+    } catch (err) {
+      console.warn("[NodeDiscovery] Manifest discovery failed:", err);
+    } finally {
+      setManifestDiscoveryActive(false);
+    }
+
+    return manifestMapRef.current;
+  }, []);
+
+  // -----------------------------------------------------------------------
+  // Merge daemon nodes + manifest data
+  // -----------------------------------------------------------------------
+  const mergeNodes = useCallback(
+    (
+      daemonNodes: DiscoveredNode[],
+      manifests: Map<string, NodeManifest>,
+    ): DiscoveredNode[] => {
+      const now = Date.now();
+      const merged = new Map<string, DiscoveredNode>();
+
+      // Add all daemon nodes first
+      for (const dn of daemonNodes) {
+        const key = nodeKey(dn.machine_id, dn.name);
+        const manifest = manifests.get(key);
+        merged.set(key, {
+          ...dn,
+          manifest: manifest ?? undefined,
+          discoveredVia: manifest ? "both" : "daemon",
+        });
+      }
+
+      // Add manifest-only nodes (not in daemon)
+      for (const [key, manifest] of manifests.entries()) {
+        if (!merged.has(key)) {
+          const lastSeen = manifestLastSeenRef.current.get(key) ?? now;
+          // Only include if not too stale (60s for manifests since they poll less often)
+          if (now - lastSeen <= 60_000) {
+            merged.set(key, manifestOnlyNode(manifest, lastSeen));
+          } else {
+            // Clean up old entries
+            manifests.delete(key);
+            manifestLastSeenRef.current.delete(key);
+          }
+        }
+      }
+
+      return Array.from(merged.values());
+    },
+    [],
+  );
+
+  // -----------------------------------------------------------------------
+  // Combined polling loop
+  // -----------------------------------------------------------------------
+  useEffect(() => {
+    if (!session) {
+      setNodes([]);
+      setLoading(true);
+      setError(null);
+      setDaemonConnected(false);
+      hasReceivedDaemonDataRef.current = false;
+      manifestMapRef.current.clear();
+      manifestLastSeenRef.current.clear();
+      machineLastSeenRef.current.clear();
+      prevDaemonNodesRef.current.clear();
+      return;
+    }
+
+    let mounted = true;
+    let daemonTimer: ReturnType<typeof setTimeout> | null = null;
+    let manifestTimer: ReturnType<typeof setTimeout> | null = null;
+    let manifestEmptyConsecutive = 0;
+    const capturedRefreshCounter = refreshCounterRef.current;
+
+    // Daemon loop
+    const runDaemonPoll = async () => {
+      if (!mounted) return;
+
+      const daemonNodes = await pollDaemon();
+
+      if (!mounted) return;
+
+      const allNodes = mergeNodes(daemonNodes, manifestMapRef.current);
+      if (allNodes.length > 0) {
+        setNodes(allNodes);
+      }
+
+      if (mounted && capturedRefreshCounter === refreshCounterRef.current) {
+        daemonTimer = setTimeout(runDaemonPoll, 3000);
+      }
+    };
+
+    // Manifest loop
+    const runManifestDiscovery = async () => {
+      if (!mounted) return;
+
+      const prevSize = manifestMapRef.current.size;
+      await discoverManifests();
+
+      if (!mounted) return;
+
+      const newSize = manifestMapRef.current.size;
+      if (newSize > prevSize) {
+        manifestEmptyConsecutive = 0;
+        // Re-merge with latest daemon state
+        const daemonNodes: DiscoveredNode[] = [];
+        for (const machineNodes of prevDaemonNodesRef.current.values()) {
+          daemonNodes.push(...machineNodes);
+        }
+        const allNodes = mergeNodes(daemonNodes, manifestMapRef.current);
+        if (allNodes.length > 0) {
+          setNodes(allNodes);
+        }
+      } else {
+        manifestEmptyConsecutive++;
+      }
+
+      if (mounted && capturedRefreshCounter === refreshCounterRef.current) {
+        const interval = manifestEmptyConsecutive >= 3 ? 30_000 : 10_000;
+        manifestTimer = setTimeout(runManifestDiscovery, interval);
+      }
+    };
+
+    // Start both loops
+    runDaemonPoll();
+    // Delay manifest discovery slightly so daemon data arrives first
+    manifestTimer = setTimeout(runManifestDiscovery, 2000);
+
+    // Timeout for initial connection
+    const timeout = setTimeout(() => {
+      if (
+        !hasReceivedDaemonDataRef.current &&
+        manifestMapRef.current.size === 0
+      ) {
+        setLoading(false);
+        setError(
+          "No data from daemon or nodes - check if bubbaloop-daemon is running",
+        );
+      }
+    }, 15_000);
+
+    return () => {
+      mounted = false;
+      clearTimeout(timeout);
+      if (daemonTimer) clearTimeout(daemonTimer);
+      if (manifestTimer) clearTimeout(manifestTimer);
+    };
+  }, [session, pollDaemon, discoverManifests, mergeNodes]);
+
+  // -----------------------------------------------------------------------
+  // Fleet reporting
+  // -----------------------------------------------------------------------
+  const { reportMachines, reportNodes } = useFleetContext();
+
+  const machineGroups = useMemo(() => {
+    const groups = new Map<
+      string,
+      {
+        hostname: string;
+        machineId: string;
+        nodes: DiscoveredNode[];
+        isOnline: boolean;
+      }
+    >();
+    for (const node of nodes) {
+      const mid = node.machine_id || "local";
+      if (!groups.has(mid)) {
+        groups.set(mid, {
+          hostname: node.machine_hostname || "local",
+          machineId: mid,
+          nodes: [],
+          isOnline: !node.stale,
+        });
+      }
+      groups.get(mid)!.nodes.push(node);
+    }
+    return Array.from(groups.values());
+  }, [nodes]);
+
+  useEffect(() => {
+    reportMachines(
+      machineGroups.map((g) => ({
+        machineId: g.machineId,
+        hostname: g.hostname,
+        nodeCount: g.nodes.length,
+        runningCount: g.nodes.filter((n) => n.status === "running").length,
+        isOnline: g.isOnline,
+        ips: g.nodes[0]?.machine_ips || [],
+      })),
+    );
+  }, [machineGroups, reportMachines]);
+
+  useEffect(() => {
+    reportNodes(
+      nodes.map((n) => ({
+        name: n.name,
+        status: n.status,
+        machineId: n.machine_id || "local",
+        hostname: n.machine_hostname || "local",
+        ips: n.machine_ips || [],
+        nodeType: n.node_type,
+        version: n.version,
+        baseNode: n.base_node || "",
+      })),
+    );
+  }, [nodes, reportNodes]);
+
+  // -----------------------------------------------------------------------
+  // Refresh (restarts both loops)
+  // -----------------------------------------------------------------------
+  const refresh = useCallback(() => {
+    refreshCounterRef.current++;
+    // Trigger re-mount of effect by bumping a dependency
+    // The effect depends on session, so we force it by clearing state
+    setLoading(true);
+    setError(null);
+    hasReceivedDaemonDataRef.current = false;
+    // The effect won't re-run just from state changes; we need the session
+    // to be the same. Instead, manually trigger a poll.
+    (async () => {
+      const daemonNodes = await pollDaemon();
+      await discoverManifests();
+      const allNodes = mergeNodes(daemonNodes, manifestMapRef.current);
+      setNodes(allNodes);
+      setLoading(false);
+    })();
+  }, [pollDaemon, discoverManifests, mergeNodes]);
+
+  // -----------------------------------------------------------------------
+  // Context value
+  // -----------------------------------------------------------------------
+  const value = useMemo<NodeDiscoveryContextValue>(
+    () => ({
+      nodes,
+      loading,
+      error,
+      daemonConnected,
+      manifestDiscoveryActive,
+      refresh,
+    }),
+    [nodes, loading, error, daemonConnected, manifestDiscoveryActive, refresh],
+  );
+
+  return (
+    <NodeDiscoveryContext.Provider value={value}>
+      {children}
+    </NodeDiscoveryContext.Provider>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useNodeDiscovery(): NodeDiscoveryContextValue {
+  return useContext(NodeDiscoveryContext);
+}

--- a/dashboard/src/contexts/__tests__/NodeDiscoveryContext.test.tsx
+++ b/dashboard/src/contexts/__tests__/NodeDiscoveryContext.test.tsx
@@ -1,0 +1,837 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { ReactNode } from 'react';
+import {
+  NodeDiscoveryProvider,
+  useNodeDiscovery,
+  type NodeManifest,
+  type DiscoveredNode,
+} from '../NodeDiscoveryContext';
+import { Reply, Sample, ReplyError } from '@eclipse-zenoh/zenoh-ts';
+
+// ============================================================================
+// Mocks
+// ============================================================================
+
+// Hoist mock functions so they can be referenced in vi.mock()
+const { mockReportMachines, mockReportNodes, mockDecodeNodeList, mockGetSamplePayload } =
+  vi.hoisted(() => ({
+    mockReportMachines: vi.fn(),
+    mockReportNodes: vi.fn(),
+    mockDecodeNodeList: vi.fn(),
+    mockGetSamplePayload: vi.fn(),
+  }));
+
+// Mock FleetContext
+vi.mock('../FleetContext', () => ({
+  useFleetContext: vi.fn(() => ({
+    reportMachines: mockReportMachines,
+    reportNodes: mockReportNodes,
+    machines: [],
+    nodes: [],
+    selectedMachineId: null,
+    setSelectedMachineId: vi.fn(),
+  })),
+}));
+
+// Mock proto/daemon
+vi.mock('../../proto/daemon', () => ({
+  decodeNodeList: mockDecodeNodeList,
+}));
+
+// Mock lib/zenoh
+vi.mock('../../lib/zenoh', () => ({
+  getSamplePayload: mockGetSamplePayload,
+}));
+
+// Mock typed-duration
+vi.mock('typed-duration', () => ({
+  Duration: {
+    milliseconds: {
+      of: (ms: number) => ms,
+    },
+  },
+}));
+
+// ============================================================================
+// Test Helpers
+// ============================================================================
+
+function createMockSession(responses: Map<string, Reply[]> = new Map()): any {
+  return {
+    get: vi.fn(async (keyexpr: string) => {
+      const replies = responses.get(keyexpr) || [];
+      return (async function* () {
+        for (const reply of replies) yield reply;
+      })();
+    }),
+    close: vi.fn(),
+    liveliness: vi.fn().mockReturnValue({
+      declare_subscriber: vi.fn().mockResolvedValue({ undeclare: vi.fn() }),
+    }),
+  };
+}
+
+function createMockSample(keyexpr: string, payload: Uint8Array): Sample {
+  return new Sample(keyexpr, payload);
+}
+
+function createMockReply(sample: Sample): Reply {
+  return new Reply(sample);
+}
+
+function createMockReplyError(): Reply {
+  return new Reply(undefined, new ReplyError('Mock error'));
+}
+
+function createNodeListPayload(nodes: any[], machineId = 'test-machine'): Uint8Array {
+  return new Uint8Array([1, 2, 3]); // Mock bytes
+}
+
+function createManifestPayload(manifest: NodeManifest): Uint8Array {
+  return new TextEncoder().encode(JSON.stringify(manifest));
+}
+
+function makeWrapper(session: any) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <NodeDiscoveryProvider session={session}>{children}</NodeDiscoveryProvider>;
+  };
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('NodeDiscoveryContext', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('useNodeDiscovery without provider', () => {
+    it('returns default context values', () => {
+      const { result } = renderHook(() => useNodeDiscovery());
+
+      expect(result.current.nodes).toEqual([]);
+      expect(result.current.loading).toBe(true);
+      expect(result.current.error).toBeNull();
+      expect(result.current.daemonConnected).toBe(false);
+      expect(result.current.manifestDiscoveryActive).toBe(false);
+      expect(result.current.refresh).toBeInstanceOf(Function);
+    });
+  });
+
+  describe('NodeDiscoveryProvider', () => {
+    describe('initialization', () => {
+      it('starts with loading=true and empty nodes', () => {
+        const session = createMockSession();
+        const wrapper = makeWrapper(session);
+
+        const { result } = renderHook(() => useNodeDiscovery(), { wrapper });
+
+        expect(result.current.loading).toBe(true);
+        expect(result.current.nodes).toEqual([]);
+      });
+
+      it('shows daemonConnected=false initially', () => {
+        const session = createMockSession();
+        const wrapper = makeWrapper(session);
+
+        const { result } = renderHook(() => useNodeDiscovery(), { wrapper });
+
+        expect(result.current.daemonConnected).toBe(false);
+      });
+
+      it('has manifestDiscoveryActive=false initially', () => {
+        const session = createMockSession();
+        const wrapper = makeWrapper(session);
+
+        const { result } = renderHook(() => useNodeDiscovery(), { wrapper });
+
+        expect(result.current.manifestDiscoveryActive).toBe(false);
+      });
+    });
+
+    describe('null session', () => {
+      it('resets all state when session is null', async () => {
+        const wrapper = makeWrapper(null);
+
+        const { result } = renderHook(() => useNodeDiscovery(), { wrapper });
+
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(100);
+        });
+
+        expect(result.current.nodes).toEqual([]);
+        expect(result.current.loading).toBe(true);
+        expect(result.current.error).toBeNull();
+        expect(result.current.daemonConnected).toBe(false);
+      });
+
+      it('sets loading=true with null session', () => {
+        const wrapper = makeWrapper(null);
+
+        const { result } = renderHook(() => useNodeDiscovery(), { wrapper });
+
+        expect(result.current.loading).toBe(true);
+      });
+    });
+
+    describe('daemon polling', () => {
+      it('queries bubbaloop/daemon/nodes when session available', async () => {
+        const mockGet = vi.fn(async () => (async function* () {})());
+        const session = { ...createMockSession(), get: mockGet };
+        const wrapper = makeWrapper(session);
+
+        renderHook(() => useNodeDiscovery(), { wrapper });
+
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(100);
+        });
+
+        expect(mockGet).toHaveBeenCalledWith('bubbaloop/daemon/nodes', { timeout: 5000 });
+      });
+
+      it('sets daemonConnected=true after receiving daemon data', async () => {
+        const nodeListData = createNodeListPayload([
+          {
+            name: 'camera-node',
+            path: '/path/to/camera',
+            status: 2, // running
+            installed: true,
+            autostartEnabled: true,
+            version: '1.0.0',
+            description: 'Camera node',
+            nodeType: 'camera',
+            isBuilt: true,
+            buildOutput: [],
+            machineId: 'machine-1',
+            machineHostname: 'host-1',
+            machineIps: ['192.168.1.1'],
+            baseNode: 'camera-base',
+          },
+        ]);
+
+        mockDecodeNodeList.mockReturnValue({
+          nodes: [
+            {
+              name: 'camera-node',
+              path: '/path/to/camera',
+              status: 2,
+              installed: true,
+              autostartEnabled: true,
+              version: '1.0.0',
+              description: 'Camera node',
+              nodeType: 'camera',
+              isBuilt: true,
+              buildOutput: [],
+              machineId: 'machine-1',
+              machineHostname: 'host-1',
+              machineIps: ['192.168.1.1'],
+              baseNode: 'camera-base',
+            },
+          ],
+          timestampMs: BigInt(Date.now()),
+          machineId: 'machine-1',
+        });
+
+        mockGetSamplePayload.mockReturnValue(nodeListData);
+
+        const sample = createMockSample('bubbaloop/daemon/nodes', nodeListData);
+        const reply = createMockReply(sample);
+        const responses = new Map([['bubbaloop/daemon/nodes', [reply]]]);
+        const session = createMockSession(responses);
+        const wrapper = makeWrapper(session);
+
+        const { result } = renderHook(() => useNodeDiscovery(), { wrapper });
+
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(100);
+        });
+
+        expect(result.current.daemonConnected).toBe(true);
+      });
+
+      it('maps protobuf status numbers to string status', async () => {
+        const nodeListData = createNodeListPayload([]);
+
+        mockDecodeNodeList.mockReturnValue({
+          nodes: [
+            {
+              name: 'stopped-node',
+              path: '/path/stopped',
+              status: 1,
+              installed: true,
+              autostartEnabled: false,
+              version: '1.0.0',
+              description: 'Stopped',
+              nodeType: 'test',
+              isBuilt: true,
+              buildOutput: [],
+              machineId: 'machine-1',
+              machineHostname: 'host-1',
+              machineIps: [],
+              baseNode: '',
+            },
+            {
+              name: 'running-node',
+              path: '/path/running',
+              status: 2,
+              installed: true,
+              autostartEnabled: true,
+              version: '1.0.0',
+              description: 'Running',
+              nodeType: 'test',
+              isBuilt: true,
+              buildOutput: [],
+              machineId: 'machine-1',
+              machineHostname: 'host-1',
+              machineIps: [],
+              baseNode: '',
+            },
+            {
+              name: 'failed-node',
+              path: '/path/failed',
+              status: 3,
+              installed: true,
+              autostartEnabled: false,
+              version: '1.0.0',
+              description: 'Failed',
+              nodeType: 'test',
+              isBuilt: true,
+              buildOutput: [],
+              machineId: 'machine-1',
+              machineHostname: 'host-1',
+              machineIps: [],
+              baseNode: '',
+            },
+          ],
+          timestampMs: BigInt(Date.now()),
+          machineId: 'machine-1',
+        });
+
+        mockGetSamplePayload.mockReturnValue(nodeListData);
+
+        const sample = createMockSample('bubbaloop/daemon/nodes', nodeListData);
+        const reply = createMockReply(sample);
+        const responses = new Map([['bubbaloop/daemon/nodes', [reply]]]);
+        const session = createMockSession(responses);
+        const wrapper = makeWrapper(session);
+
+        const { result } = renderHook(() => useNodeDiscovery(), { wrapper });
+
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(100);
+        });
+
+        expect(result.current.nodes).toHaveLength(3);
+        expect(result.current.nodes[0].status).toBe('stopped');
+        expect(result.current.nodes[1].status).toBe('running');
+        expect(result.current.nodes[2].status).toBe('failed');
+      });
+
+      it('handles empty daemon response gracefully', async () => {
+        mockDecodeNodeList.mockReturnValue({
+          nodes: [],
+          timestampMs: BigInt(Date.now()),
+          machineId: 'machine-1',
+        });
+
+        const nodeListData = createNodeListPayload([]);
+        mockGetSamplePayload.mockReturnValue(nodeListData);
+
+        const sample = createMockSample('bubbaloop/daemon/nodes', nodeListData);
+        const reply = createMockReply(sample);
+        const responses = new Map([['bubbaloop/daemon/nodes', [reply]]]);
+        const session = createMockSession(responses);
+        const wrapper = makeWrapper(session);
+
+        const { result } = renderHook(() => useNodeDiscovery(), { wrapper });
+
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(100);
+        });
+
+        // Should not crash, but won't set daemonConnected since no nodes
+        expect(result.current.nodes).toEqual([]);
+      });
+
+      it('handles daemon poll error without crashing', async () => {
+        const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        mockDecodeNodeList.mockReturnValue(null);
+
+        const nodeListData = createNodeListPayload([]);
+        mockGetSamplePayload.mockReturnValue(nodeListData);
+
+        const errorReply = createMockReplyError();
+        const responses = new Map([['bubbaloop/daemon/nodes', [errorReply]]]);
+        const session = createMockSession(responses);
+        const wrapper = makeWrapper(session);
+
+        const { result } = renderHook(() => useNodeDiscovery(), { wrapper });
+
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(100);
+        });
+
+        // Should not crash
+        expect(result.current.nodes).toEqual([]);
+
+        consoleWarnSpy.mockRestore();
+      });
+    });
+
+    describe('manifest discovery', () => {
+      it('queries bubbaloop/**/manifest for node discovery', async () => {
+        const mockGet = vi.fn(async () => (async function* () {})());
+        const session = { ...createMockSession(), get: mockGet };
+        const wrapper = makeWrapper(session);
+
+        renderHook(() => useNodeDiscovery(), { wrapper });
+
+        // Wait for manifest discovery to start (2s delay + 100ms buffer)
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(2100);
+        });
+
+        expect(mockGet).toHaveBeenCalledWith('bubbaloop/**/manifest', { timeout: 5000 });
+      });
+
+      it('parses manifest JSON from zenoh replies', async () => {
+        const manifest: NodeManifest = {
+          name: 'camera-node',
+          version: '1.0.0',
+          language: 'rust',
+          description: 'Camera node',
+          machine_id: 'machine-1',
+          scope: 'machine',
+          capabilities: ['vision'],
+          requires_hardware: ['camera'],
+          publishes: [
+            {
+              topic_suffix: 'frames',
+              full_topic: 'bubbaloop/camera-node/frames',
+              rate_hz: 30,
+            },
+          ],
+          subscribes: [],
+          schema_key: 'bubbaloop/camera-node/schema',
+          health_key: 'bubbaloop/camera-node/health',
+          config_key: 'bubbaloop/camera-node/config',
+          security: {
+            acl_prefix: 'bubbaloop/camera',
+            data_classification: 'public',
+          },
+          time: {
+            clock_source: 'system',
+            timestamp_field: 'timestamp',
+            timestamp_unit: 'ms',
+          },
+        };
+
+        const manifestData = createManifestPayload(manifest);
+        const sample = createMockSample('bubbaloop/camera-node/manifest', manifestData);
+        const reply = createMockReply(sample);
+
+        mockGetSamplePayload.mockReturnValue(manifestData);
+
+        const responses = new Map([['bubbaloop/**/manifest', [reply]]]);
+        const session = createMockSession(responses);
+        const wrapper = makeWrapper(session);
+
+        const { result } = renderHook(() => useNodeDiscovery(), { wrapper });
+
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(2100);
+        });
+
+        // Should have manifest-only node
+        expect(result.current.nodes).toHaveLength(1);
+        expect(result.current.nodes[0].name).toBe('camera-node');
+        expect(result.current.nodes[0].manifest).toEqual(manifest);
+      });
+
+      it('handles invalid manifest JSON gracefully', async () => {
+        const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        const invalidData = new TextEncoder().encode('not valid json {');
+        const sample = createMockSample('bubbaloop/invalid/manifest', invalidData);
+        const reply = createMockReply(sample);
+
+        mockGetSamplePayload.mockReturnValue(invalidData);
+
+        const responses = new Map([['bubbaloop/**/manifest', [reply]]]);
+        const session = createMockSession(responses);
+        const wrapper = makeWrapper(session);
+
+        const { result } = renderHook(() => useNodeDiscovery(), { wrapper });
+
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(2100);
+        });
+
+        // Should not crash
+        expect(result.current.nodes).toEqual([]);
+
+        consoleWarnSpy.mockRestore();
+      });
+    });
+
+    describe('node merging', () => {
+      it('marks daemon-only nodes as discoveredVia=daemon', async () => {
+        const nodeListData = createNodeListPayload([]);
+
+        mockDecodeNodeList.mockReturnValue({
+          nodes: [
+            {
+              name: 'daemon-only',
+              path: '/path/daemon',
+              status: 2,
+              installed: true,
+              autostartEnabled: true,
+              version: '1.0.0',
+              description: 'Daemon only',
+              nodeType: 'test',
+              isBuilt: true,
+              buildOutput: [],
+              machineId: 'machine-1',
+              machineHostname: 'host-1',
+              machineIps: [],
+              baseNode: '',
+            },
+          ],
+          timestampMs: BigInt(Date.now()),
+          machineId: 'machine-1',
+        });
+
+        mockGetSamplePayload.mockReturnValue(nodeListData);
+
+        const sample = createMockSample('bubbaloop/daemon/nodes', nodeListData);
+        const reply = createMockReply(sample);
+        const responses = new Map([['bubbaloop/daemon/nodes', [reply]]]);
+        const session = createMockSession(responses);
+        const wrapper = makeWrapper(session);
+
+        const { result } = renderHook(() => useNodeDiscovery(), { wrapper });
+
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(100);
+        });
+
+        expect(result.current.nodes).toHaveLength(1);
+        expect(result.current.nodes[0].discoveredVia).toBe('daemon');
+      });
+
+      it('marks manifest-only nodes as discoveredVia=manifest with status=unknown', async () => {
+        const manifest: NodeManifest = {
+          name: 'manifest-only',
+          version: '1.0.0',
+          language: 'python',
+          description: 'Manifest only',
+          machine_id: 'machine-1',
+          scope: 'machine',
+          capabilities: [],
+          requires_hardware: [],
+          publishes: [],
+          subscribes: [],
+          schema_key: '',
+          health_key: '',
+          config_key: '',
+          security: { acl_prefix: '', data_classification: '' },
+          time: { clock_source: '', timestamp_field: '', timestamp_unit: '' },
+        };
+
+        const manifestData = createManifestPayload(manifest);
+        const sample = createMockSample('bubbaloop/manifest-only/manifest', manifestData);
+        const reply = createMockReply(sample);
+
+        mockGetSamplePayload.mockReturnValue(manifestData);
+
+        const responses = new Map([['bubbaloop/**/manifest', [reply]]]);
+        const session = createMockSession(responses);
+        const wrapper = makeWrapper(session);
+
+        const { result } = renderHook(() => useNodeDiscovery(), { wrapper });
+
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(2100);
+        });
+
+        expect(result.current.nodes).toHaveLength(1);
+        expect(result.current.nodes[0].discoveredVia).toBe('manifest');
+        expect(result.current.nodes[0].status).toBe('unknown');
+      });
+
+      it('marks nodes found in both as discoveredVia=both', async () => {
+        const nodeName = 'combined-node';
+        const machineId = 'machine-1';
+
+        // Daemon response
+        const nodeListData = createNodeListPayload([]);
+        mockDecodeNodeList.mockReturnValue({
+          nodes: [
+            {
+              name: nodeName,
+              path: '/path/combined',
+              status: 2,
+              installed: true,
+              autostartEnabled: true,
+              version: '1.0.0',
+              description: 'Combined',
+              nodeType: 'test',
+              isBuilt: true,
+              buildOutput: [],
+              machineId,
+              machineHostname: 'host-1',
+              machineIps: [],
+              baseNode: '',
+            },
+          ],
+          timestampMs: BigInt(Date.now()),
+          machineId,
+        });
+        mockGetSamplePayload.mockReturnValueOnce(nodeListData);
+
+        // Manifest response
+        const manifest: NodeManifest = {
+          name: nodeName,
+          version: '1.0.0',
+          language: 'rust',
+          description: 'Combined manifest',
+          machine_id: machineId,
+          scope: 'machine',
+          capabilities: [],
+          requires_hardware: [],
+          publishes: [],
+          subscribes: [],
+          schema_key: '',
+          health_key: '',
+          config_key: '',
+          security: { acl_prefix: '', data_classification: '' },
+          time: { clock_source: '', timestamp_field: '', timestamp_unit: '' },
+        };
+        const manifestData = createManifestPayload(manifest);
+        mockGetSamplePayload.mockReturnValueOnce(manifestData);
+
+        const daemonSample = createMockSample('bubbaloop/daemon/nodes', nodeListData);
+        const daemonReply = createMockReply(daemonSample);
+
+        const manifestSample = createMockSample(
+          `bubbaloop/${nodeName}/manifest`,
+          manifestData
+        );
+        const manifestReply = createMockReply(manifestSample);
+
+        const responses = new Map([
+          ['bubbaloop/daemon/nodes', [daemonReply]],
+          ['bubbaloop/**/manifest', [manifestReply]],
+        ]);
+
+        const session = createMockSession(responses);
+        const wrapper = makeWrapper(session);
+
+        const { result } = renderHook(() => useNodeDiscovery(), { wrapper });
+
+        // Let daemon poll run
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(100);
+        });
+
+        // Let manifest discovery run
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(2100);
+        });
+
+        expect(result.current.nodes).toHaveLength(1);
+        expect(result.current.nodes[0].discoveredVia).toBe('both');
+        expect(result.current.nodes[0].manifest).toEqual(manifest);
+      });
+    });
+
+    describe('fleet reporting', () => {
+      it('calls reportMachines with machine groups', async () => {
+        const nodeListData = createNodeListPayload([]);
+
+        mockDecodeNodeList.mockReturnValue({
+          nodes: [
+            {
+              name: 'node-1',
+              path: '/path/1',
+              status: 2,
+              installed: true,
+              autostartEnabled: true,
+              version: '1.0.0',
+              description: 'Node 1',
+              nodeType: 'test',
+              isBuilt: true,
+              buildOutput: [],
+              machineId: 'machine-1',
+              machineHostname: 'host-1',
+              machineIps: ['192.168.1.1'],
+              baseNode: '',
+            },
+            {
+              name: 'node-2',
+              path: '/path/2',
+              status: 1,
+              installed: true,
+              autostartEnabled: false,
+              version: '1.0.0',
+              description: 'Node 2',
+              nodeType: 'test',
+              isBuilt: true,
+              buildOutput: [],
+              machineId: 'machine-1',
+              machineHostname: 'host-1',
+              machineIps: ['192.168.1.1'],
+              baseNode: '',
+            },
+          ],
+          timestampMs: BigInt(Date.now()),
+          machineId: 'machine-1',
+        });
+
+        mockGetSamplePayload.mockReturnValue(nodeListData);
+
+        const sample = createMockSample('bubbaloop/daemon/nodes', nodeListData);
+        const reply = createMockReply(sample);
+        const responses = new Map([['bubbaloop/daemon/nodes', [reply]]]);
+        const session = createMockSession(responses);
+        const wrapper = makeWrapper(session);
+
+        renderHook(() => useNodeDiscovery(), { wrapper });
+
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(100);
+        });
+
+        // Give React time to flush effects (not timer-based)
+        await act(async () => {
+          await Promise.resolve();
+        });
+
+        expect(mockReportMachines).toHaveBeenCalled();
+
+        const call = mockReportMachines.mock.calls[mockReportMachines.mock.calls.length - 1];
+        const machines = call[0];
+
+        expect(machines).toHaveLength(1);
+        expect(machines[0]).toMatchObject({
+          machineId: 'machine-1',
+          hostname: 'host-1',
+          nodeCount: 2,
+          runningCount: 1,
+          isOnline: true,
+          ips: ['192.168.1.1'],
+        });
+      });
+
+      it('calls reportNodes with all discovered nodes', async () => {
+        const nodeListData = createNodeListPayload([]);
+
+        mockDecodeNodeList.mockReturnValue({
+          nodes: [
+            {
+              name: 'test-node',
+              path: '/path/test',
+              status: 2,
+              installed: true,
+              autostartEnabled: true,
+              version: '1.0.0',
+              description: 'Test',
+              nodeType: 'test',
+              isBuilt: true,
+              buildOutput: [],
+              machineId: 'machine-1',
+              machineHostname: 'host-1',
+              machineIps: ['192.168.1.1'],
+              baseNode: 'test-base',
+            },
+          ],
+          timestampMs: BigInt(Date.now()),
+          machineId: 'machine-1',
+        });
+
+        mockGetSamplePayload.mockReturnValue(nodeListData);
+
+        const sample = createMockSample('bubbaloop/daemon/nodes', nodeListData);
+        const reply = createMockReply(sample);
+        const responses = new Map([['bubbaloop/daemon/nodes', [reply]]]);
+        const session = createMockSession(responses);
+        const wrapper = makeWrapper(session);
+
+        renderHook(() => useNodeDiscovery(), { wrapper });
+
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(100);
+        });
+
+        // Give React time to flush effects (not timer-based)
+        await act(async () => {
+          await Promise.resolve();
+        });
+
+        expect(mockReportNodes).toHaveBeenCalled();
+
+        const call = mockReportNodes.mock.calls[mockReportNodes.mock.calls.length - 1];
+        const nodes = call[0];
+
+        expect(nodes).toHaveLength(1);
+        expect(nodes[0]).toMatchObject({
+          name: 'test-node',
+          status: 'running',
+          machineId: 'machine-1',
+          hostname: 'host-1',
+          ips: ['192.168.1.1'],
+          nodeType: 'test',
+          version: '1.0.0',
+          baseNode: 'test-base',
+        });
+      });
+    });
+
+    describe('refresh', () => {
+      it('refresh function is callable', async () => {
+        const session = createMockSession();
+        const wrapper = makeWrapper(session);
+
+        const { result } = renderHook(() => useNodeDiscovery(), { wrapper });
+
+        await act(async () => {
+          result.current.refresh();
+        });
+
+        expect(result.current.refresh).toBeInstanceOf(Function);
+      });
+
+      it('refresh triggers new polls', async () => {
+        const mockGet = vi.fn(async () => (async function* () {})());
+        const session = { ...createMockSession(), get: mockGet };
+        const wrapper = makeWrapper(session);
+
+        const { result } = renderHook(() => useNodeDiscovery(), { wrapper });
+
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(100);
+        });
+
+        const callCountBefore = mockGet.mock.calls.length;
+
+        await act(async () => {
+          result.current.refresh();
+          await vi.advanceTimersByTimeAsync(100);
+        });
+
+        const callCountAfter = mockGet.mock.calls.length;
+
+        // Refresh should trigger new queries
+        expect(callCountAfter).toBeGreaterThan(callCountBefore);
+      });
+    });
+  });
+});

--- a/dashboard/src/hooks/__tests__/useLiveliness.test.ts
+++ b/dashboard/src/hooks/__tests__/useLiveliness.test.ts
@@ -1,0 +1,344 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useLiveliness } from '../useLiveliness';
+
+function createMockSession(): any {
+  return {
+    declareSubscriber: vi.fn().mockResolvedValue({ undeclare: vi.fn() }),
+    get: vi.fn().mockResolvedValue((async function* () {})()),
+    put: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn().mockResolvedValue(undefined),
+    liveliness: vi.fn().mockReturnValue({
+      declare_subscriber: vi.fn().mockResolvedValue({ undeclare: vi.fn() }),
+      declare_token: vi.fn().mockResolvedValue({ undeclare: vi.fn() }),
+      get: vi.fn().mockResolvedValue((async function* () {})()),
+    }),
+  };
+}
+
+describe('useLiveliness', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('initializes with empty state', () => {
+    const mockSession = createMockSession();
+    const { result } = renderHook(() => useLiveliness(mockSession));
+
+    expect(result.current.aliveNodes).toBeInstanceOf(Set);
+    expect(result.current.aliveNodes.size).toBe(0);
+    expect(result.current.events).toEqual([]);
+  });
+
+  it('handles null session gracefully', () => {
+    const { result } = renderHook(() => useLiveliness(null));
+
+    expect(result.current.aliveNodes).toBeInstanceOf(Set);
+    expect(result.current.aliveNodes.size).toBe(0);
+    expect(result.current.events).toEqual([]);
+  });
+
+  it('gracefully handles missing liveliness API', async () => {
+    const mockSession = createMockSession();
+    // Remove liveliness API to simulate older zenoh-ts version
+    (mockSession as any).liveliness = undefined;
+
+    const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const { result } = renderHook(() => useLiveliness(mockSession));
+
+    // Wait for async setup to complete
+    await waitFor(() => {
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        '[Liveliness] API not available in this zenoh-ts version'
+      );
+    });
+
+    expect(result.current.aliveNodes.size).toBe(0);
+    expect(result.current.events).toEqual([]);
+  });
+
+  it('subscribes to bubbaloop/** when session is available', async () => {
+    const mockSession = createMockSession();
+    const mockSubscriber = { undeclare: vi.fn() };
+    const declareSubscriberSpy = vi.fn().mockResolvedValue(mockSubscriber);
+
+    (mockSession as any).liveliness = () => ({
+      declare_subscriber: declareSubscriberSpy,
+    });
+
+    renderHook(() => useLiveliness(mockSession));
+
+    await waitFor(() => {
+      expect(declareSubscriberSpy).toHaveBeenCalledWith('bubbaloop/**', {
+        callback: expect.any(Function),
+      });
+    });
+  });
+
+  it('tracks join events and adds to aliveNodes', async () => {
+    const mockSession = createMockSession();
+    let capturedCallback: ((sample: any) => void) | undefined;
+
+    (mockSession as any).liveliness = () => ({
+      declare_subscriber: vi.fn().mockImplementation((_topic: string, options: any) => {
+        capturedCallback = options.callback;
+        return Promise.resolve({ undeclare: vi.fn() });
+      }),
+    });
+
+    const { result } = renderHook(() => useLiveliness(mockSession));
+
+    // Wait for subscription to be set up
+    await waitFor(() => {
+      expect(capturedCallback).toBeDefined();
+    });
+
+    // Simulate a join event
+    act(() => {
+      capturedCallback!({
+        keyexpr: { toString: () => 'bubbaloop/node1' },
+        kind: 'PUT',
+      });
+    });
+
+    expect(result.current.aliveNodes.has('bubbaloop/node1')).toBe(true);
+    expect(result.current.events).toHaveLength(1);
+    expect(result.current.events[0]).toMatchObject({
+      keyExpr: 'bubbaloop/node1',
+      type: 'join',
+    });
+  });
+
+  it('tracks leave events and removes from aliveNodes', async () => {
+    const mockSession = createMockSession();
+    let capturedCallback: ((sample: any) => void) | undefined;
+
+    (mockSession as any).liveliness = () => ({
+      declare_subscriber: vi.fn().mockImplementation((_topic: string, options: any) => {
+        capturedCallback = options.callback;
+        return Promise.resolve({ undeclare: vi.fn() });
+      }),
+    });
+
+    const { result } = renderHook(() => useLiveliness(mockSession));
+
+    await waitFor(() => {
+      expect(capturedCallback).toBeDefined();
+    });
+
+    // Join first
+    act(() => {
+      capturedCallback!({
+        keyexpr: { toString: () => 'bubbaloop/node1' },
+        kind: 'PUT',
+      });
+    });
+
+    expect(result.current.aliveNodes.has('bubbaloop/node1')).toBe(true);
+
+    // Then leave
+    act(() => {
+      capturedCallback!({
+        keyexpr: { toString: () => 'bubbaloop/node1' },
+        kind: 'DELETE',
+      });
+    });
+
+    expect(result.current.aliveNodes.has('bubbaloop/node1')).toBe(false);
+    expect(result.current.events).toHaveLength(2);
+    expect(result.current.events[1]).toMatchObject({
+      keyExpr: 'bubbaloop/node1',
+      type: 'leave',
+    });
+  });
+
+  it('calls onNodeJoin callback when node joins', async () => {
+    const mockSession = createMockSession();
+    let capturedCallback: ((sample: any) => void) | undefined;
+    const onNodeJoin = vi.fn();
+
+    (mockSession as any).liveliness = () => ({
+      declare_subscriber: vi.fn().mockImplementation((_topic: string, options: any) => {
+        capturedCallback = options.callback;
+        return Promise.resolve({ undeclare: vi.fn() });
+      }),
+    });
+
+    renderHook(() => useLiveliness(mockSession, onNodeJoin));
+
+    await waitFor(() => {
+      expect(capturedCallback).toBeDefined();
+    });
+
+    act(() => {
+      capturedCallback!({
+        keyexpr: { toString: () => 'bubbaloop/camera' },
+        kind: 'PUT',
+      });
+    });
+
+    expect(onNodeJoin).toHaveBeenCalledWith('bubbaloop/camera');
+  });
+
+  it('calls onNodeLeave callback when node leaves', async () => {
+    const mockSession = createMockSession();
+    let capturedCallback: ((sample: any) => void) | undefined;
+    const onNodeLeave = vi.fn();
+
+    (mockSession as any).liveliness = () => ({
+      declare_subscriber: vi.fn().mockImplementation((_topic: string, options: any) => {
+        capturedCallback = options.callback;
+        return Promise.resolve({ undeclare: vi.fn() });
+      }),
+    });
+
+    renderHook(() => useLiveliness(mockSession, undefined, onNodeLeave));
+
+    await waitFor(() => {
+      expect(capturedCallback).toBeDefined();
+    });
+
+    act(() => {
+      capturedCallback!({
+        keyexpr: { toString: () => 'bubbaloop/weather' },
+        kind: 'DELETE',
+      });
+    });
+
+    expect(onNodeLeave).toHaveBeenCalledWith('bubbaloop/weather');
+  });
+
+  it('keeps last 100 events only', async () => {
+    const mockSession = createMockSession();
+    let capturedCallback: ((sample: any) => void) | undefined;
+
+    (mockSession as any).liveliness = () => ({
+      declare_subscriber: vi.fn().mockImplementation((_topic: string, options: any) => {
+        capturedCallback = options.callback;
+        return Promise.resolve({ undeclare: vi.fn() });
+      }),
+    });
+
+    const { result } = renderHook(() => useLiveliness(mockSession));
+
+    await waitFor(() => {
+      expect(capturedCallback).toBeDefined();
+    });
+
+    // Simulate 150 events
+    act(() => {
+      for (let i = 0; i < 150; i++) {
+        capturedCallback!({
+          keyexpr: { toString: () => `bubbaloop/node${i}` },
+          kind: 'PUT',
+        });
+      }
+    });
+
+    expect(result.current.events).toHaveLength(100);
+    // First event should be node50 (events 0-49 were dropped)
+    expect(result.current.events[0].keyExpr).toBe('bubbaloop/node50');
+  });
+
+  it('handles alternative keyExpr accessor (key_expr)', async () => {
+    const mockSession = createMockSession();
+    let capturedCallback: ((sample: any) => void) | undefined;
+
+    (mockSession as any).liveliness = () => ({
+      declare_subscriber: vi.fn().mockImplementation((_topic: string, options: any) => {
+        capturedCallback = options.callback;
+        return Promise.resolve({ undeclare: vi.fn() });
+      }),
+    });
+
+    const { result } = renderHook(() => useLiveliness(mockSession));
+
+    await waitFor(() => {
+      expect(capturedCallback).toBeDefined();
+    });
+
+    // Use key_expr instead of keyexpr
+    act(() => {
+      capturedCallback!({
+        key_expr: { toString: () => 'bubbaloop/alternative' },
+        kind: 'PUT',
+      });
+    });
+
+    expect(result.current.aliveNodes.has('bubbaloop/alternative')).toBe(true);
+  });
+
+  it('undeclares subscriber on unmount', async () => {
+    const mockSession = createMockSession();
+    const undeclareSpy = vi.fn();
+
+    (mockSession as any).liveliness = () => ({
+      declare_subscriber: vi.fn().mockResolvedValue({
+        undeclare: undeclareSpy,
+      }),
+    });
+
+    const { unmount } = renderHook(() => useLiveliness(mockSession));
+
+    await waitFor(() => {
+      expect(undeclareSpy).not.toHaveBeenCalled();
+    });
+
+    unmount();
+
+    expect(undeclareSpy).toHaveBeenCalled();
+  });
+
+  it('handles errors during setup gracefully', async () => {
+    const mockSession = createMockSession();
+    const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    (mockSession as any).liveliness = () => ({
+      declare_subscriber: vi.fn().mockRejectedValue(new Error('Connection failed')),
+    });
+
+    const { result } = renderHook(() => useLiveliness(mockSession));
+
+    await waitFor(() => {
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        '[Liveliness] Not supported:',
+        expect.any(Error)
+      );
+    });
+
+    expect(result.current.aliveNodes.size).toBe(0);
+    expect(result.current.events).toEqual([]);
+  });
+
+  it('does not re-subscribe when callbacks change', async () => {
+    const mockSession = createMockSession();
+    const declareSubscriberSpy = vi.fn().mockResolvedValue({ undeclare: vi.fn() });
+
+    (mockSession as any).liveliness = () => ({
+      declare_subscriber: declareSubscriberSpy,
+    });
+
+    const onJoin1 = vi.fn();
+    const onJoin2 = vi.fn();
+
+    const { rerender } = renderHook(
+      ({ onJoin }) => useLiveliness(mockSession, onJoin),
+      { initialProps: { onJoin: onJoin1 } }
+    );
+
+    await waitFor(() => {
+      expect(declareSubscriberSpy).toHaveBeenCalledTimes(1);
+    });
+
+    // Change callback
+    rerender({ onJoin: onJoin2 });
+
+    // Should not re-subscribe
+    expect(declareSubscriberSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/dashboard/src/hooks/__tests__/useSchemaReady.test.ts
+++ b/dashboard/src/hooks/__tests__/useSchemaReady.test.ts
@@ -1,0 +1,42 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+const _mockState = vi.hoisted(() => ({ schemaVersion: 0 }));
+
+vi.mock('../../contexts/SchemaRegistryContext', () => ({
+  useSchemaRegistry: () => ({
+    registry: {},
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+    decode: vi.fn(),
+    discoverForTopic: vi.fn(),
+    schemaVersion: _mockState.schemaVersion,
+  }),
+}));
+
+import { useSchemaReady } from '../useSchemaReady';
+
+describe('useSchemaReady', () => {
+  beforeEach(() => {
+    _mockState.schemaVersion = 0;
+  });
+
+  it('returns false when schemaVersion is 0', () => {
+    _mockState.schemaVersion = 0;
+    const { result } = renderHook(() => useSchemaReady());
+    expect(result.current).toBe(false);
+  });
+
+  it('returns true when schemaVersion > 0', () => {
+    _mockState.schemaVersion = 1;
+    const { result } = renderHook(() => useSchemaReady());
+    expect(result.current).toBe(true);
+  });
+
+  it('returns true when schemaVersion is greater than 1', () => {
+    _mockState.schemaVersion = 5;
+    const { result } = renderHook(() => useSchemaReady());
+    expect(result.current).toBe(true);
+  });
+});

--- a/dashboard/src/hooks/useLiveliness.ts
+++ b/dashboard/src/hooks/useLiveliness.ts
@@ -1,0 +1,104 @@
+import { useEffect, useRef, useState } from "react";
+import { Session } from "@eclipse-zenoh/zenoh-ts";
+
+export interface LivelinessEvent {
+  keyExpr: string;
+  type: "join" | "leave";
+  timestamp: number;
+}
+
+export interface LivelinessState {
+  aliveNodes: Set<string>;
+  events: LivelinessEvent[];
+}
+
+/**
+ * Hook that subscribes to Zenoh liveliness changes for instant node detection.
+ * Falls back gracefully if liveliness API is not available.
+ */
+export function useLiveliness(
+  session: Session | null,
+  onNodeJoin?: (keyExpr: string) => void,
+  onNodeLeave?: (keyExpr: string) => void,
+): LivelinessState {
+  const [aliveNodes, setAliveNodes] = useState<Set<string>>(new Set());
+  const [events, setEvents] = useState<LivelinessEvent[]>([]);
+  const onNodeJoinRef = useRef(onNodeJoin);
+  const onNodeLeaveRef = useRef(onNodeLeave);
+
+  // Keep callback refs updated without triggering re-subscription
+  useEffect(() => {
+    onNodeJoinRef.current = onNodeJoin;
+  }, [onNodeJoin]);
+
+  useEffect(() => {
+    onNodeLeaveRef.current = onNodeLeave;
+  }, [onNodeLeave]);
+
+  useEffect(() => {
+    if (!session) return;
+
+    let cleanup: (() => void) | undefined;
+
+    // Try to subscribe to liveliness
+    const setupLiveliness = async () => {
+      try {
+        // Check if liveliness API exists on session
+        const livelinessApi = (session as any).liveliness?.();
+        if (!livelinessApi) {
+          console.log(
+            "[Liveliness] API not available in this zenoh-ts version",
+          );
+          return;
+        }
+
+        const subscriber = await livelinessApi.declare_subscriber(
+          "bubbaloop/**",
+          {
+            callback: (sample: any) => {
+              const keyExpr =
+                sample.key_expr?.toString?.() ||
+                sample.keyexpr?.toString?.() ||
+                "";
+              const kind = sample.kind; // PUT = join, DELETE = leave
+
+              const event: LivelinessEvent = {
+                keyExpr,
+                type: kind === "DELETE" ? "leave" : "join",
+                timestamp: Date.now(),
+              };
+
+              setEvents((prev) => [...prev.slice(-99), event]); // Keep last 100 events
+
+              if (event.type === "join") {
+                setAliveNodes((prev) => {
+                  const next = new Set(prev);
+                  next.add(keyExpr);
+                  return next;
+                });
+                onNodeJoinRef.current?.(keyExpr);
+              } else {
+                setAliveNodes((prev) => {
+                  const next = new Set(prev);
+                  next.delete(keyExpr);
+                  return next;
+                });
+                onNodeLeaveRef.current?.(keyExpr);
+              }
+            },
+          },
+        );
+
+        cleanup = () => subscriber?.undeclare?.();
+      } catch (e) {
+        console.log("[Liveliness] Not supported:", e);
+      }
+    };
+
+    setupLiveliness();
+
+    return () => cleanup?.();
+  }, [session]);
+
+  return { aliveNodes, events };
+}

--- a/dashboard/src/hooks/useSchemaReady.ts
+++ b/dashboard/src/hooks/useSchemaReady.ts
@@ -1,0 +1,10 @@
+import { useSchemaRegistry } from '../contexts/SchemaRegistryContext';
+
+/**
+ * Returns true once schemas have loaded at least once (schemaVersion > 0).
+ * Components can use this to gate subscriptions or know when decode is possible.
+ */
+export function useSchemaReady(): boolean {
+  const { schemaVersion } = useSchemaRegistry();
+  return schemaVersion > 0;
+}

--- a/dashboard/src/lib/__tests__/schema-registry.test.ts
+++ b/dashboard/src/lib/__tests__/schema-registry.test.ts
@@ -192,6 +192,47 @@ describe('extractTopicPrefix', () => {
       expect(extractTopicPrefix('')).toBe(null);
     });
   });
+
+  describe('ros-z new format (slash-preserved)', () => {
+    it('extracts prefix from new format camera topic', () => {
+      const topic = '0/bubbaloop/local/nvidia_orin00/camera/entrance/compressed/bubbaloop.camera.v1.Image/RIHS01_abc';
+      expect(extractTopicPrefix(topic)).toBe('bubbaloop/local/nvidia_orin00/camera');
+    });
+
+    it('extracts prefix from new format telemetry topic', () => {
+      const topic = '0/bubbaloop/local/m1/system_telemetry/metrics/bubbaloop.system_telemetry.v1.SystemMetrics/RIHS01_xyz';
+      expect(extractTopicPrefix(topic)).toBe('bubbaloop/local/m1/system_telemetry');
+    });
+
+    it('extracts prefix from new format weather topic', () => {
+      const topic = '42/bubbaloop/dev/orin_dev01/weather/current/type/hash';
+      expect(extractTopicPrefix(topic)).toBe('bubbaloop/dev/orin_dev01/weather');
+    });
+
+    it('returns null for new format without bubbaloop prefix', () => {
+      const topic = '0/other/local/m1/node/output';
+      expect(extractTopicPrefix(topic)).toBe(null);
+    });
+
+    it('returns null for new format with too few segments', () => {
+      const topic = '0/bubbaloop/local/m1';
+      expect(extractTopicPrefix(topic)).toBe(null);
+    });
+  });
+
+  describe('format equivalence', () => {
+    it('old and new format extract same prefix for camera topic', () => {
+      const oldTopic = '0/bubbaloop%local%nvidia_orin00%camera%entrance%compressed/Type/RIHS123';
+      const newTopic = '0/bubbaloop/local/nvidia_orin00/camera/entrance/compressed/Type/RIHS123';
+      expect(extractTopicPrefix(oldTopic)).toBe(extractTopicPrefix(newTopic));
+    });
+
+    it('old and new format extract same prefix for telemetry topic', () => {
+      const oldTopic = '0/bubbaloop%production%jetson_nano%system_telemetry%metrics/Type/Hash';
+      const newTopic = '0/bubbaloop/production/jetson_nano/system_telemetry/metrics/Type/Hash';
+      expect(extractTopicPrefix(oldTopic)).toBe(extractTopicPrefix(newTopic));
+    });
+  });
 });
 
 describe('extractMachineId', () => {

--- a/dashboard/src/lib/__tests__/status-enum-consistency.test.ts
+++ b/dashboard/src/lib/__tests__/status-enum-consistency.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { STATUS_MAP, statusNumberToString } from '../../components/NodesView';
+
+/**
+ * Status enum consistency test — CONTRACT: proto/daemon.ts + Rust zenoh_api.rs
+ *
+ * Ensures that the dashboard STATUS_MAP matches the proto NodeStatus enum.
+ * If the proto enum changes, update:
+ * - Rust: zenoh_api.rs::status_to_string()
+ * - Dashboard: NodesView.tsx::STATUS_MAP
+ */
+describe('Status enum consistency', () => {
+  it('handles all proto NodeStatus enum values (0-6)', () => {
+    // Proto enum values from daemon.proto:
+    // NODE_STATUS_UNKNOWN = 0
+    // NODE_STATUS_STOPPED = 1
+    // NODE_STATUS_RUNNING = 2
+    // NODE_STATUS_FAILED = 3
+    // NODE_STATUS_INSTALLING = 4
+    // NODE_STATUS_BUILDING = 5
+    // NODE_STATUS_NOT_INSTALLED = 6
+
+    expect(statusNumberToString(0)).toBe('unknown');
+    expect(statusNumberToString(1)).toBe('stopped');
+    expect(statusNumberToString(2)).toBe('running');
+    expect(statusNumberToString(3)).toBe('failed');
+    expect(statusNumberToString(4)).toBe('installing');
+    expect(statusNumberToString(5)).toBe('building');
+    expect(statusNumberToString(6)).toBe('not-installed');
+  });
+
+  it('returns "unknown" for unknown status values', () => {
+    expect(statusNumberToString(7)).toBe('unknown');
+    expect(statusNumberToString(-1)).toBe('unknown');
+    expect(statusNumberToString(100)).toBe('unknown');
+  });
+
+  it('STATUS_MAP contains exactly 6 entries (1-6)', () => {
+    // 0 is not in the map — handled by default '?? unknown'
+    expect(Object.keys(STATUS_MAP)).toHaveLength(6);
+    expect(STATUS_MAP[1]).toBe('stopped');
+    expect(STATUS_MAP[2]).toBe('running');
+    expect(STATUS_MAP[3]).toBe('failed');
+    expect(STATUS_MAP[4]).toBe('installing');
+    expect(STATUS_MAP[5]).toBe('building');
+    expect(STATUS_MAP[6]).toBe('not-installed');
+  });
+
+  it('matches Rust status_to_string() output', () => {
+    // These must match the Rust side in zenoh_api.rs::status_to_string()
+    const rustMappings = [
+      { status: 0, expected: 'unknown' },
+      { status: 1, expected: 'stopped' },
+      { status: 2, expected: 'running' },
+      { status: 3, expected: 'failed' },
+      { status: 4, expected: 'installing' },
+      { status: 5, expected: 'building' },
+      { status: 6, expected: 'not-installed' },
+    ];
+
+    for (const { status, expected } of rustMappings) {
+      expect(statusNumberToString(status)).toBe(expected);
+    }
+  });
+
+  it('no status maps to empty string', () => {
+    for (let i = 0; i <= 6; i++) {
+      expect(statusNumberToString(i)).not.toBe('');
+    }
+  });
+});

--- a/dashboard/src/lib/__tests__/subscription-manager.test.ts
+++ b/dashboard/src/lib/__tests__/subscription-manager.test.ts
@@ -87,6 +87,33 @@ describe('normalizeTopicPattern', () => {
     const topic = 'camera/terrace/data';
     expect(normalizeTopicPattern(topic)).toBe('camera/terrace/data');
   });
+
+  describe('ros-z new format (slash-preserved)', () => {
+    it('strips type and hash from new ros-z format', () => {
+      const topic = '0/bubbaloop/local/m1/camera/terrace/raw_shm/bubbaloop.camera.v1.Image/RIHS01_abc123';
+      expect(normalizeTopicPattern(topic)).toBe('0/bubbaloop/local/m1/camera/terrace/raw_shm');
+    });
+
+    it('strips type and hash from telemetry new format', () => {
+      const topic = '0/bubbaloop/local/nvidia_orin00/system_telemetry/metrics/bubbaloop.system_telemetry.v1.SystemMetrics/RIHS01_xyz';
+      expect(normalizeTopicPattern(topic)).toBe('0/bubbaloop/local/nvidia_orin00/system_telemetry/metrics');
+    });
+
+    it('preserves new format without type/hash', () => {
+      const topic = '0/bubbaloop/local/m1/camera/raw';
+      expect(normalizeTopicPattern(topic)).toBe('0/bubbaloop/local/m1/camera/raw');
+    });
+
+    it('handles new format with only hash suffix', () => {
+      const topic = '0/bubbaloop/local/m1/test/RIHS01_abc123';
+      expect(normalizeTopicPattern(topic)).toBe('0/bubbaloop/local/m1/test');
+    });
+
+    it('handles new format with trailing wildcard', () => {
+      const topic = '0/bubbaloop/local/m1/camera/**';
+      expect(normalizeTopicPattern(topic)).toBe('0/bubbaloop/local/m1/camera');
+    });
+  });
 });
 
 describe('ZenohSubscriptionManager', () => {

--- a/dashboard/src/lib/schema-registry.ts
+++ b/dashboard/src/lib/schema-registry.ts
@@ -555,8 +555,13 @@ export function extractTopicPrefix(topic: string): string | null {
   const parts = topic.split('/');
 
   if (parts.length >= 2 && /^\d+$/.test(parts[0])) {
-    // ros-z: decode %-encoded topic portion (second slash-separated part)
-    segments = parts[1].replace(/%/g, '/').split('/');
+    if (parts[1].includes('%')) {
+      // Old ros-z: decode %-encoded topic portion
+      segments = parts[1].replace(/%/g, '/').split('/');
+    } else {
+      // New ros-z: slashes preserved, skip domain ID
+      segments = parts.slice(1);
+    }
   } else {
     segments = parts;
   }

--- a/dashboard/src/lib/subscription-manager.ts
+++ b/dashboard/src/lib/subscription-manager.ts
@@ -33,28 +33,15 @@ export function normalizeTopicPattern(topic: string): string {
 
   const parts = normalized.split('/');
 
-  // Check if it's ros-z format (starts with domain ID like "0/")
-  if (parts.length >= 2 && /^\d+$/.test(parts[0])) {
-    // ros-z format: domain/encoded_topic/type/hash
-    // Check if part[2] is type info
-    if (parts.length >= 3) {
-      const thirdPart = parts[2];
-      if (thirdPart.includes('.') || thirdPart.startsWith('RIHS')) {
-        return parts.slice(0, 2).join('/');
-      }
-    }
-    return normalized;
-  }
-
-  // Raw Zenoh key format: find type/hash from the end and strip them
-  // Type looks like "bubbaloop.camera.v1.Image", hash starts with "RIHS"
+  // Strip type/hash segments from the end.
+  // Type name looks like "bubbaloop.camera.v1.Image" (has dots, starts with "bubbaloop")
+  // Hash starts with "RIHS"
   let cutIndex = parts.length;
   for (let i = parts.length - 1; i >= 0; i--) {
     const part = parts[i];
     if (part.startsWith('RIHS') || (part.includes('.') && part.startsWith('bubbaloop'))) {
       cutIndex = i;
     } else {
-      // Stop when we hit a part that's not type/hash
       break;
     }
   }

--- a/dashboard/src/test-utils/mocks/zenoh-ts-mock.ts
+++ b/dashboard/src/test-utils/mocks/zenoh-ts-mock.ts
@@ -108,6 +108,20 @@ export class Session {
   async put(_keyexpr: string, _payload: unknown): Promise<void> {}
 
   async close(): Promise<void> {}
+
+  liveliness() {
+    return {
+      declare_subscriber: async (_topic: string, _options?: unknown) => {
+        return new Subscriber();
+      },
+      declare_token: async (_topic: string) => {
+        return { undeclare: async () => {} };
+      },
+      get: async (_topic: string) => {
+        return (async function* () {})();
+      },
+    };
+  }
 }
 
 /** Mock open function */

--- a/templates/python-node/AGENTS.md.template
+++ b/templates/python-node/AGENTS.md.template
@@ -26,8 +26,10 @@
 ### Adding a New Zenoh Publisher
 Edit `main.py`:
 ```python
-# Declare publisher
-publisher = session.declare_publisher("{{node_name}}/my_topic")
+# Topics follow scoped pattern: bubbaloop/{scope}/{machine_id}/{{node_name}}/{resource}
+# The topic prefix is built automatically from BUBBALOOP_SCOPE and BUBBALOOP_MACHINE_ID
+publish_topic = f"{self._topic_prefix}/my_topic"
+publisher = session.declare_publisher(publish_topic)
 
 # Publish data (in run loop)
 publisher.put(json.dumps(data).encode())
@@ -39,21 +41,28 @@ def on_message(sample):
     data = json.loads(sample.payload.to_bytes())
     # Process data
 
-subscriber = session.declare_subscriber("other/topic", on_message)
+# Subscribe using scoped pattern (wildcards discover across machines)
+subscriber = session.declare_subscriber("bubbaloop/**/other_node/output", on_message)
 ```
 
 ### Changing Configuration
 Edit `config.yaml`:
 ```yaml
-publish_topic: "/{{node_name}}/output"
+publish_topic: "output"  # Appended to bubbaloop/{scope}/{machine_id}/{{node_name}}/
 rate_hz: 10.0  # Adjust publish rate
 ```
 
 ## Zenoh Topics
 
-| Topic | Direction | Format | Description |
-|-------|-----------|--------|-------------|
-| `/{{node_name}}/output` | Publish | JSON | Main output data |
+All topics follow the scoped pattern: `bubbaloop/{scope}/{machine_id}/{{node_name}}/{resource}`
+
+| Topic Suffix | Direction | Format | Description |
+|--------------|-----------|--------|-------------|
+| `output` | Publish | JSON | Main output data |
+| `schema` | Queryable | Protobuf | FileDescriptorSet (if protos exist) |
+| `manifest` | Queryable | JSON | Node self-description contract |
+| `health` | Queryable | JSON | Node health status |
+| `config` | Queryable | JSON | Read-only configuration |
 
 Data published to these topics is:
 - Visible in the Bubbaloop Dashboard

--- a/templates/python-node/AGENTS.md.template
+++ b/templates/python-node/AGENTS.md.template
@@ -58,8 +58,8 @@ All topics follow the scoped pattern: `bubbaloop/{scope}/{machine_id}/{{node_nam
 
 | Topic Suffix | Direction | Format | Description |
 |--------------|-----------|--------|-------------|
-| `output` | Publish | JSON | Main output data |
-| `schema` | Queryable | Protobuf | FileDescriptorSet (if protos exist) |
+| `output` | Publish | JSON/Protobuf | Main output data |
+| `schema` | Queryable | Protobuf | FileDescriptorSet (REQUIRED for protobuf nodes) |
 | `manifest` | Queryable | JSON | Node self-description contract |
 | `health` | Queryable | JSON | Node health status |
 | `config` | Queryable | JSON | Read-only configuration |
@@ -68,6 +68,47 @@ Data published to these topics is:
 - Visible in the Bubbaloop Dashboard
 - Available to other nodes on the Zenoh network
 - Persisted if a recorder node is running
+
+### Schema Contract (Protobuf Nodes)
+
+If this node publishes protobuf messages, it **MUST** serve its schema:
+
+1. **Add protos directory** with your .proto files + `header.proto`:
+   ```
+   {{node_name}}/
+   ├── protos/
+   │   ├── header.proto         # Copy from bubbaloop-schemas
+   │   └── {{node_name}}.proto
+   ├── descriptor.bin            # Compiled by protoc (add to .gitignore)
+   └── main.py
+   ```
+
+2. **Compile descriptor.bin** using protoc:
+   ```bash
+   protoc --descriptor_set_out=descriptor.bin \
+          --include_imports \
+          protos/{{node_name}}.proto protos/header.proto
+   ```
+
+3. **Declare schema queryable** in `main.py`:
+   ```python
+   # Load descriptor once at startup
+   with open("descriptor.bin", "rb") as f:
+       DESCRIPTOR_BYTES = f.read()
+
+   # Declare queryable (NEVER use complete=True)
+   @session.declare_queryable(f"{topic_prefix}/schema")
+   def handle_schema_query(query):
+       # query.key_expr is a PROPERTY, not a method
+       query.reply(query.key_expr, DESCRIPTOR_BYTES)
+   ```
+
+4. **Common mistakes** to avoid:
+   - ❌ `complete=True` — blocks wildcard discovery
+   - ❌ `query.key_expr()` — TypeError (it's a property, not method)
+   - ❌ Serving JSON instead of raw bytes
+
+See `ARCHITECTURE.md` for full schema contract details.
 
 ## Dependencies
 

--- a/templates/python-node/README.md.template
+++ b/templates/python-node/README.md.template
@@ -20,7 +20,7 @@ bubbaloop node logs {{node_name}} -f
 Edit `config.yaml`:
 
 ```yaml
-publish_topic: "/{{node_name}}/output"
+publish_topic: "output"  # Appended to bubbaloop/{scope}/{machine_id}/{{node_name}}/
 rate_hz: 1.0
 ```
 
@@ -36,6 +36,12 @@ python3 main.py -c config.yaml -e tcp/192.168.1.100:7447
 
 ## Zenoh Topics
 
-| Topic | Direction | Description |
-|-------|-----------|-------------|
-| `/{{node_name}}/output` | Publish | Node output data |
+Topics follow scoped pattern: `bubbaloop/{scope}/{machine_id}/{{node_name}}/{suffix}`
+
+| Topic Suffix | Direction | Description |
+|--------------|-----------|-------------|
+| `output` | Publish | Node output data |
+| `schema` | Queryable | Protobuf FileDescriptorSet |
+| `manifest` | Queryable | Node self-description |
+| `health` | Queryable | Health status |
+| `config` | Queryable | Read-only configuration |

--- a/templates/python-node/config.yaml.template
+++ b/templates/python-node/config.yaml.template
@@ -1,10 +1,31 @@
 # {{node_name}} node configuration
 
-# Topic to publish output to
-publish_topic: {{node_name}}/output
+# Topic suffix for published data (full topic: bubbaloop/{scope}/{machine_id}/{{node_name}}/{suffix})
+publish_topic: output
 
 # Topic to subscribe to (optional, set to null to disable)
 subscribe_topic: null
 
 # Publishing rate in Hz
 rate_hz: 1.0
+
+# --- Node Manifest (served at {prefix}/manifest) ---
+# Capabilities this node provides (e.g., sensor, actuator, health-check, network, compute)
+capabilities:
+  - sensor
+
+# Hardware requirements (e.g., camera, gpio, network, gpu, serial)
+requires_hardware:
+  - network
+
+# Data classification for security (internal, confidential, public)
+data_classification: internal
+
+# Clock source for timestamp correlation (system_realtime, hardware_clock, ntp_synced)
+clock_source: system_realtime
+
+# Timestamp field path in published messages (for multi-sensor correlation)
+timestamp_field: timestamp
+
+# Timestamp unit (nanoseconds, milliseconds, seconds, iso8601)
+timestamp_unit: milliseconds

--- a/templates/python-node/main.py.template
+++ b/templates/python-node/main.py.template
@@ -4,11 +4,14 @@
 import argparse
 import json
 import logging
+import os
 import signal
+import socket
 import sys
 import time
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
 
 import yaml
 import zenoh
@@ -20,6 +23,19 @@ logging.basicConfig(
     datefmt="%Y-%m-%d %H:%M:%S",
 )
 logger = logging.getLogger(__name__)
+
+
+def _get_machine_id() -> str:
+    """Get machine ID from env var or sanitized hostname."""
+    machine_id = os.environ.get("BUBBALOOP_MACHINE_ID")
+    if machine_id:
+        return machine_id.replace("-", "_")
+    return socket.gethostname().replace("-", "_")
+
+
+def _get_scope() -> str:
+    """Get scope from env var, default 'local'."""
+    return os.environ.get("BUBBALOOP_SCOPE", "local")
 
 
 def _load_descriptor_set() -> bytes | None:
@@ -41,10 +57,24 @@ class {{node_name_pascal}}Node:
         else:
             logger.warning(f"Config file not found: {config_path}, using defaults")
             self.config = {
-                "publish_topic": "{{node_name}}/output",
+                "publish_topic": "output",
                 "subscribe_topic": None,
                 "rate_hz": 1.0,
+                "version": "0.1.0",
+                "capabilities": ["sensor"],
+                "requires_hardware": [],
+                "data_classification": "internal",
+                "clock_source": "system_realtime",
+                "timestamp_field": "timestamp",
+                "timestamp_unit": "milliseconds",
             }
+
+        # Resolve scoped topic prefix
+        self._machine_id = _get_machine_id()
+        self._scope = _get_scope()
+        self._node_name = "{{node_name}}"
+        self._topic_prefix = f"bubbaloop/{self._scope}/{self._machine_id}/{self._node_name}"
+        logger.info(f"Topic prefix: {self._topic_prefix}")
 
         # Setup zenoh
         zenoh_config = zenoh.Config()
@@ -54,20 +84,54 @@ class {{node_name_pascal}}Node:
         self.session = zenoh.open(zenoh_config)
         logger.info("Connected to zenoh")
 
-        # Setup publisher
-        self.publisher = self.session.declare_publisher(self.config["publish_topic"])
-        logger.info(f"Publishing to: {self.config['publish_topic']}")
+        # Track node start time for health reporting
+        self._start_time = time.time()
+
+        # Setup publisher with scoped topic
+        publish_suffix = self.config["publish_topic"]
+        publish_topic = f"{self._topic_prefix}/{publish_suffix}"
+        self.publisher = self.session.declare_publisher(publish_topic)
+        logger.info(f"Publishing to: {publish_topic}")
 
         # Declare schema queryable so the dashboard can fetch our protobuf schemas
         self._descriptor_bytes = _load_descriptor_set()
         self._schema_queryable = None
         if self._descriptor_bytes:
+            schema_key = f"{self._topic_prefix}/schema"
             # Do NOT use complete=True — it blocks wildcard queries like "bubbaloop/**/schema"
             self._schema_queryable = self.session.declare_queryable(
-                "{{node_name}}/schema",
+                schema_key,
                 self._on_schema_query,
             )
-            logger.info("Schema queryable declared on {{node_name}}/schema")
+            logger.info(f"Schema queryable declared on {schema_key}")
+
+        # Declare manifest queryable for node self-description
+        manifest_key = f"{self._topic_prefix}/manifest"
+        self._manifest_queryable = self.session.declare_queryable(
+            manifest_key,
+            self._on_manifest_query,
+        )
+        logger.info(f"Manifest queryable declared on {manifest_key}")
+
+        # Declare health queryable for monitoring
+        health_key = f"{self._topic_prefix}/health"
+        self._health_queryable = self.session.declare_queryable(
+            health_key,
+            self._on_health_query,
+        )
+        logger.info(f"Health queryable declared on {health_key}")
+
+        # Declare config queryable for runtime configuration (GET/SET)
+        config_key = f"{self._topic_prefix}/config"
+        self._config_queryable = self.session.declare_queryable(
+            config_key,
+            self._on_config_query,
+        )
+        logger.info(f"Config queryable declared on {config_key}")
+
+        # TODO: Zenoh liveliness tokens (requires zenoh-python with liveliness support)
+        # liveliness_key = f"bubbaloop/{self._scope}/{self._machine_id}/{self._node_name}"
+        # self._liveliness_token = self.session.liveliness().declare_token(liveliness_key)
 
         # Setup subscriber (optional)
         self.subscriber = None
@@ -86,6 +150,85 @@ class {{node_name_pascal}}Node:
         logger.debug("Schema query received")
         if self._descriptor_bytes:
             query.reply(query.key_expr, self._descriptor_bytes)
+
+    def _build_manifest(self) -> dict[str, Any]:
+        """Build the node manifest (self-describing contract)."""
+        publish_suffix = self.config.get("publish_topic", "output")
+        full_publish_topic = f"{self._topic_prefix}/{publish_suffix}"
+        return {
+            "name": self._node_name,
+            "version": self.config.get("version", "0.1.0"),
+            "language": "python",
+            "description": "{{description}}",
+            "machine_id": self._machine_id,
+            "scope": self._scope,
+            "capabilities": self.config.get("capabilities", ["sensor"]),
+            "requires_hardware": self.config.get("requires_hardware", []),
+            "publishes": [
+                {
+                    "topic_suffix": publish_suffix,
+                    "full_topic": full_publish_topic,
+                    "rate_hz": self.config.get("rate_hz", 1.0),
+                }
+            ],
+            "subscribes": [self.config["subscribe_topic"]] if self.config.get("subscribe_topic") else [],
+            "schema_key": f"{self._topic_prefix}/schema",
+            "health_key": f"{self._topic_prefix}/health",
+            "config_key": f"{self._topic_prefix}/config",
+            "security": {
+                "acl_prefix": f"bubbaloop/*/{self._machine_id}/{self._node_name}/**",
+                "data_classification": self.config.get("data_classification", "internal"),
+            },
+            "time": {
+                "clock_source": self.config.get("clock_source", "system_realtime"),
+                "timestamp_field": self.config.get("timestamp_field", "timestamp"),
+                "timestamp_unit": self.config.get("timestamp_unit", "milliseconds"),
+            },
+        }
+
+    def _on_manifest_query(self, query: zenoh.Query):
+        """Respond to manifest queries with node contract JSON."""
+        logger.debug("Manifest query received")
+        manifest = self._build_manifest()
+        query.reply(query.key_expr, json.dumps(manifest).encode())
+
+    def _on_health_query(self, query: zenoh.Query):
+        """Respond to health queries."""
+        logger.debug("Health query received")
+        health = {
+            "status": "ok",
+            "uptime_s": time.time() - self._start_time,
+            "sequence": self.sequence,
+        }
+        query.reply(query.key_expr, json.dumps(health).encode())
+
+    def _on_config_query(self, query: zenoh.Query):
+        """Respond to config queries. GET returns config, PUT updates it."""
+        logger.debug("Config query received")
+        # Check if this is a PUT (has payload)
+        payload = query.payload
+        if payload is not None:
+            try:
+                new_config = json.loads(payload.to_bytes().decode())
+                # Validate: only allow updating known keys
+                updated_keys = []
+                for key in new_config:
+                    if key in self.config:
+                        self.config[key] = new_config[key]
+                        updated_keys.append(key)
+                logger.info(f"Config updated: {updated_keys}")
+                query.reply(
+                    query.key_expr,
+                    json.dumps({"status": "ok", "updated": updated_keys}).encode(),
+                )
+            except Exception as e:
+                query.reply(
+                    query.key_expr,
+                    json.dumps({"status": "error", "message": str(e)}).encode(),
+                )
+        else:
+            # GET — return current config
+            query.reply(query.key_expr, json.dumps(self.config).encode())
 
     def _on_message(self, sample: zenoh.Sample):
         """Handle incoming messages."""
@@ -127,6 +270,15 @@ class {{node_name_pascal}}Node:
         """Clean up resources."""
         if self._schema_queryable:
             self._schema_queryable.undeclare()
+        if self._manifest_queryable:
+            self._manifest_queryable.undeclare()
+        if self._health_queryable:
+            self._health_queryable.undeclare()
+        if self._config_queryable:
+            self._config_queryable.undeclare()
+        # TODO: Undeclare liveliness token when zenoh-python supports it
+        # if self._liveliness_token:
+        #     self._liveliness_token.undeclare()
         if self.subscriber:
             self.subscriber.undeclare()
         self.publisher.undeclare()

--- a/templates/python-node/main.py.template
+++ b/templates/python-node/main.py.template
@@ -61,7 +61,7 @@ class {{node_name_pascal}}Node:
                 "subscribe_topic": None,
                 "rate_hz": 1.0,
                 "version": "0.1.0",
-                "capabilities": ["sensor"],
+                "capabilities": [],
                 "requires_hardware": [],
                 "data_classification": "internal",
                 "clock_source": "system_realtime",
@@ -78,8 +78,15 @@ class {{node_name_pascal}}Node:
 
         # Setup zenoh
         zenoh_config = zenoh.Config()
-        if endpoint:
-            zenoh_config.insert_json5("connect/endpoints", json.dumps([endpoint]))
+
+        # Resolve endpoint: CLI arg > env var > default
+        if not endpoint:
+            endpoint = os.environ.get("BUBBALOOP_ZENOH_ENDPOINT", "tcp/127.0.0.1:7447")
+        zenoh_config.insert_json5("connect/endpoints", json.dumps([endpoint]))
+
+        # Disable scouting to prevent connecting to remote peers via Tailscale/VPN
+        zenoh_config.insert_json5("scouting/multicast/enabled", "false")
+        zenoh_config.insert_json5("scouting/gossip/enabled", "false")
 
         self.session = zenoh.open(zenoh_config)
         logger.info("Connected to zenoh")
@@ -121,7 +128,7 @@ class {{node_name_pascal}}Node:
         )
         logger.info(f"Health queryable declared on {health_key}")
 
-        # Declare config queryable for runtime configuration (GET/SET)
+        # Declare config queryable for read-only configuration access
         config_key = f"{self._topic_prefix}/config"
         self._config_queryable = self.session.declare_queryable(
             config_key,
@@ -162,7 +169,7 @@ class {{node_name_pascal}}Node:
             "description": "{{description}}",
             "machine_id": self._machine_id,
             "scope": self._scope,
-            "capabilities": self.config.get("capabilities", ["sensor"]),
+            "capabilities": self.config.get("capabilities", []),
             "requires_hardware": self.config.get("requires_hardware", []),
             "publishes": [
                 {
@@ -198,37 +205,13 @@ class {{node_name_pascal}}Node:
         health = {
             "status": "ok",
             "uptime_s": time.time() - self._start_time,
-            "sequence": self.sequence,
         }
         query.reply(query.key_expr, json.dumps(health).encode())
 
     def _on_config_query(self, query: zenoh.Query):
-        """Respond to config queries. GET returns config, PUT updates it."""
+        """Respond to config queries (read-only)."""
         logger.debug("Config query received")
-        # Check if this is a PUT (has payload)
-        payload = query.payload
-        if payload is not None:
-            try:
-                new_config = json.loads(payload.to_bytes().decode())
-                # Validate: only allow updating known keys
-                updated_keys = []
-                for key in new_config:
-                    if key in self.config:
-                        self.config[key] = new_config[key]
-                        updated_keys.append(key)
-                logger.info(f"Config updated: {updated_keys}")
-                query.reply(
-                    query.key_expr,
-                    json.dumps({"status": "ok", "updated": updated_keys}).encode(),
-                )
-            except Exception as e:
-                query.reply(
-                    query.key_expr,
-                    json.dumps({"status": "error", "message": str(e)}).encode(),
-                )
-        else:
-            # GET — return current config
-            query.reply(query.key_expr, json.dumps(self.config).encode())
+        query.reply(query.key_expr, json.dumps(self.config).encode())
 
     def _on_message(self, sample: zenoh.Sample):
         """Handle incoming messages."""

--- a/templates/python-node/main.py.template
+++ b/templates/python-node/main.py.template
@@ -79,6 +79,9 @@ class {{node_name_pascal}}Node:
         # Setup zenoh
         zenoh_config = zenoh.Config()
 
+        # Use client mode for proper routing through zenohd router
+        zenoh_config.insert_json5('mode', '"client"')
+
         # Resolve endpoint: CLI arg > env var > default
         if not endpoint:
             endpoint = os.environ.get("BUBBALOOP_ZENOH_ENDPOINT", "tcp/127.0.0.1:7447")

--- a/templates/rust-node/AGENTS.md.template
+++ b/templates/rust-node/AGENTS.md.template
@@ -29,8 +29,10 @@
 ### Adding a New Zenoh Publisher
 Edit `src/node.rs`:
 ```rust
-// In the node struct, add a publisher field
-let publisher = session.declare_publisher("{{node_name}}/my_topic").await?;
+// Topics follow scoped pattern: bubbaloop/{scope}/{machine_id}/{{node_name}}/{resource}
+// The topic_prefix is built automatically from BUBBALOOP_SCOPE and BUBBALOOP_MACHINE_ID
+let my_topic = format!("{}/my_topic", topic_prefix);
+let publisher = session.declare_publisher(&my_topic).await?;
 
 // In the run loop, publish data
 publisher.put(serde_json::to_vec(&data)?).await?;
@@ -38,22 +40,29 @@ publisher.put(serde_json::to_vec(&data)?).await?;
 
 ### Adding a Subscriber
 ```rust
-let subscriber = session.declare_subscriber("other/topic").await?;
+// Subscribe using scoped pattern (wildcards discover across machines)
+let subscriber = session.declare_subscriber("bubbaloop/**/other_node/output").await?;
 // Handle in select! loop
 ```
 
 ### Changing Configuration
 Edit `config.yaml`:
 ```yaml
-publish_topic: "/{{node_name}}/output"
+publish_topic: "output"  # Appended to bubbaloop/{scope}/{machine_id}/{{node_name}}/
 rate_hz: 10.0  # Adjust publish rate
 ```
 
 ## Zenoh Topics
 
-| Topic | Direction | Format | Description |
-|-------|-----------|--------|-------------|
-| `/{{node_name}}/output` | Publish | JSON | Main output data |
+All topics follow the scoped pattern: `bubbaloop/{scope}/{machine_id}/{{node_name}}/{resource}`
+
+| Topic Suffix | Direction | Format | Description |
+|--------------|-----------|--------|-------------|
+| `output` | Publish | JSON | Main output data |
+| `schema` | Queryable | Protobuf | FileDescriptorSet (if protos exist) |
+| `manifest` | Queryable | JSON | Node self-description contract |
+| `health` | Queryable | JSON | Node health status |
+| `config` | Queryable | JSON | Read-only configuration |
 
 Data published to these topics is:
 - Visible in the Bubbaloop Dashboard

--- a/templates/rust-node/AGENTS.md.template
+++ b/templates/rust-node/AGENTS.md.template
@@ -58,8 +58,8 @@ All topics follow the scoped pattern: `bubbaloop/{scope}/{machine_id}/{{node_nam
 
 | Topic Suffix | Direction | Format | Description |
 |--------------|-----------|--------|-------------|
-| `output` | Publish | JSON | Main output data |
-| `schema` | Queryable | Protobuf | FileDescriptorSet (if protos exist) |
+| `output` | Publish | JSON/Protobuf | Main output data |
+| `schema` | Queryable | Protobuf | FileDescriptorSet (REQUIRED for protobuf nodes) |
 | `manifest` | Queryable | JSON | Node self-description contract |
 | `health` | Queryable | JSON | Node health status |
 | `config` | Queryable | JSON | Read-only configuration |
@@ -68,6 +68,52 @@ Data published to these topics is:
 - Visible in the Bubbaloop Dashboard
 - Available to other nodes on the Zenoh network
 - Persisted if a recorder node is running
+
+### Schema Contract (Protobuf Nodes)
+
+If this node publishes protobuf messages, it **MUST** serve its schema:
+
+1. **Add protos directory** with your .proto files + `header.proto`:
+   ```
+   {{node_name}}/
+   ├── protos/
+   │   ├── header.proto      # Copy from bubbaloop-schemas
+   │   └── {{node_name}}.proto
+   ├── build.rs               # Compiles descriptor.bin
+   └── src/
+       └── node.rs
+   ```
+
+2. **Create build.rs** to compile descriptor.bin:
+   ```rust
+   fn main() {
+       let out_dir = std::path::PathBuf::from(std::env::var("OUT_DIR").unwrap());
+       prost_build::Config::new()
+           .file_descriptor_set_path(out_dir.join("descriptor.bin"))
+           .compile_protos(
+               &["protos/{{node_name}}.proto", "protos/header.proto"],
+               &["protos/"]
+           ).unwrap();
+   }
+   ```
+
+3. **Declare schema queryable** in `src/node.rs`:
+   ```rust
+   pub const DESCRIPTOR: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/descriptor.bin"));
+
+   let schema_queryable = session
+       .declare_queryable(format!("{}/schema", topic_prefix))
+       .await?;
+
+   // In select! loop, handle queries:
+   Ok(query) = schema_queryable.recv_async() => {
+       query.reply(query.key_expr().clone(), DESCRIPTOR).await?;
+   }
+   ```
+
+4. **NEVER use `.complete(true)`** — it blocks wildcard schema discovery.
+
+See `ARCHITECTURE.md` for full schema contract details.
 
 ## Dependencies
 

--- a/templates/rust-node/Cargo.toml.template
+++ b/templates/rust-node/Cargo.toml.template
@@ -39,6 +39,9 @@ anyhow = "1.0"
 # Graceful shutdown
 ctrlc = "3.4"
 
+# Machine identification
+hostname = "0.3"
+
 # Time utilities
 chrono = { version = "0.4", features = ["serde"] }
 

--- a/templates/rust-node/README.md.template
+++ b/templates/rust-node/README.md.template
@@ -20,7 +20,7 @@ bubbaloop node logs {{node_name}} -f
 Edit `config.yaml`:
 
 ```yaml
-publish_topic: "/{{node_name}}/output"
+publish_topic: "output"  # Appended to bubbaloop/{scope}/{machine_id}/{{node_name}}/
 rate_hz: 1.0
 ```
 
@@ -36,6 +36,12 @@ cargo build --release
 
 ## Zenoh Topics
 
-| Topic | Direction | Description |
-|-------|-----------|-------------|
-| `/{{node_name}}/output` | Publish | Node output data |
+Topics follow scoped pattern: `bubbaloop/{scope}/{machine_id}/{{node_name}}/{suffix}`
+
+| Topic Suffix | Direction | Description |
+|--------------|-----------|-------------|
+| `output` | Publish | Node output data |
+| `schema` | Queryable | Protobuf FileDescriptorSet |
+| `manifest` | Queryable | Node self-description |
+| `health` | Queryable | Health status |
+| `config` | Queryable | Read-only configuration |

--- a/templates/rust-node/config.yaml.template
+++ b/templates/rust-node/config.yaml.template
@@ -1,10 +1,31 @@
 # {{node_name}} node configuration
 
-# Topic to publish output to
-publish_topic: {{node_name}}/output
+# Topic suffix for published data (full topic: bubbaloop/{scope}/{machine_id}/{{node_name}}/{suffix})
+publish_topic: output
 
 # Topic to subscribe to (optional, comment out to disable)
 # subscribe_topic: /some/input/topic
 
 # Publishing rate in Hz
 rate_hz: 1.0
+
+# --- Node Manifest (served at {prefix}/manifest) ---
+# Capabilities this node provides (e.g., sensor, actuator, health-check, network, compute)
+capabilities:
+  - sensor
+
+# Hardware requirements (e.g., camera, gpio, network, gpu, serial)
+requires_hardware:
+  - network
+
+# Data classification for security (internal, confidential, public)
+data_classification: internal
+
+# Clock source for timestamp correlation (system_realtime, hardware_clock, ntp_synced)
+clock_source: system_realtime
+
+# Timestamp field path in published messages (for multi-sensor correlation)
+timestamp_field: timestamp
+
+# Timestamp unit (nanoseconds, milliseconds, seconds, iso8601)
+timestamp_unit: milliseconds

--- a/templates/rust-node/src/node.rs.template
+++ b/templates/rust-node/src/node.rs.template
@@ -16,10 +16,42 @@ use zenoh::sample::Sample;
 #[cfg(feature = "proto")]
 pub const DESCRIPTOR: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/descriptor.bin"));
 
+/// Get machine ID from environment or hostname
+fn get_machine_id() -> String {
+    std::env::var("BUBBALOOP_MACHINE_ID").unwrap_or_else(|_| {
+        hostname::get()
+            .ok()
+            .and_then(|h| h.into_string().ok())
+            .unwrap_or_else(|| "unknown".to_string())
+            .replace('-', "_")
+    })
+}
+
+/// Get scope from environment, defaults to "local"
+fn get_scope() -> String {
+    std::env::var("BUBBALOOP_SCOPE").unwrap_or_else(|_| "local".to_string())
+}
+
+fn default_data_classification() -> String {
+    "internal".to_string()
+}
+
+fn default_clock_source() -> String {
+    "system_realtime".to_string()
+}
+
+fn default_timestamp_field() -> String {
+    "timestamp".to_string()
+}
+
+fn default_timestamp_unit() -> String {
+    "milliseconds".to_string()
+}
+
 /// Node configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
-    /// Topic to publish to
+    /// Topic suffix to publish to (appended to bubbaloop/{scope}/{machine_id}/{{node_name}}/)
     pub publish_topic: String,
 
     /// Topic to subscribe to (optional)
@@ -27,14 +59,44 @@ pub struct Config {
 
     /// Publishing rate in Hz
     pub rate_hz: f64,
+
+    /// Node capabilities (e.g., "sensor", "actuator")
+    #[serde(default)]
+    pub capabilities: Vec<String>,
+
+    /// Hardware requirements (e.g., "camera", "network")
+    #[serde(default)]
+    pub requires_hardware: Vec<String>,
+
+    /// Data classification (internal, confidential, public)
+    #[serde(default = "default_data_classification")]
+    pub data_classification: String,
+
+    /// Clock source for timestamps
+    #[serde(default = "default_clock_source")]
+    pub clock_source: String,
+
+    /// Timestamp field name in messages
+    #[serde(default = "default_timestamp_field")]
+    pub timestamp_field: String,
+
+    /// Timestamp unit
+    #[serde(default = "default_timestamp_unit")]
+    pub timestamp_unit: String,
 }
 
 impl Default for Config {
     fn default() -> Self {
         Self {
-            publish_topic: "{{node_name}}/output".to_string(),
+            publish_topic: "output".to_string(),
             subscribe_topic: None,
             rate_hz: 1.0,
+            capabilities: Vec::new(),
+            requires_hardware: Vec::new(),
+            data_classification: default_data_classification(),
+            clock_source: default_clock_source(),
+            timestamp_field: default_timestamp_field(),
+            timestamp_unit: default_timestamp_unit(),
         }
     }
 }
@@ -72,18 +134,28 @@ impl {{node_name_pascal}}Node {
             .map_err(|e| anyhow!("Failed to open zenoh session: {}", e))?;
 
         log::info!("Connected to zenoh");
-        log::info!("Publishing to: {}", config.publish_topic);
-        if let Some(ref topic) = config.subscribe_topic {
-            log::info!("Subscribing to: {}", topic);
-        }
 
         Ok(Self { config, session })
     }
 
     /// Run the node main loop
     pub async fn run(&mut self, running: Arc<AtomicBool>) -> Result<()> {
+        let scope = get_scope();
+        let machine_id = get_machine_id();
+        let topic_prefix = format!("bubbaloop/{}/{}/{{{{node_name}}}}", scope, machine_id);
+
+        log::info!("Node scoped topic prefix: {}", topic_prefix);
+
+        // Construct full publish topic
+        let full_publish_topic = format!("{}/{}", topic_prefix, self.config.publish_topic);
+        log::info!("Publishing to: {}", full_publish_topic);
+
+        if let Some(ref topic) = self.config.subscribe_topic {
+            log::info!("Subscribing to: {}", topic);
+        }
+
         let publisher: Publisher<'_> = self.session
-            .declare_publisher(&self.config.publish_topic)
+            .declare_publisher(&full_publish_topic)
             .await
             .map_err(|e| anyhow!("Failed to create publisher: {}", e))?;
 
@@ -91,8 +163,10 @@ impl {{node_name_pascal}}Node {
         // NOTE: Do NOT use .complete(true) — it blocks wildcard queries (e.g., "bubbaloop/**/schema")
         // from reaching other queryables. The .wait() call is required to actually send the reply.
         #[cfg(feature = "proto")]
+        let schema_key = format!("{}/schema", topic_prefix);
+        #[cfg(feature = "proto")]
         let _schema_queryable = self.session
-            .declare_queryable("{{node_name}}/schema")
+            .declare_queryable(&schema_key)
             .callback(|query| {
                 use zenoh::Wait;
                 log::debug!("Schema query received");
@@ -102,6 +176,92 @@ impl {{node_name_pascal}}Node {
             })
             .await
             .map_err(|e| anyhow!("Failed to create schema queryable: {}", e))?;
+
+        // Declare manifest queryable for node metadata
+        let manifest_config = self.config.clone();
+        let manifest_scope = scope.clone();
+        let manifest_machine_id = machine_id.clone();
+        let manifest_prefix = topic_prefix.clone();
+        let manifest_publish = full_publish_topic.clone();
+        let _manifest_queryable = self.session
+            .declare_queryable(&format!("{}/manifest", topic_prefix))
+            .callback(move |query| {
+                use zenoh::Wait;
+                log::debug!("Manifest query received");
+                let manifest = serde_json::json!({
+                    "name": "{{node_name}}",
+                    "version": "0.1.0",
+                    "language": "rust",
+                    "description": "{{description}}",
+                    "machine_id": &manifest_machine_id,
+                    "scope": &manifest_scope,
+                    "capabilities": &manifest_config.capabilities,
+                    "requires_hardware": &manifest_config.requires_hardware,
+                    "publishes": [{
+                        "topic_suffix": &manifest_config.publish_topic,
+                        "full_topic": &manifest_publish,
+                        "rate_hz": manifest_config.rate_hz,
+                    }],
+                    "subscribes": manifest_config.subscribe_topic.as_deref().map(|t| vec![t]).unwrap_or_default(),
+                    "schema_key": format!("{}/schema", manifest_prefix),
+                    "health_key": format!("{}/health", manifest_prefix),
+                    "config_key": format!("{}/config", manifest_prefix),
+                    "security": {
+                        "acl_prefix": format!("bubbaloop/*/{}/{{{{node_name}}}}/**", manifest_machine_id),
+                        "data_classification": &manifest_config.data_classification,
+                    },
+                    "time": {
+                        "clock_source": &manifest_config.clock_source,
+                        "timestamp_field": &manifest_config.timestamp_field,
+                        "timestamp_unit": &manifest_config.timestamp_unit,
+                    },
+                });
+                if let Err(e) = query.reply(query.key_expr(), ZBytes::from(manifest.to_string().into_bytes())).wait() {
+                    log::warn!("Failed to reply to manifest query: {}", e);
+                }
+            })
+            .await
+            .map_err(|e| anyhow!("Failed to create manifest queryable: {}", e))?;
+
+        // Declare health queryable for node status monitoring
+        let start_time = std::time::Instant::now();
+        let _health_queryable = self.session
+            .declare_queryable(&format!("{}/health", topic_prefix))
+            .callback(move |query| {
+                use zenoh::Wait;
+                log::debug!("Health query received");
+                let health = serde_json::json!({
+                    "status": "ok",
+                    "uptime_s": start_time.elapsed().as_secs(),
+                });
+                if let Err(e) = query.reply(query.key_expr(), ZBytes::from(health.to_string().into_bytes())).wait() {
+                    log::warn!("Failed to reply to health query: {}", e);
+                }
+            })
+            .await
+            .map_err(|e| anyhow!("Failed to create health queryable: {}", e))?;
+
+        // Declare config queryable for read-only configuration access
+        let config_json = serde_json::to_string(&self.config).unwrap_or_default();
+        let _config_queryable = self.session
+            .declare_queryable(&format!("{}/config", topic_prefix))
+            .callback(move |query| {
+                use zenoh::Wait;
+                log::debug!("Config query received");
+                if let Err(e) = query.reply(query.key_expr(), ZBytes::from(config_json.as_bytes().to_vec())).wait() {
+                    log::warn!("Failed to reply to config query: {}", e);
+                }
+            })
+            .await
+            .map_err(|e| anyhow!("Failed to create config queryable: {}", e))?;
+
+        // Declare liveliness token for presence detection
+        let _liveliness_token = self.session
+            .liveliness()
+            .declare_token(&topic_prefix)
+            .await
+            .map_err(|e| anyhow!("Failed to declare liveliness token: {}", e))?;
+        log::info!("Liveliness token declared for {{{{node_name}}}}");
 
         // Optional subscriber
         let subscriber: Option<Subscriber<FifoChannelHandler<Sample>>> = if let Some(ref topic) = self.config.subscribe_topic {

--- a/templates/rust-node/src/node.rs.template
+++ b/templates/rust-node/src/node.rs.template
@@ -124,6 +124,9 @@ impl {{node_name_pascal}}Node {
         // Create zenoh session
         let mut zenoh_config = zenoh::Config::default();
 
+        // Use client mode for proper routing through zenohd router
+        zenoh_config.insert_json5("mode", r#""client""#).unwrap();
+
         // Resolve endpoint: CLI arg > env var > default
         let ep = endpoint
             .or_else(|| std::env::var("BUBBALOOP_ZENOH_ENDPOINT").ok())

--- a/templates/rust-node/src/node.rs.template
+++ b/templates/rust-node/src/node.rs.template
@@ -123,11 +123,18 @@ impl {{node_name_pascal}}Node {
 
         // Create zenoh session
         let mut zenoh_config = zenoh::Config::default();
-        if let Some(ep) = endpoint {
-            zenoh_config
-                .insert_json5("connect/endpoints", &format!(r#"["{}"]"#, ep))
-                .unwrap();
-        }
+
+        // Resolve endpoint: CLI arg > env var > default
+        let ep = endpoint
+            .or_else(|| std::env::var("BUBBALOOP_ZENOH_ENDPOINT").ok())
+            .unwrap_or_else(|| "tcp/127.0.0.1:7447".to_string());
+        zenoh_config
+            .insert_json5("connect/endpoints", &format!(r#"["{}"]"#, ep))
+            .unwrap();
+
+        // Disable scouting to prevent connecting to remote peers via Tailscale/VPN
+        zenoh_config.insert_json5("scouting/multicast/enabled", "false").ok();
+        zenoh_config.insert_json5("scouting/gossip/enabled", "false").ok();
 
         let session = zenoh::open(zenoh_config)
             .await


### PR DESCRIPTION
## Summary
- **Schema-ready gating**: `useSchemaReady` hook prevents dashboard race condition where Zenoh delivers messages before schemas load. Applied to CameraView, WeatherView, SystemTelemetryView, NetworkMonitorView
- **Self-describing nodes**: Rust/Python templates now serve manifest, health, config, and schema queryables with consistent contract
- **Hardened daemon**: D-Bus timeouts, node name validation, unknown command errors, graceful unregister when dir deleted
- **Security configs**: Zenoh ACL and TLS example configurations
- **Doctor checks**: Node contract compliance validation in `bubbaloop doctor`

## Test plan
- [x] 267 Rust tests pass (`cargo test --lib -p bubbaloop`)
- [x] 509 dashboard tests pass (`cd dashboard && npm test -- --run`)
- [x] Clippy clean (`cargo clippy --lib -p bubbaloop -- -D warnings`)
- [x] Format clean (`cargo fmt --check`)
- [ ] Manual: start camera node, verify dashboard video within seconds
- [ ] Manual: `bubbaloop doctor` reports clean on registered nodes

🤖 Generated with [Claude Code](https://claude.com/claude-code)