### PR TITLE
feat: migrate CLI from Zenoh to REST API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ Testing: `cargo test --features test-harness --test integration_mcp` (47 tests)
 ```bash
 pixi run check     # cargo check (fast — run after every change)
 pixi run clippy    # zero warnings enforced (-D warnings)
-pixi run test      # cargo test (298 unit tests)
+pixi run test      # cargo test (358 unit tests)
 pixi run fmt       # cargo fmt --all
 pixi run build     # cargo build --release (slow on ARM64)
 cargo test --features test-harness --test integration_mcp  # 47 integration tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,7 @@ dashboard/                 # React + Vite + TypeScript
 ```
 
 Key source files in `crates/bubbaloop/src/`:
+- `cli/login.rs` — login/logout/status for Anthropic API key management
 - `cli/node/mod.rs` — node CRUD, validation, list/add/remove
 - `cli/node/install.rs` — install, precompiled binary download, GitHub clone
 - `cli/node/lifecycle.rs` — start, stop, restart, logs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -348,6 +348,7 @@ dependencies = [
  "anyhow",
  "argh",
  "axum",
+ "chrono",
  "cron",
  "ctrlc",
  "dirs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,6 +628,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ctrlc"
 version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -882,7 +903,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "env_filter",
- "jiff",
+ "jiff 0.2.16",
  "log",
 ]
 
@@ -1716,6 +1737,18 @@ name = "itoa"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ee5b5339afb4c41626dde77b7a611bd4f2c202b897852b4bcf5d03eddc61010"
+
+[[package]]
+name = "jiff"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c04ef77ae73f3cf50510712722f0c4e8b46f5aaa1bf5ffad2ae213e6495e78e5"
+dependencies = [
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+]
 
 [[package]]
 name = "jiff"
@@ -3052,11 +3085,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c6d5e5acb6f6129fe3f7ba0a7fc77bca1942cb568535e18e7bc40262baf3110"
 dependencies = [
  "bitflags",
+ "chrono",
+ "csv",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
+ "jiff 0.1.29",
  "libsqlite3-sys",
+ "serde_json",
  "smallvec",
+ "time",
+ "url",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -348,6 +348,7 @@ dependencies = [
  "anyhow",
  "argh",
  "axum",
+ "cron",
  "ctrlc",
  "dirs",
  "env_logger",
@@ -360,7 +361,9 @@ dependencies = [
  "prost-build",
  "prost-reflect",
  "prost-types",
+ "reqwest",
  "rmcp",
+ "rusqlite",
  "rust-embed",
  "schemars 1.1.0",
  "serde",
@@ -542,6 +545,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "cron"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5877d3fbf742507b66bc2a1945106bd30dd8504019d596901ddd012a4dd01740"
+dependencies = [
+ "chrono",
+ "once_cell",
+ "winnow 0.6.26",
 ]
 
 [[package]]
@@ -907,6 +921,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastbloom"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1239,6 +1265,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1360,6 +1395,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1378,6 +1430,7 @@ version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
 dependencies = [
+ "base64",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -1385,7 +1438,9 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.1",
  "tokio",
@@ -1595,11 +1650,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
 name = "ipnetwork"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf466541e9d546596ee94f9f69590f89473455f88372423e0008fc1a7daf100e"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "iri-string"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+dependencies = [
+ "memchr",
  "serde",
 ]
 
@@ -1783,6 +1854,17 @@ dependencies = [
  "bitflags",
  "libc",
  "redox_syscall 0.6.0",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8935b44e7c13394a179a438e0cebba0fe08fe01b54f152e29a93b5cf993fd4"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2757,6 +2839,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2863,6 +2983,20 @@ dependencies = [
  "spki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c6d5e5acb6f6129fe3f7ba0a7fc77bca1942cb568535e18e7bc40262baf3110"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]
@@ -3525,6 +3659,9 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -3797,7 +3934,7 @@ dependencies = [
  "indexmap 2.12.1",
  "toml_datetime",
  "toml_parser",
- "winnow",
+ "winnow 0.7.14",
 ]
 
 [[package]]
@@ -3806,7 +3943,7 @@ version = "1.0.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
 dependencies = [
- "winnow",
+ "winnow 0.7.14",
 ]
 
 [[package]]
@@ -3855,6 +3992,24 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -4182,6 +4337,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4244,6 +4405,19 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -4641,6 +4815,15 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
+version = "0.6.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e90edd2ac1aa278a5c4599b1d89cf03074b610800f866d4026dc199d7929a28"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
 version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
@@ -4724,7 +4907,7 @@ dependencies = [
  "uds_windows",
  "uuid",
  "windows-sys 0.61.2",
- "winnow",
+ "winnow 0.7.14",
  "zbus_macros",
  "zbus_names",
  "zvariant",
@@ -4752,7 +4935,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffd8af6d5b78619bab301ff3c560a5bd22426150253db278f164d6cf3b72c50f"
 dependencies = [
  "serde",
- "winnow",
+ "winnow 0.7.14",
  "zvariant",
 ]
 
@@ -5391,7 +5574,7 @@ dependencies = [
  "endi",
  "enumflags2",
  "serde",
- "winnow",
+ "winnow 0.7.14",
  "zvariant_derive",
  "zvariant_utils",
 ]
@@ -5419,5 +5602,5 @@ dependencies = [
  "quote",
  "serde",
  "syn 2.0.111",
- "winnow",
+ "winnow 0.7.14",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,7 +343,7 @@ dependencies = [
 
 [[package]]
 name = "bubbaloop"
-version = "0.0.6"
+version = "0.0.7-dev"
 dependencies = [
  "anyhow",
  "argh",
@@ -358,12 +358,14 @@ dependencies = [
  "hostname",
  "log",
  "mime_guess",
+ "open",
  "prost",
  "prost-build",
  "prost-reflect",
  "prost-types",
  "reqwest",
  "rmcp",
+ "rpassword",
  "rusqlite",
  "rust-embed",
  "schemars 1.1.0",
@@ -1676,6 +1678,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2177,6 +2198,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "open"
+version = "5.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43bb73a7fa3799b198970490a51174027ba0d4ec504b03cd08caf513d40024bc"
+dependencies = [
+ "is-wsl",
+ "libc",
+ "pathdiff",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2238,6 +2270,12 @@ name = "pastey"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "pem-rfc7468"
@@ -2967,6 +3005,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rpassword"
+version = "7.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66d4c8b64f049c6721ec8ccec37ddfc3d641c4a7fca57e8f2a89de509c73df39"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rsa"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2984,6 +3033,16 @@ dependencies = [
  "spki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7cc970b249fbe527d6e02e0a227762c9108b2f49d81094fe357ffc6d14d7f6f"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4606,6 +4665,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ rusqlite = { version = "0.33", features = ["bundled"] }
 
 # Cron expression parsing (scheduler)
 cron = "0.15"
+chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 
 # Hex encoding
 hex = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ anyhow = "1"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 
 # Embedded database (memory layer)
-rusqlite = { version = "0.33", features = ["bundled"] }
+rusqlite = { version = "0.33", features = ["bundled-full"] }
 
 # Cron expression parsing (scheduler)
 cron = "0.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,15 @@ dirs = "6"
 # Error handling
 anyhow = "1"
 
+# HTTP client (Claude API)
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
+
+# Embedded database (memory layer)
+rusqlite = { version = "0.33", features = ["bundled"] }
+
+# Cron expression parsing (scheduler)
+cron = "0.15"
+
 # Hex encoding
 hex = "0.4"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.0.6"
+version = "0.0.7-dev"
 authors = ["Edgar Riba <edgar.riba@gmail.com>"]
 license = "Apache-2.0"
 edition = "2021"
@@ -36,6 +36,8 @@ env_logger = "0.11"
 # CLI
 argh = "0.1"
 ctrlc = "3.4"
+rpassword = "7"
+open = "5"
 
 # Error handling
 thiserror = "2.0"

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -99,7 +99,7 @@ bubbaloop agent
 - [x] 3-tier RBAC (Viewer/Operator/Admin) + bearer token auth
 - [x] systemd integration via D-Bus (zbus)
 - [x] Dashboard (React + Vite)
-- [x] 298 unit tests + 47 MCP integration tests
+- [x] 358 unit tests + 47 MCP integration tests
 - [x] TUI removed — codebase simplified to ~14K lines
 
 **Binary size: 11 MB.** Runs on NVIDIA Jetson, Raspberry Pi, any Linux ARM64/x86_64.
@@ -122,12 +122,12 @@ config:
 ```
 
 **Deliverables:**
-- [ ] `~/.bubbaloop/skills/*.yaml` loader — parse driver + config at startup
-- [ ] Driver registry: map `driver: rtsp` → marketplace node `rtsp-camera`
-- [ ] Auto-install: download precompiled binary if driver not present
-- [ ] Config injection: YAML config → node env vars / config.yaml
-- [ ] `bubbaloop up` command: load all skills, ensure nodes running
-- [ ] Built-in driver catalog (v1):
+- [x] `~/.bubbaloop/skills/*.yaml` loader — parse driver + config at startup
+- [x] Driver registry: map `driver: rtsp` → marketplace node `rtsp-camera`
+- [x] Auto-install: download precompiled binary if driver not present
+- [x] Config injection: YAML config → node env vars / config.yaml
+- [x] `bubbaloop up` command: load all skills, ensure nodes running
+- [x] Built-in driver catalog (v1):
 
 | Driver | Marketplace Node | Use Case |
 |--------|-----------------|----------|
@@ -159,11 +159,11 @@ config:
 ```
 
 **Deliverables:**
-- [ ] `bubbaloop agent` CLI command (terminal chat interface)
-- [ ] Claude API integration via `reqwest` (tool_use for MCP tools)
-- [ ] Internal MCP tool dispatch (call tools without HTTP round-trip)
-- [ ] System prompt injection: sensor inventory, node status, active schedules
-- [ ] Multi-turn conversation loop with tool use
+- [x] `bubbaloop agent` CLI command (terminal chat interface)
+- [x] Claude API integration via `reqwest` (tool_use for MCP tools)
+- [x] Internal MCP tool dispatch (call tools without HTTP round-trip)
+- [x] System prompt injection: sensor inventory, node status, active schedules
+- [x] Multi-turn conversation loop with tool use
 - [ ] HTTP chat endpoint for future dashboard integration
 
 **New deps:** None (`reqwest` already in dep tree). **New code:** ~500-800 lines.
@@ -184,12 +184,12 @@ schedules     (id, name, cron, actions, tier, last_run, next_run)
 ```
 
 **Deliverables:**
-- [ ] SQLite via `rusqlite` (static libsqlite3) at `~/.bubbaloop/memory.db`
-- [ ] `conversations` table with FTS5 full-text search
-- [ ] `sensor_events` table: health changes, crashes, alerts with timestamps
-- [ ] `schedules` table: active jobs + execution history
+- [x] SQLite via `rusqlite` (static libsqlite3) at `~/.bubbaloop/memory.db`
+- [x] `conversations` table with timestamp indexing
+- [x] `sensor_events` table: health changes, crashes, alerts with timestamps
+- [x] `schedules` table: active jobs + execution history
 - [ ] Daemon event hook: write sensor events as they happen (no polling)
-- [ ] Context injection: recent events included in agent system prompt
+- [x] Context injection: recent events included in agent system prompt
 - [ ] Future: add `sqlite-vec` (~200KB) for vector search if needed
 
 **New deps:** `rusqlite` (+1-2 MB). **New code:** ~300-500 lines.
@@ -232,8 +232,8 @@ Built-in actions: `check_all_health`, `restart`, `capture_frame`, `start_node`, 
 ```
 
 **Deliverables:**
-- [ ] Tier 1 cron executor with built-in action set (offline, no LLM)
-- [ ] YAML `schedule:` + `actions:` syntax in skill files
+- [x] Tier 1 cron executor with built-in action set (offline, no LLM)
+- [x] YAML `schedule:` + `actions:` syntax in skill files
 - [ ] Tier 2 conversational schedules stored in SQLite
 - [ ] Rate limiting: configurable max LLM calls/day
 - [ ] `bubbaloop jobs` CLI: list, pause, resume, delete
@@ -312,5 +312,7 @@ These are out of scope but represent natural evolution:
 ## Design Documents
 
 - `docs/plans/2026-02-27-hardware-ai-agent-design.md` — Full agent design (architecture, memory, scheduling, security)
+- `docs/plans/2026-02-28-agent-implementation-design.md` — Agent implementation design (Phases 2-4)
+- `docs/plans/2026-02-28-agent-implementation.md` — Step-by-step implementation plan
 - `ARCHITECTURE.md` — Layer model, node contract, security, technology choices
 - `CONTRIBUTING.md` — Agentic workflows, agent tiers, validation

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -256,7 +256,8 @@ Built-in actions: `check_all_health`, `restart`, `capture_frame`, `start_node`, 
 
 **Deliverables:**
 - [ ] `curl -sSL https://get.bubbaloop.com | bash` install script
-- [ ] First-run wizard: detect hardware, suggest skills, set up API key
+- [x] `bubbaloop login` — API key setup (browser + paste + validate + save)
+- [ ] First-run wizard: detect hardware, suggest skills
 - [ ] `bubbaloop agent` auto-loads skills, auto-installs drivers, starts chat
 - [ ] AI-assisted skill creation: "Add my garage camera at rtsp://..."
 - [ ] Conversational scheduling: "Check cameras every hour"

--- a/crates/bubbaloop/Cargo.toml
+++ b/crates/bubbaloop/Cargo.toml
@@ -70,6 +70,11 @@ rust-embed = { workspace = true, optional = true }
 mime_guess = { workspace = true, optional = true }
 tokio-tungstenite = { workspace = true, optional = true }
 
+# Agent layer (Claude API + memory + scheduler)
+reqwest.workspace = true
+rusqlite.workspace = true
+cron.workspace = true
+
 # MCP server (core)
 rmcp.workspace = true
 schemars.workspace = true

--- a/crates/bubbaloop/Cargo.toml
+++ b/crates/bubbaloop/Cargo.toml
@@ -35,6 +35,8 @@ argh.workspace = true
 log.workspace = true
 env_logger.workspace = true
 walkdir = "2"
+rpassword.workspace = true
+open.workspace = true
 
 # Zenoh for daemon communication
 zenoh.workspace = true

--- a/crates/bubbaloop/Cargo.toml
+++ b/crates/bubbaloop/Cargo.toml
@@ -74,6 +74,7 @@ tokio-tungstenite = { workspace = true, optional = true }
 reqwest.workspace = true
 rusqlite.workspace = true
 cron.workspace = true
+chrono.workspace = true
 
 # MCP server (core)
 rmcp.workspace = true

--- a/crates/bubbaloop/src/agent/claude.rs
+++ b/crates/bubbaloop/src/agent/claude.rs
@@ -1,0 +1,494 @@
+//! Raw reqwest Claude API client with tool_use support.
+//!
+//! Provides a minimal client for the Anthropic Messages API, supporting
+//! text messages and tool use (function calling). No streaming — single
+//! request/response only.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+// ── Constants ───────────────────────────────────────────────────────
+
+/// Anthropic Messages API endpoint.
+const API_URL: &str = "https://api.anthropic.com/v1/messages";
+
+/// API version header value.
+const API_VERSION: &str = "2023-06-01";
+
+/// Default model when none is specified.
+const DEFAULT_MODEL: &str = "claude-sonnet-4-20250514";
+
+/// Default max tokens per response.
+const MAX_TOKENS: u32 = 4096;
+
+// ── Errors ──────────────────────────────────────────────────────────
+
+/// Errors from Claude API operations.
+#[derive(Debug, thiserror::Error)]
+pub enum ClaudeError {
+    #[error("HTTP error: {0}")]
+    Http(#[from] reqwest::Error),
+
+    #[error("API error (status {status}): {message}")]
+    Api { status: u16, message: String },
+
+    #[error("ANTHROPIC_API_KEY not set")]
+    MissingApiKey,
+
+    #[error("format error: {0}")]
+    Format(String),
+}
+
+pub type Result<T> = std::result::Result<T, ClaudeError>;
+
+// ── Content blocks ──────────────────────────────────────────────────
+
+/// A single content block in a message (text, tool_use, or tool_result).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type")]
+pub enum ContentBlock {
+    #[serde(rename = "text")]
+    Text { text: String },
+
+    #[serde(rename = "tool_use")]
+    ToolUse {
+        id: String,
+        name: String,
+        input: Value,
+    },
+
+    #[serde(rename = "tool_result")]
+    ToolResult {
+        tool_use_id: String,
+        content: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        is_error: Option<bool>,
+    },
+}
+
+// ── Message ─────────────────────────────────────────────────────────
+
+/// A conversation message with role and content blocks.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Message {
+    pub role: String,
+    pub content: Vec<ContentBlock>,
+}
+
+impl Message {
+    /// Create a user message from plain text.
+    pub fn user(text: &str) -> Self {
+        Self {
+            role: "user".to_string(),
+            content: vec![ContentBlock::Text {
+                text: text.to_string(),
+            }],
+        }
+    }
+
+    /// Create a user message containing tool results.
+    ///
+    /// Each tuple is `(tool_use_id, content, is_error)`.
+    pub fn tool_results(results: Vec<(String, String, Option<bool>)>) -> Self {
+        Self {
+            role: "user".to_string(),
+            content: results
+                .into_iter()
+                .map(
+                    |(tool_use_id, content, is_error)| ContentBlock::ToolResult {
+                        tool_use_id,
+                        content,
+                        is_error,
+                    },
+                )
+                .collect(),
+        }
+    }
+
+    /// Concatenate all text blocks into a single string.
+    pub fn text(&self) -> String {
+        self.content
+            .iter()
+            .filter_map(|b| match b {
+                ContentBlock::Text { text } => Some(text.as_str()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("")
+    }
+
+    /// Extract all tool_use blocks as `(id, name, input)` tuples.
+    pub fn tool_uses(&self) -> Vec<(&str, &str, &Value)> {
+        self.content
+            .iter()
+            .filter_map(|b| match b {
+                ContentBlock::ToolUse { id, name, input } => {
+                    Some((id.as_str(), name.as_str(), input))
+                }
+                _ => None,
+            })
+            .collect()
+    }
+}
+
+// ── Tool definition ─────────────────────────────────────────────────
+
+/// A tool definition for the Claude API.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolDefinition {
+    pub name: String,
+    pub description: String,
+    pub input_schema: Value,
+}
+
+// ── API request/response ────────────────────────────────────────────
+
+/// Wire format for the Messages API request (not public).
+#[derive(Debug, Serialize)]
+struct ApiRequest<'a> {
+    model: &'a str,
+    max_tokens: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    system: Option<&'a str>,
+    messages: &'a [Message],
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    tools: &'a Vec<ToolDefinition>,
+}
+
+/// Token usage from the API response.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Usage {
+    pub input_tokens: u32,
+    pub output_tokens: u32,
+}
+
+/// Wire format for the Messages API response.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ApiResponse {
+    pub id: String,
+    pub content: Vec<ContentBlock>,
+    pub stop_reason: Option<String>,
+    pub usage: Usage,
+}
+
+// ── Client ──────────────────────────────────────────────────────────
+
+/// A minimal Claude API client.
+#[derive(Debug)]
+pub struct ClaudeClient {
+    client: reqwest::Client,
+    api_key: String,
+    model: String,
+}
+
+impl ClaudeClient {
+    /// Create a client from the `ANTHROPIC_API_KEY` environment variable.
+    ///
+    /// Uses `DEFAULT_MODEL` when `model` is `None`.
+    pub fn from_env(model: Option<&str>) -> Result<Self> {
+        let api_key = std::env::var("ANTHROPIC_API_KEY").map_err(|_| ClaudeError::MissingApiKey)?;
+
+        Ok(Self {
+            client: reqwest::Client::new(),
+            api_key,
+            model: model.unwrap_or(DEFAULT_MODEL).to_string(),
+        })
+    }
+
+    /// Send a message to the Claude API.
+    ///
+    /// Returns the parsed API response or a `ClaudeError`.
+    pub async fn send(
+        &self,
+        system: Option<&str>,
+        messages: &[Message],
+        tools: &Vec<ToolDefinition>,
+    ) -> Result<ApiResponse> {
+        let body = ApiRequest {
+            model: &self.model,
+            max_tokens: MAX_TOKENS,
+            system,
+            messages,
+            tools,
+        };
+
+        let response = self
+            .client
+            .post(API_URL)
+            .header("x-api-key", &self.api_key)
+            .header("anthropic-version", API_VERSION)
+            .header("content-type", "application/json")
+            .json(&body)
+            .send()
+            .await?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let message = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "unknown error".to_string());
+            return Err(ClaudeError::Api {
+                status: status.as_u16(),
+                message,
+            });
+        }
+
+        let api_response: ApiResponse = response.json().await?;
+        Ok(api_response)
+    }
+}
+
+// ── Tests ───────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn message_user_constructor() {
+        let msg = Message::user("hello");
+        assert_eq!(msg.role, "user");
+        assert_eq!(msg.content.len(), 1);
+        assert_eq!(msg.text(), "hello");
+    }
+
+    #[test]
+    fn message_text_concatenation() {
+        let msg = Message {
+            role: "assistant".to_string(),
+            content: vec![
+                ContentBlock::Text {
+                    text: "Hello ".to_string(),
+                },
+                ContentBlock::ToolUse {
+                    id: "t1".to_string(),
+                    name: "get_weather".to_string(),
+                    input: json!({}),
+                },
+                ContentBlock::Text {
+                    text: "world".to_string(),
+                },
+            ],
+        };
+        assert_eq!(msg.text(), "Hello world");
+    }
+
+    #[test]
+    fn message_tool_uses_extraction() {
+        let msg = Message {
+            role: "assistant".to_string(),
+            content: vec![
+                ContentBlock::Text {
+                    text: "Let me check.".to_string(),
+                },
+                ContentBlock::ToolUse {
+                    id: "tu_1".to_string(),
+                    name: "list_nodes".to_string(),
+                    input: json!({"status": "running"}),
+                },
+                ContentBlock::ToolUse {
+                    id: "tu_2".to_string(),
+                    name: "get_health".to_string(),
+                    input: json!({}),
+                },
+            ],
+        };
+
+        let uses = msg.tool_uses();
+        assert_eq!(uses.len(), 2);
+        assert_eq!(uses[0].0, "tu_1");
+        assert_eq!(uses[0].1, "list_nodes");
+        assert_eq!(uses[0].2, &json!({"status": "running"}));
+        assert_eq!(uses[1].0, "tu_2");
+        assert_eq!(uses[1].1, "get_health");
+    }
+
+    #[test]
+    fn tool_result_message() {
+        let msg = Message::tool_results(vec![
+            ("tu_1".to_string(), "success".to_string(), None),
+            ("tu_2".to_string(), "not found".to_string(), Some(true)),
+        ]);
+
+        assert_eq!(msg.role, "user");
+        assert_eq!(msg.content.len(), 2);
+
+        match &msg.content[0] {
+            ContentBlock::ToolResult {
+                tool_use_id,
+                content,
+                is_error,
+            } => {
+                assert_eq!(tool_use_id, "tu_1");
+                assert_eq!(content, "success");
+                assert_eq!(*is_error, None);
+            }
+            _ => panic!("expected ToolResult"),
+        }
+
+        match &msg.content[1] {
+            ContentBlock::ToolResult {
+                tool_use_id,
+                content,
+                is_error,
+            } => {
+                assert_eq!(tool_use_id, "tu_2");
+                assert_eq!(content, "not found");
+                assert_eq!(*is_error, Some(true));
+            }
+            _ => panic!("expected ToolResult"),
+        }
+    }
+
+    #[test]
+    fn content_block_serde_text() {
+        let block = ContentBlock::Text {
+            text: "hello".to_string(),
+        };
+        let json = serde_json::to_string(&block).unwrap();
+        let parsed: ContentBlock = serde_json::from_str(&json).unwrap();
+        assert_eq!(block, parsed);
+    }
+
+    #[test]
+    fn content_block_serde_tool_use() {
+        let json_str = r#"{
+            "type": "tool_use",
+            "id": "toolu_abc",
+            "name": "list_nodes",
+            "input": {"filter": "running"}
+        }"#;
+        let block: ContentBlock = serde_json::from_str(json_str).unwrap();
+        match &block {
+            ContentBlock::ToolUse { id, name, input } => {
+                assert_eq!(id, "toolu_abc");
+                assert_eq!(name, "list_nodes");
+                assert_eq!(input["filter"], "running");
+            }
+            _ => panic!("expected ToolUse"),
+        }
+    }
+
+    #[test]
+    fn content_block_serde_tool_result() {
+        let block = ContentBlock::ToolResult {
+            tool_use_id: "toolu_abc".to_string(),
+            content: "done".to_string(),
+            is_error: Some(false),
+        };
+        let json = serde_json::to_string(&block).unwrap();
+        let parsed: ContentBlock = serde_json::from_str(&json).unwrap();
+        assert_eq!(block, parsed);
+
+        // Verify is_error=None is omitted from serialization
+        let block_no_err = ContentBlock::ToolResult {
+            tool_use_id: "toolu_xyz".to_string(),
+            content: "ok".to_string(),
+            is_error: None,
+        };
+        let json_no_err = serde_json::to_string(&block_no_err).unwrap();
+        assert!(!json_no_err.contains("is_error"));
+        let parsed_no_err: ContentBlock = serde_json::from_str(&json_no_err).unwrap();
+        assert_eq!(block_no_err, parsed_no_err);
+    }
+
+    #[test]
+    fn api_response_deserialization() {
+        let json_str = r#"{
+            "id": "msg_01XFDUDYJgAACzvnptvVoYEL",
+            "content": [
+                {"type": "text", "text": "Hello! How can I help?"}
+            ],
+            "stop_reason": "end_turn",
+            "usage": {"input_tokens": 10, "output_tokens": 25}
+        }"#;
+        let resp: ApiResponse = serde_json::from_str(json_str).unwrap();
+        assert_eq!(resp.id, "msg_01XFDUDYJgAACzvnptvVoYEL");
+        assert_eq!(resp.content.len(), 1);
+        assert_eq!(resp.stop_reason.as_deref(), Some("end_turn"));
+        assert_eq!(resp.usage.input_tokens, 10);
+        assert_eq!(resp.usage.output_tokens, 25);
+    }
+
+    #[test]
+    fn api_response_with_tool_use() {
+        let json_str = r#"{
+            "id": "msg_02abc",
+            "content": [
+                {"type": "text", "text": "I'll check that for you."},
+                {
+                    "type": "tool_use",
+                    "id": "toolu_01A",
+                    "name": "list_nodes",
+                    "input": {"status": "all"}
+                }
+            ],
+            "stop_reason": "tool_use",
+            "usage": {"input_tokens": 50, "output_tokens": 100}
+        }"#;
+        let resp: ApiResponse = serde_json::from_str(json_str).unwrap();
+        assert_eq!(resp.stop_reason.as_deref(), Some("tool_use"));
+        assert_eq!(resp.content.len(), 2);
+
+        match &resp.content[1] {
+            ContentBlock::ToolUse { id, name, input } => {
+                assert_eq!(id, "toolu_01A");
+                assert_eq!(name, "list_nodes");
+                assert_eq!(input["status"], "all");
+            }
+            _ => panic!("expected ToolUse"),
+        }
+    }
+
+    #[test]
+    fn client_from_env_missing_key() {
+        // Ensure the key is not set (test isolation: we cannot unset
+        // env vars safely across threads, so we just check that if it
+        // happens to be unset the error is correct).
+        // Use a temp override approach: save, remove, test, restore.
+        let saved = std::env::var("ANTHROPIC_API_KEY").ok();
+        std::env::remove_var("ANTHROPIC_API_KEY");
+
+        let result = ClaudeClient::from_env(None);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err, ClaudeError::MissingApiKey),
+            "expected MissingApiKey, got: {err:?}"
+        );
+
+        // Restore if it was set
+        if let Some(key) = saved {
+            std::env::set_var("ANTHROPIC_API_KEY", key);
+        }
+    }
+
+    #[test]
+    fn tool_definition_serialization() {
+        let tool = ToolDefinition {
+            name: "list_nodes".to_string(),
+            description: "List all registered nodes".to_string(),
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "status": {
+                        "type": "string",
+                        "description": "Filter by status"
+                    }
+                },
+                "required": []
+            }),
+        };
+
+        let json = serde_json::to_value(&tool).unwrap();
+        assert_eq!(json["name"], "list_nodes");
+        assert_eq!(json["description"], "List all registered nodes");
+        assert_eq!(json["input_schema"]["type"], "object");
+
+        // Roundtrip
+        let parsed: ToolDefinition = serde_json::from_value(json).unwrap();
+        assert_eq!(parsed.name, "list_nodes");
+    }
+}

--- a/crates/bubbaloop/src/agent/dispatch.rs
+++ b/crates/bubbaloop/src/agent/dispatch.rs
@@ -1,0 +1,796 @@
+//! Internal MCP tool dispatch — calls PlatformOperations directly.
+//!
+//! Maps tool names to platform method calls without going through the full
+//! MCP server stack (avoids constructing `RequestContext`).
+
+use crate::agent::claude::{ContentBlock, ToolDefinition};
+use crate::mcp::platform::{NodeCommand, PlatformOperations};
+use crate::validation;
+use serde_json::{json, Value};
+use std::sync::Arc;
+
+/// Dispatches MCP tool calls directly to `PlatformOperations` methods.
+pub struct Dispatcher<P: PlatformOperations> {
+    platform: Arc<P>,
+    scope: String,
+    machine_id: String,
+}
+
+impl<P: PlatformOperations> Dispatcher<P> {
+    /// Create a new dispatcher.
+    pub fn new(platform: Arc<P>, scope: String, machine_id: String) -> Self {
+        Self {
+            platform,
+            scope,
+            machine_id,
+        }
+    }
+
+    /// Returns Claude-compatible tool definitions for all 24 MCP tools.
+    ///
+    /// Names, descriptions, and schemas match the MCP server exactly.
+    pub fn tool_definitions() -> Vec<ToolDefinition> {
+        let empty_object = json!({
+            "type": "object",
+            "properties": {},
+            "required": []
+        });
+
+        let node_name_schema = json!({
+            "type": "object",
+            "properties": {
+                "node_name": {
+                    "type": "string",
+                    "description": "Name of the node (e.g., \"rtsp-camera\", \"openmeteo\")"
+                }
+            },
+            "required": ["node_name"]
+        });
+
+        vec![
+            // ── No-parameter tools ──────────────────────────────────
+            ToolDefinition {
+                name: "list_nodes".to_string(),
+                description: "List all registered nodes with their status, capabilities, \
+                    and topics. Returns node name, status (running/stopped/etc), type, \
+                    and whether it's built."
+                    .to_string(),
+                input_schema: empty_object.clone(),
+            },
+            ToolDefinition {
+                name: "discover_nodes".to_string(),
+                description: "Discover all nodes across all machines by querying manifests. \
+                    Returns a list of all self-describing nodes with their capabilities."
+                    .to_string(),
+                input_schema: empty_object.clone(),
+            },
+            ToolDefinition {
+                name: "get_system_status".to_string(),
+                description: "Get overall system status including daemon health, node count, \
+                    and Zenoh connection state."
+                    .to_string(),
+                input_schema: empty_object.clone(),
+            },
+            ToolDefinition {
+                name: "get_machine_info".to_string(),
+                description: "Get machine hardware and OS information: architecture, \
+                    hostname, OS version."
+                    .to_string(),
+                input_schema: empty_object,
+            },
+            // ── Single node_name tools ──────────────────────────────
+            ToolDefinition {
+                name: "get_node_health".to_string(),
+                description: "Get detailed health status of a specific node including uptime."
+                    .to_string(),
+                input_schema: node_name_schema.clone(),
+            },
+            ToolDefinition {
+                name: "get_node_config".to_string(),
+                description: "Get the current configuration of a node by querying its \
+                    Zenoh config queryable."
+                    .to_string(),
+                input_schema: node_name_schema.clone(),
+            },
+            ToolDefinition {
+                name: "get_node_manifest".to_string(),
+                description: "Get the full manifest for a node, including capabilities, \
+                    published topics, commands, and hardware requirements."
+                    .to_string(),
+                input_schema: node_name_schema.clone(),
+            },
+            ToolDefinition {
+                name: "list_commands".to_string(),
+                description: "List available commands for a specific node with their \
+                    parameters and descriptions. Use this before send_command to discover \
+                    what actions a node supports."
+                    .to_string(),
+                input_schema: node_name_schema.clone(),
+            },
+            ToolDefinition {
+                name: "start_node".to_string(),
+                description: "Start a stopped node via the daemon. The node must be \
+                    installed and built."
+                    .to_string(),
+                input_schema: node_name_schema.clone(),
+            },
+            ToolDefinition {
+                name: "stop_node".to_string(),
+                description: "Stop a running node via the daemon.".to_string(),
+                input_schema: node_name_schema.clone(),
+            },
+            ToolDefinition {
+                name: "restart_node".to_string(),
+                description: "Restart a node (stop then start).".to_string(),
+                input_schema: node_name_schema.clone(),
+            },
+            ToolDefinition {
+                name: "get_node_logs".to_string(),
+                description: "Get the latest logs from a node's systemd service.".to_string(),
+                input_schema: node_name_schema.clone(),
+            },
+            ToolDefinition {
+                name: "build_node".to_string(),
+                description: "Trigger a build for a node. Builds the node's source code \
+                    using its configured build command (Cargo, pixi, etc.). Admin only."
+                    .to_string(),
+                input_schema: node_name_schema.clone(),
+            },
+            ToolDefinition {
+                name: "remove_node".to_string(),
+                description: "Remove a registered node. Stops the node first if it is \
+                    running, then removes it from the daemon registry. Admin only."
+                    .to_string(),
+                input_schema: node_name_schema.clone(),
+            },
+            ToolDefinition {
+                name: "uninstall_node".to_string(),
+                description: "Uninstall a node's systemd service. Stops the node if \
+                    running and removes the systemd service file, but keeps the node \
+                    registered. Admin only."
+                    .to_string(),
+                input_schema: node_name_schema.clone(),
+            },
+            ToolDefinition {
+                name: "clean_node".to_string(),
+                description: "Clean a node's build artifacts and cached data. Useful for \
+                    forcing a rebuild. Admin only."
+                    .to_string(),
+                input_schema: node_name_schema.clone(),
+            },
+            ToolDefinition {
+                name: "enable_autostart".to_string(),
+                description: "Enable autostart for a node. The node's systemd service \
+                    will start automatically on boot."
+                    .to_string(),
+                input_schema: node_name_schema.clone(),
+            },
+            ToolDefinition {
+                name: "disable_autostart".to_string(),
+                description: "Disable autostart for a node. The node's systemd service \
+                    will no longer start automatically on boot."
+                    .to_string(),
+                input_schema: node_name_schema.clone(),
+            },
+            ToolDefinition {
+                name: "get_stream_info".to_string(),
+                description: "Get Zenoh connection parameters for subscribing to a node's \
+                    data stream. Returns topic pattern, encoding, and endpoint. Use this \
+                    to set up streaming data access outside MCP."
+                    .to_string(),
+                input_schema: node_name_schema.clone(),
+            },
+            ToolDefinition {
+                name: "get_node_schema".to_string(),
+                description: "Get the protobuf schema of a node's data messages. Returns \
+                    the schema in human-readable format if available."
+                    .to_string(),
+                input_schema: node_name_schema,
+            },
+            // ── Custom-parameter tools ──────────────────────────────
+            ToolDefinition {
+                name: "send_command".to_string(),
+                description: "Send a command to a node's command queryable. The node must \
+                    support the command — call list_commands first to see available commands. \
+                    Example: node_name='rtsp-camera', command='capture_frame', \
+                    params={\"resolution\": \"1080p\"}. Returns the command result or error."
+                    .to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "node_name": {
+                            "type": "string",
+                            "description": "Name of the node to send the command to"
+                        },
+                        "command": {
+                            "type": "string",
+                            "description": "Command name (must be listed in the node's manifest)"
+                        },
+                        "params": {
+                            "description": "Optional JSON parameters for the command"
+                        }
+                    },
+                    "required": ["node_name", "command"]
+                }),
+            },
+            ToolDefinition {
+                name: "query_zenoh".to_string(),
+                description: "Query a Zenoh key expression (admin only). Key must start \
+                    with 'bubbaloop/'. Returns up to 100 results."
+                    .to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "key_expr": {
+                            "type": "string",
+                            "description": "Full Zenoh key expression to query (e.g., \
+                                \"bubbaloop/local/nvidia_orin00/openmeteo/status\")"
+                        }
+                    },
+                    "required": ["key_expr"]
+                }),
+            },
+            ToolDefinition {
+                name: "install_node".to_string(),
+                description: "Install a node from the marketplace, a local path, or \
+                    GitHub repository. Accepts a marketplace name (e.g., 'rtsp-camera'), \
+                    a local directory path (e.g., '/path/to/my-node'), or GitHub format \
+                    (e.g., 'user/repo'). Downloads precompiled binaries when available, \
+                    registers the node with the daemon, and creates the systemd service. \
+                    Admin only."
+                    .to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "source": {
+                            "type": "string",
+                            "description": "Source path: marketplace name, local directory \
+                                path, or GitHub \"user/repo\" format"
+                        }
+                    },
+                    "required": ["source"]
+                }),
+            },
+            ToolDefinition {
+                name: "discover_capabilities".to_string(),
+                description: "Discover available node capabilities. Returns nodes grouped \
+                    by capability type (sensor, actuator, processor, gateway). Optionally \
+                    filter by a single capability type."
+                    .to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "capability": {
+                            "type": "string",
+                            "description": "Filter by capability type: \"sensor\", \
+                                \"actuator\", \"processor\", \"gateway\". Omit for all."
+                        }
+                    },
+                    "required": []
+                }),
+            },
+        ]
+    }
+
+    /// Dispatch a tool call by name, returning a `ContentBlock::ToolResult`.
+    ///
+    /// Maps all 24 tool names to the corresponding `PlatformOperations` method.
+    pub async fn call_tool(&self, tool_use_id: &str, name: &str, input: &Value) -> ContentBlock {
+        let (text, is_error) = match name {
+            // ── No-parameter tools ──────────────────────────────────
+            "list_nodes" => self.handle_list_nodes().await,
+            "discover_nodes" => self.handle_discover_nodes().await,
+            "get_system_status" => self.handle_get_system_status().await,
+            "get_machine_info" => self.handle_get_machine_info(),
+
+            // ── Single node_name tools ──────────────────────────────
+            "get_node_health" => self.handle_get_node_health(input).await,
+            "get_node_config" => self.handle_get_node_config(input).await,
+            "get_node_manifest" => self.handle_get_node_manifest(input).await,
+            "list_commands" => self.handle_list_commands(input).await,
+            "start_node" => self.handle_node_command(input, NodeCommand::Start).await,
+            "stop_node" => self.handle_node_command(input, NodeCommand::Stop).await,
+            "restart_node" => self.handle_node_command(input, NodeCommand::Restart).await,
+            "get_node_logs" => self.handle_node_command(input, NodeCommand::GetLogs).await,
+            "build_node" => self.handle_node_command(input, NodeCommand::Build).await,
+            "remove_node" => self.handle_remove_node(input).await,
+            "uninstall_node" => {
+                self.handle_node_command(input, NodeCommand::Uninstall)
+                    .await
+            }
+            "clean_node" => self.handle_node_command(input, NodeCommand::Clean).await,
+            "enable_autostart" => {
+                self.handle_node_command(input, NodeCommand::EnableAutostart)
+                    .await
+            }
+            "disable_autostart" => {
+                self.handle_node_command(input, NodeCommand::DisableAutostart)
+                    .await
+            }
+            "get_stream_info" => self.handle_get_stream_info(input).await,
+            "get_node_schema" => self.handle_get_node_schema(input).await,
+
+            // ── Custom-parameter tools ──────────────────────────────
+            "send_command" => self.handle_send_command(input).await,
+            "query_zenoh" => self.handle_query_zenoh(input).await,
+            "install_node" => self.handle_install_node(input).await,
+            "discover_capabilities" => self.handle_discover_capabilities(input).await,
+
+            _ => (format!("Unknown tool: {}", name), Some(true)),
+        };
+
+        ContentBlock::ToolResult {
+            tool_use_id: tool_use_id.to_string(),
+            content: text,
+            is_error,
+        }
+    }
+
+    /// List nodes and format as a text summary for the agent system prompt.
+    pub async fn get_node_inventory(&self) -> String {
+        match self.platform.list_nodes().await {
+            Ok(nodes) if nodes.is_empty() => "No nodes registered.".to_string(),
+            Ok(nodes) => {
+                let mut lines = Vec::with_capacity(nodes.len() + 1);
+                lines.push(format!("{} node(s) registered:", nodes.len()));
+                for n in &nodes {
+                    lines.push(format!(
+                        "  - {} [status={}, health={}, type={}, installed={}, built={}]",
+                        n.name, n.status, n.health, n.node_type, n.installed, n.is_built,
+                    ));
+                }
+                lines.join("\n")
+            }
+            Err(e) => format!("Failed to list nodes: {}", e),
+        }
+    }
+
+    // ── Internal helpers ─────────────────────────────────────────────
+
+    /// Extract and validate `node_name` from JSON input.
+    fn extract_node_name(input: &Value) -> Result<String, (String, Option<bool>)> {
+        let name = input
+            .get("node_name")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| {
+                (
+                    "Missing required parameter: node_name".to_string(),
+                    Some(true),
+                )
+            })?;
+        validation::validate_node_name(name).map_err(|e| (e, Some(true)))?;
+        Ok(name.to_string())
+    }
+
+    /// Extract `node_name`, validate, and execute a `NodeCommand`.
+    async fn handle_node_command(&self, input: &Value, cmd: NodeCommand) -> (String, Option<bool>) {
+        let node_name = match Self::extract_node_name(input) {
+            Ok(n) => n,
+            Err(e) => return e,
+        };
+        match self.platform.execute_command(&node_name, cmd).await {
+            Ok(msg) => (msg, None),
+            Err(e) => (format!("Error: {}", e), Some(true)),
+        }
+    }
+
+    // ── No-parameter tool handlers ───────────────────────────────────
+
+    async fn handle_list_nodes(&self) -> (String, Option<bool>) {
+        match self.platform.list_nodes().await {
+            Ok(nodes) => {
+                let json_nodes: Vec<Value> = nodes
+                    .iter()
+                    .map(|n| {
+                        json!({
+                            "name": n.name,
+                            "status": n.status,
+                            "health": n.health,
+                            "installed": n.installed,
+                            "is_built": n.is_built,
+                            "node_type": n.node_type,
+                        })
+                    })
+                    .collect();
+                let text =
+                    serde_json::to_string_pretty(&json_nodes).unwrap_or_else(|_| "[]".to_string());
+                (text, None)
+            }
+            Err(e) => (format!("Error: {}", e), Some(true)),
+        }
+    }
+
+    async fn handle_discover_nodes(&self) -> (String, Option<bool>) {
+        match self.platform.query_zenoh("bubbaloop/**/manifest").await {
+            Ok(result) => (result, None),
+            Err(e) => (format!("Error: {}", e), Some(true)),
+        }
+    }
+
+    async fn handle_get_system_status(&self) -> (String, Option<bool>) {
+        let nodes = self.platform.list_nodes().await;
+        let (total, running, healthy) = match &nodes {
+            Ok(list) => {
+                let total = list.len();
+                let running = list.iter().filter(|n| n.status == "Running").count();
+                let healthy = list.iter().filter(|n| n.health == "Healthy").count();
+                (total, running, healthy)
+            }
+            Err(_) => (0, 0, 0),
+        };
+        let status = json!({
+            "scope": self.scope,
+            "machine_id": self.machine_id,
+            "nodes_total": total,
+            "nodes_running": running,
+            "nodes_healthy": healthy,
+            "mcp_server": "running",
+        });
+        let text = serde_json::to_string_pretty(&status).unwrap_or_else(|_| "{}".to_string());
+        (text, None)
+    }
+
+    fn handle_get_machine_info(&self) -> (String, Option<bool>) {
+        let info = json!({
+            "machine_id": self.machine_id,
+            "scope": self.scope,
+            "arch": std::env::consts::ARCH,
+            "os": std::env::consts::OS,
+            "hostname": hostname::get()
+                .ok()
+                .and_then(|h| h.into_string().ok())
+                .unwrap_or_else(|| "unknown".to_string()),
+        });
+        let text = serde_json::to_string_pretty(&info).unwrap_or_else(|_| "{}".to_string());
+        (text, None)
+    }
+
+    // ── Node-name tool handlers ──────────────────────────────────────
+
+    async fn handle_get_node_health(&self, input: &Value) -> (String, Option<bool>) {
+        let node_name = match Self::extract_node_name(input) {
+            Ok(n) => n,
+            Err(e) => return e,
+        };
+        match self.platform.get_node_detail(&node_name).await {
+            Ok(detail) => {
+                let text = serde_json::to_string_pretty(&detail).unwrap_or_default();
+                (text, None)
+            }
+            Err(crate::mcp::platform::PlatformError::NodeNotFound(_)) => {
+                (format!("Node '{}' not found", node_name), Some(true))
+            }
+            Err(e) => (format!("Error: {}", e), Some(true)),
+        }
+    }
+
+    async fn handle_get_node_config(&self, input: &Value) -> (String, Option<bool>) {
+        let node_name = match Self::extract_node_name(input) {
+            Ok(n) => n,
+            Err(e) => return e,
+        };
+        match self.platform.get_node_config(&node_name).await {
+            Ok(config) => {
+                let text = serde_json::to_string_pretty(&config).unwrap_or_default();
+                (text, None)
+            }
+            Err(e) => (format!("Error: {}", e), Some(true)),
+        }
+    }
+
+    async fn handle_get_node_manifest(&self, input: &Value) -> (String, Option<bool>) {
+        let node_name = match Self::extract_node_name(input) {
+            Ok(n) => n,
+            Err(e) => return e,
+        };
+        match self.platform.get_manifests(None).await {
+            Ok(manifests) => {
+                let found = manifests.into_iter().find(|(name, _)| name == &node_name);
+                match found {
+                    Some((_name, manifest)) => {
+                        let text = serde_json::to_string_pretty(&manifest).unwrap_or_default();
+                        (text, None)
+                    }
+                    None => (
+                        format!("No manifest found for node '{}'", node_name),
+                        Some(true),
+                    ),
+                }
+            }
+            Err(e) => (format!("Error: {}", e), Some(true)),
+        }
+    }
+
+    async fn handle_list_commands(&self, input: &Value) -> (String, Option<bool>) {
+        let node_name = match Self::extract_node_name(input) {
+            Ok(n) => n,
+            Err(e) => return e,
+        };
+        let key_expr = format!(
+            "bubbaloop/{}/{}/{}/manifest",
+            self.scope, self.machine_id, node_name
+        );
+        let manifest_text = match self.platform.query_zenoh(&key_expr).await {
+            Ok(text) => text,
+            Err(e) => return (format!("Error: {}", e), Some(true)),
+        };
+        // Try to parse the manifest and extract commands.
+        // query_zenoh formats as "[key_expr] json_body".
+        let commands = manifest_text
+            .lines()
+            .filter_map(|line| {
+                let json_start = line.find(']').map(|i| i + 2)?;
+                let json_str = line.get(json_start..)?;
+                let manifest: Value = serde_json::from_str(json_str).ok()?;
+                manifest.get("commands").cloned()
+            })
+            .next();
+
+        match commands {
+            Some(cmds) if cmds.is_array() && !cmds.as_array().unwrap().is_empty() => {
+                let text = serde_json::to_string_pretty(&cmds).unwrap_or_else(|_| "[]".to_string());
+                (text, None)
+            }
+            _ => (
+                format!("No commands available for node '{}'", node_name),
+                None,
+            ),
+        }
+    }
+
+    async fn handle_remove_node(&self, input: &Value) -> (String, Option<bool>) {
+        let node_name = match Self::extract_node_name(input) {
+            Ok(n) => n,
+            Err(e) => return e,
+        };
+        match self.platform.remove_node(&node_name).await {
+            Ok(msg) => (msg, None),
+            Err(e) => (format!("Error: {}", e), Some(true)),
+        }
+    }
+
+    async fn handle_get_stream_info(&self, input: &Value) -> (String, Option<bool>) {
+        let node_name = match Self::extract_node_name(input) {
+            Ok(n) => n,
+            Err(e) => return e,
+        };
+        let info = json!({
+            "zenoh_topic": format!(
+                "bubbaloop/{}/{}/{}/**",
+                self.scope, self.machine_id, node_name
+            ),
+            "encoding": "protobuf",
+            "endpoint": "tcp/localhost:7447",
+            "note": "Subscribe to this topic via Zenoh client library for real-time \
+                data. MCP is control-plane only.",
+        });
+        let text = serde_json::to_string_pretty(&info).unwrap_or_else(|_| "{}".to_string());
+        (text, None)
+    }
+
+    async fn handle_get_node_schema(&self, input: &Value) -> (String, Option<bool>) {
+        let node_name = match Self::extract_node_name(input) {
+            Ok(n) => n,
+            Err(e) => return e,
+        };
+        let key = format!(
+            "bubbaloop/{}/{}/{}/schema",
+            self.scope, self.machine_id, node_name
+        );
+        match self.platform.query_zenoh(&key).await {
+            Ok(result) => (result, None),
+            Err(e) => (format!("Error: {}", e), Some(true)),
+        }
+    }
+
+    // ── Custom-parameter tool handlers ───────────────────────────────
+
+    async fn handle_send_command(&self, input: &Value) -> (String, Option<bool>) {
+        let node_name = match Self::extract_node_name(input) {
+            Ok(n) => n,
+            Err(e) => return e,
+        };
+        let command = match input.get("command").and_then(|v| v.as_str()) {
+            Some(cmd) => cmd.to_string(),
+            None => {
+                return (
+                    "Missing required parameter: command".to_string(),
+                    Some(true),
+                )
+            }
+        };
+        let params = input.get("params").cloned().unwrap_or(json!({}));
+
+        let key_expr = format!(
+            "bubbaloop/{}/{}/{}/command",
+            self.scope, self.machine_id, node_name
+        );
+        let payload = json!({
+            "command": command,
+            "params": params,
+        });
+        let payload_bytes = serde_json::to_vec(&payload).unwrap_or_default();
+
+        match self
+            .platform
+            .send_zenoh_query(&key_expr, payload_bytes)
+            .await
+        {
+            Ok(results) => {
+                if results.is_empty() {
+                    ("No response from node (is it running?)".to_string(), None)
+                } else {
+                    (results.join("\n"), None)
+                }
+            }
+            Err(e) => (format!("Error: {}", e), Some(true)),
+        }
+    }
+
+    async fn handle_query_zenoh(&self, input: &Value) -> (String, Option<bool>) {
+        let key_expr = match input.get("key_expr").and_then(|v| v.as_str()) {
+            Some(k) => k.to_string(),
+            None => {
+                return (
+                    "Missing required parameter: key_expr".to_string(),
+                    Some(true),
+                )
+            }
+        };
+        if let Err(e) = validation::validate_query_key_expr(&key_expr) {
+            return (format!("Validation error: {}", e), Some(true));
+        }
+        match self.platform.query_zenoh(&key_expr).await {
+            Ok(result) => (result, None),
+            Err(e) => (format!("Error: {}", e), Some(true)),
+        }
+    }
+
+    async fn handle_install_node(&self, input: &Value) -> (String, Option<bool>) {
+        let source = match input.get("source").and_then(|v| v.as_str()) {
+            Some(s) => s.to_string(),
+            None => return ("Missing required parameter: source".to_string(), Some(true)),
+        };
+
+        // Route based on source format (same logic as MCP server):
+        // - Simple name (no `/`, no `.` prefix, valid node name) -> marketplace
+        // - Path/URL -> existing install_node flow
+        let is_marketplace_name = !source.contains('/')
+            && !source.starts_with('.')
+            && validation::validate_node_name(&source).is_ok();
+
+        let result = if is_marketplace_name {
+            self.platform.install_from_marketplace(&source).await
+        } else {
+            if let Err(e) = validation::validate_install_source(&source) {
+                return (format!("Error: {}", e), Some(true));
+            }
+            self.platform.install_node(&source).await
+        };
+
+        match result {
+            Ok(msg) => (msg, None),
+            Err(e) => (format!("Error: {}", e), Some(true)),
+        }
+    }
+
+    async fn handle_discover_capabilities(&self, input: &Value) -> (String, Option<bool>) {
+        let capability = input
+            .get("capability")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+
+        match self.platform.get_manifests(capability.as_deref()).await {
+            Ok(manifests) => {
+                // Group nodes by capability type (same logic as MCP server).
+                let mut grouped: std::collections::HashMap<String, Vec<Value>> =
+                    std::collections::HashMap::new();
+
+                for (name, manifest) in &manifests {
+                    let capabilities = manifest
+                        .get("capabilities")
+                        .and_then(|c| c.as_array())
+                        .cloned()
+                        .unwrap_or_default();
+
+                    if capabilities.is_empty() {
+                        grouped
+                            .entry("uncategorized".to_string())
+                            .or_default()
+                            .push(json!({
+                                "name": name,
+                                "description": manifest.get("description")
+                                    .and_then(|d| d.as_str()).unwrap_or(""),
+                                "version": manifest.get("version")
+                                    .and_then(|v| v.as_str()).unwrap_or(""),
+                            }));
+                    } else {
+                        for cap in &capabilities {
+                            let cap_str = cap.as_str().unwrap_or("unknown").to_string();
+                            grouped.entry(cap_str).or_default().push(json!({
+                                "name": name,
+                                "description": manifest.get("description")
+                                    .and_then(|d| d.as_str()).unwrap_or(""),
+                                "version": manifest.get("version")
+                                    .and_then(|v| v.as_str()).unwrap_or(""),
+                                "publishes": manifest.get("publishes")
+                                    .cloned().unwrap_or(json!([])),
+                                "commands": manifest.get("commands")
+                                    .cloned().unwrap_or(json!([])),
+                            }));
+                        }
+                    }
+                }
+
+                let result = json!({
+                    "total_nodes": manifests.len(),
+                    "capabilities": grouped,
+                });
+                let text =
+                    serde_json::to_string_pretty(&result).unwrap_or_else(|_| "{}".to_string());
+                (text, None)
+            }
+            Err(e) => (format!("Error: {}", e), Some(true)),
+        }
+    }
+}
+
+// ── Tests ───────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    /// Expected number of tools exposed by the dispatcher.
+    const TOOL_COUNT: usize = 24;
+
+    #[test]
+    fn tool_definitions_count() {
+        let defs = Dispatcher::<crate::mcp::platform::DaemonPlatform>::tool_definitions();
+        assert_eq!(
+            defs.len(),
+            TOOL_COUNT,
+            "expected {} tool definitions, got {}",
+            TOOL_COUNT,
+            defs.len()
+        );
+    }
+
+    #[test]
+    fn tool_definitions_have_required_fields() {
+        let defs = Dispatcher::<crate::mcp::platform::DaemonPlatform>::tool_definitions();
+        for def in &defs {
+            assert!(!def.name.is_empty(), "tool name must not be empty");
+            assert!(
+                !def.description.is_empty(),
+                "tool '{}' must have a description",
+                def.name
+            );
+            assert!(
+                def.input_schema.is_object(),
+                "tool '{}' input_schema must be an object",
+                def.name
+            );
+            assert_eq!(
+                def.input_schema.get("type").and_then(|v| v.as_str()),
+                Some("object"),
+                "tool '{}' input_schema type must be \"object\"",
+                def.name
+            );
+        }
+    }
+
+    #[test]
+    fn tool_definition_names_unique() {
+        let defs = Dispatcher::<crate::mcp::platform::DaemonPlatform>::tool_definitions();
+        let mut seen = HashSet::new();
+        for def in &defs {
+            assert!(
+                seen.insert(def.name.clone()),
+                "duplicate tool name: {}",
+                def.name
+            );
+        }
+    }
+}

--- a/crates/bubbaloop/src/agent/memory.rs
+++ b/crates/bubbaloop/src/agent/memory.rs
@@ -1,0 +1,464 @@
+//! SQLite memory layer — conversations, sensor events, schedules.
+//!
+//! Stores agent conversation history, sensor lifecycle events, and
+//! scheduled jobs in a single SQLite database at `~/.bubbaloop/memory.db`.
+
+use rusqlite::{params, Connection};
+use std::path::Path;
+
+/// Errors from memory operations.
+#[derive(Debug, thiserror::Error)]
+pub enum MemoryError {
+    #[error("SQLite error: {0}")]
+    Sqlite(#[from] rusqlite::Error),
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+pub type Result<T> = std::result::Result<T, MemoryError>;
+
+/// A conversation message row.
+#[derive(Debug, Clone)]
+pub struct ConversationRow {
+    pub id: String,
+    pub timestamp: String,
+    pub role: String,
+    pub content: String,
+    pub tool_calls: Option<String>,
+}
+
+/// A sensor event row.
+#[derive(Debug, Clone)]
+pub struct SensorEvent {
+    pub id: String,
+    pub timestamp: String,
+    pub node_name: String,
+    pub event_type: String,
+    pub details: Option<String>,
+}
+
+/// A scheduled job row.
+#[derive(Debug, Clone)]
+pub struct Schedule {
+    pub id: String,
+    pub name: String,
+    pub cron: String,
+    pub actions: String,
+    pub tier: i32,
+    pub last_run: Option<String>,
+    pub next_run: Option<String>,
+    pub created_by: String,
+}
+
+/// SQLite-backed memory store.
+pub struct Memory {
+    conn: Connection,
+}
+
+impl Memory {
+    /// Open (or create) the memory database at the given path.
+    ///
+    /// Creates all tables if they don't exist. Sets WAL journal mode
+    /// and file permissions to 0600 (owner read/write only).
+    pub fn open(path: &Path) -> Result<Self> {
+        // Ensure parent directory exists
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        let conn = Connection::open(path)?;
+
+        // WAL mode for better concurrent read performance
+        conn.pragma_update(None, "journal_mode", "WAL")?;
+
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS conversations (
+                id          TEXT PRIMARY KEY,
+                timestamp   TEXT NOT NULL,
+                role        TEXT NOT NULL,
+                content     TEXT NOT NULL,
+                tool_calls  TEXT
+            );
+            CREATE INDEX IF NOT EXISTS idx_conv_ts ON conversations(timestamp);
+
+            CREATE TABLE IF NOT EXISTS sensor_events (
+                id          TEXT PRIMARY KEY,
+                timestamp   TEXT NOT NULL,
+                node_name   TEXT NOT NULL,
+                event_type  TEXT NOT NULL,
+                details     TEXT
+            );
+            CREATE INDEX IF NOT EXISTS idx_events_node_ts ON sensor_events(node_name, timestamp);
+
+            CREATE TABLE IF NOT EXISTS schedules (
+                id          TEXT PRIMARY KEY,
+                name        TEXT NOT NULL UNIQUE,
+                cron        TEXT NOT NULL,
+                actions     TEXT NOT NULL,
+                tier        INTEGER NOT NULL DEFAULT 1,
+                last_run    TEXT,
+                next_run    TEXT,
+                created_by  TEXT NOT NULL
+            );",
+        )?;
+
+        // Set file permissions to 0600 (owner read/write only)
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            if path.exists() {
+                let perms = std::fs::Permissions::from_mode(0o600);
+                std::fs::set_permissions(path, perms)?;
+            }
+        }
+
+        Ok(Self { conn })
+    }
+
+    /// Log a conversation message (user, assistant, or tool).
+    pub fn log_message(&self, role: &str, content: &str, tool_calls: Option<&str>) -> Result<()> {
+        let id = uuid::Uuid::new_v4().to_string();
+        let timestamp = now_iso8601();
+        self.conn.execute(
+            "INSERT INTO conversations (id, timestamp, role, content, tool_calls) \
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![id, timestamp, role, content, tool_calls],
+        )?;
+        Ok(())
+    }
+
+    /// Log a sensor event (health change, started, stopped, etc.).
+    pub fn log_event(
+        &self,
+        node_name: &str,
+        event_type: &str,
+        details: Option<&str>,
+    ) -> Result<()> {
+        let id = uuid::Uuid::new_v4().to_string();
+        let timestamp = now_iso8601();
+        self.conn.execute(
+            "INSERT INTO sensor_events (id, timestamp, node_name, event_type, details) \
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![id, timestamp, node_name, event_type, details],
+        )?;
+        Ok(())
+    }
+
+    /// Get recent conversation messages (most recent first).
+    pub fn recent_conversations(&self, limit: usize) -> Result<Vec<ConversationRow>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, timestamp, role, content, tool_calls \
+             FROM conversations ORDER BY timestamp DESC LIMIT ?1",
+        )?;
+        let rows = stmt.query_map(params![limit as i64], |row| {
+            Ok(ConversationRow {
+                id: row.get(0)?,
+                timestamp: row.get(1)?,
+                role: row.get(2)?,
+                content: row.get(3)?,
+                tool_calls: row.get(4)?,
+            })
+        })?;
+        rows.collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(MemoryError::from)
+    }
+
+    /// Get recent sensor events (most recent first).
+    pub fn recent_events(&self, limit: usize) -> Result<Vec<SensorEvent>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, timestamp, node_name, event_type, details \
+             FROM sensor_events ORDER BY timestamp DESC LIMIT ?1",
+        )?;
+        let rows = stmt.query_map(params![limit as i64], |row| {
+            Ok(SensorEvent {
+                id: row.get(0)?,
+                timestamp: row.get(1)?,
+                node_name: row.get(2)?,
+                event_type: row.get(3)?,
+                details: row.get(4)?,
+            })
+        })?;
+        rows.collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(MemoryError::from)
+    }
+
+    /// Get events for a specific node (most recent first).
+    pub fn events_for_node(&self, node_name: &str, limit: usize) -> Result<Vec<SensorEvent>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, timestamp, node_name, event_type, details \
+             FROM sensor_events WHERE node_name = ?1 \
+             ORDER BY timestamp DESC LIMIT ?2",
+        )?;
+        let rows = stmt.query_map(params![node_name, limit as i64], |row| {
+            Ok(SensorEvent {
+                id: row.get(0)?,
+                timestamp: row.get(1)?,
+                node_name: row.get(2)?,
+                event_type: row.get(3)?,
+                details: row.get(4)?,
+            })
+        })?;
+        rows.collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(MemoryError::from)
+    }
+
+    /// Insert or update a schedule (upsert on name conflict).
+    pub fn upsert_schedule(&self, schedule: &Schedule) -> Result<()> {
+        self.conn.execute(
+            "INSERT INTO schedules (id, name, cron, actions, tier, last_run, next_run, created_by) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8) \
+             ON CONFLICT(name) DO UPDATE SET \
+                cron = excluded.cron, \
+                actions = excluded.actions, \
+                tier = excluded.tier, \
+                next_run = excluded.next_run",
+            params![
+                schedule.id,
+                schedule.name,
+                schedule.cron,
+                schedule.actions,
+                schedule.tier,
+                schedule.last_run,
+                schedule.next_run,
+                schedule.created_by,
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// List all schedules, ordered by name.
+    pub fn list_schedules(&self) -> Result<Vec<Schedule>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, name, cron, actions, tier, last_run, next_run, created_by \
+             FROM schedules ORDER BY name",
+        )?;
+        let rows = stmt.query_map([], |row| {
+            Ok(Schedule {
+                id: row.get(0)?,
+                name: row.get(1)?,
+                cron: row.get(2)?,
+                actions: row.get(3)?,
+                tier: row.get(4)?,
+                last_run: row.get(5)?,
+                next_run: row.get(6)?,
+                created_by: row.get(7)?,
+            })
+        })?;
+        rows.collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(MemoryError::from)
+    }
+
+    /// Update last_run and next_run for a schedule.
+    pub fn update_schedule_run(&self, name: &str, last_run: &str, next_run: &str) -> Result<()> {
+        self.conn.execute(
+            "UPDATE schedules SET last_run = ?1, next_run = ?2 WHERE name = ?3",
+            params![last_run, next_run, name],
+        )?;
+        Ok(())
+    }
+
+    /// Delete a schedule by name.
+    pub fn delete_schedule(&self, name: &str) -> Result<()> {
+        self.conn
+            .execute("DELETE FROM schedules WHERE name = ?1", params![name])?;
+        Ok(())
+    }
+}
+
+/// ISO 8601 timestamp for the current time (UTC, no chrono dependency).
+///
+/// Returns a string like `"1709136000"` (Unix epoch seconds), which is
+/// monotonically increasing and sufficient for ordering. A proper ISO 8601
+/// string (e.g. `"2024-02-28T16:00:00Z"`) would require the `chrono` crate.
+fn now_iso8601() -> String {
+    let duration = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default();
+    format!("{}", duration.as_secs())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    /// Helper: create an in-tempdir Memory instance.
+    /// Returns (Memory, TempDir) so the tempdir stays alive.
+    fn test_memory() -> (Memory, tempfile::TempDir) {
+        let dir = tempdir().unwrap();
+        let mem = Memory::open(&dir.path().join("test.db")).unwrap();
+        (mem, dir)
+    }
+
+    #[test]
+    fn open_creates_tables() {
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+        let mem = Memory::open(&db_path).unwrap();
+        // Verify tables exist by running a query on each
+        mem.recent_conversations(1).unwrap();
+        mem.recent_events(1).unwrap();
+        mem.list_schedules().unwrap();
+    }
+
+    #[test]
+    fn open_twice_idempotent() {
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+        Memory::open(&db_path).unwrap();
+        Memory::open(&db_path).unwrap(); // should not error
+    }
+
+    #[test]
+    fn log_and_retrieve_messages() {
+        let (mem, _dir) = test_memory();
+        mem.log_message("user", "hello", None).unwrap();
+        mem.log_message("assistant", "hi there", None).unwrap();
+        mem.log_message(
+            "assistant",
+            "tool result",
+            Some(r#"[{"name":"list_nodes"}]"#),
+        )
+        .unwrap();
+
+        let msgs = mem.recent_conversations(10).unwrap();
+        assert_eq!(msgs.len(), 3);
+        // Most recent first
+        assert_eq!(msgs[0].role, "assistant");
+        assert!(msgs[0].tool_calls.is_some());
+        assert_eq!(msgs[2].role, "user");
+    }
+
+    #[test]
+    fn log_and_retrieve_events() {
+        let (mem, _dir) = test_memory();
+        mem.log_event("rtsp-camera", "started", None).unwrap();
+        mem.log_event("rtsp-camera", "health_ok", Some(r#"{"uptime":120}"#))
+            .unwrap();
+        mem.log_event("system-telemetry", "started", None).unwrap();
+
+        let all = mem.recent_events(10).unwrap();
+        assert_eq!(all.len(), 3);
+
+        let cam = mem.events_for_node("rtsp-camera", 10).unwrap();
+        assert_eq!(cam.len(), 2);
+    }
+
+    #[test]
+    fn upsert_and_list_schedules() {
+        let (mem, _dir) = test_memory();
+        let sched = Schedule {
+            id: "s1".into(),
+            name: "health-patrol".into(),
+            cron: "*/15 * * * *".into(),
+            actions: r#"["check_all_health"]"#.into(),
+            tier: 1,
+            last_run: None,
+            next_run: Some("1709136000".into()),
+            created_by: "yaml".into(),
+        };
+        mem.upsert_schedule(&sched).unwrap();
+
+        let list = mem.list_schedules().unwrap();
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].name, "health-patrol");
+        assert_eq!(list[0].tier, 1);
+    }
+
+    #[test]
+    fn upsert_schedule_updates_existing() {
+        let (mem, _dir) = test_memory();
+        let sched1 = Schedule {
+            id: "s1".into(),
+            name: "patrol".into(),
+            cron: "*/15 * * * *".into(),
+            actions: r#"["check_all_health"]"#.into(),
+            tier: 1,
+            last_run: None,
+            next_run: None,
+            created_by: "yaml".into(),
+        };
+        mem.upsert_schedule(&sched1).unwrap();
+
+        // Update cron via upsert on same name
+        let sched2 = Schedule {
+            id: "s2".into(),
+            name: "patrol".into(),
+            cron: "*/5 * * * *".into(),
+            actions: r#"["check_all_health","restart"]"#.into(),
+            tier: 1,
+            last_run: None,
+            next_run: None,
+            created_by: "yaml".into(),
+        };
+        mem.upsert_schedule(&sched2).unwrap();
+
+        let list = mem.list_schedules().unwrap();
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].cron, "*/5 * * * *");
+    }
+
+    #[test]
+    fn update_schedule_run() {
+        let (mem, _dir) = test_memory();
+        let sched = Schedule {
+            id: "s1".into(),
+            name: "patrol".into(),
+            cron: "*/15 * * * *".into(),
+            actions: "[]".into(),
+            tier: 1,
+            last_run: None,
+            next_run: None,
+            created_by: "yaml".into(),
+        };
+        mem.upsert_schedule(&sched).unwrap();
+        mem.update_schedule_run("patrol", "1709136000", "1709136900")
+            .unwrap();
+
+        let list = mem.list_schedules().unwrap();
+        assert_eq!(list[0].last_run.as_deref(), Some("1709136000"));
+        assert_eq!(list[0].next_run.as_deref(), Some("1709136900"));
+    }
+
+    #[test]
+    fn delete_schedule() {
+        let (mem, _dir) = test_memory();
+        let sched = Schedule {
+            id: "s1".into(),
+            name: "patrol".into(),
+            cron: "*/15 * * * *".into(),
+            actions: "[]".into(),
+            tier: 1,
+            last_run: None,
+            next_run: None,
+            created_by: "yaml".into(),
+        };
+        mem.upsert_schedule(&sched).unwrap();
+        mem.delete_schedule("patrol").unwrap();
+
+        let list = mem.list_schedules().unwrap();
+        assert!(list.is_empty());
+    }
+
+    #[test]
+    fn conversation_limit() {
+        let (mem, _dir) = test_memory();
+        for i in 0..10 {
+            mem.log_message("user", &format!("msg {}", i), None)
+                .unwrap();
+        }
+        let msgs = mem.recent_conversations(3).unwrap();
+        assert_eq!(msgs.len(), 3);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn file_permissions_0600() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("secure.db");
+        Memory::open(&db_path).unwrap();
+        let perms = std::fs::metadata(&db_path).unwrap().permissions();
+        assert_eq!(perms.mode() & 0o777, 0o600);
+    }
+}

--- a/crates/bubbaloop/src/agent/memory.rs
+++ b/crates/bubbaloop/src/agent/memory.rs
@@ -3,6 +3,7 @@
 //! Stores agent conversation history, sensor lifecycle events, and
 //! scheduled jobs in a single SQLite database at `~/.bubbaloop/memory.db`.
 
+use chrono::SecondsFormat;
 use rusqlite::{params, Connection};
 use std::path::Path;
 
@@ -50,6 +51,15 @@ pub struct Schedule {
     pub created_by: String,
 }
 
+/// A skill search result with BM25 rank score.
+#[derive(Debug, Clone)]
+pub struct SkillSearchResult {
+    pub name: String,
+    pub driver: String,
+    pub body: String,
+    pub rank: f64,
+}
+
 /// SQLite-backed memory store.
 pub struct Memory {
     conn: Connection,
@@ -68,8 +78,12 @@ impl Memory {
 
         let conn = Connection::open(path)?;
 
-        // WAL mode for better concurrent read performance
-        conn.pragma_update(None, "journal_mode", "WAL")?;
+        // WAL mode for better concurrent read performance.
+        // Use query_row because bundled-full enables COLUMN_METADATA which
+        // makes pragma_update fail with ExecuteReturnedResults.
+        conn.query_row("PRAGMA journal_mode=WAL", [], |_| Ok(()))?;
+        // Allow up to 5 s wait when another connection holds the write lock
+        conn.query_row("PRAGMA busy_timeout=5000", [], |_| Ok(()))?;
 
         conn.execute_batch(
             "CREATE TABLE IF NOT EXISTS conversations (
@@ -102,6 +116,21 @@ impl Memory {
             );",
         )?;
 
+        // FTS5 virtual tables are created via query() rather than execute_batch()
+        // because SQLite returns SQLITE_ROW for CREATE VIRTUAL TABLE in some
+        // configurations (bundled-full enables extra_check which rejects SQLITE_ROW
+        // from execute), so we use the query path and discard any rows.
+        for fts_ddl in &[
+            "CREATE VIRTUAL TABLE IF NOT EXISTS fts_conversations USING fts5(\
+                id UNINDEXED, role UNINDEXED, content, timestamp UNINDEXED)",
+            "CREATE VIRTUAL TABLE IF NOT EXISTS fts_events USING fts5(\
+                id UNINDEXED, node_name, event_type, details, timestamp UNINDEXED)",
+            "CREATE VIRTUAL TABLE IF NOT EXISTS fts_skills USING fts5(\
+                name, driver UNINDEXED, body)",
+        ] {
+            conn.prepare(fts_ddl)?.query([])?.next()?;
+        }
+
         // Set file permissions to 0600 (owner read/write only)
         #[cfg(unix)]
         {
@@ -118,11 +147,17 @@ impl Memory {
     /// Log a conversation message (user, assistant, or tool).
     pub fn log_message(&self, role: &str, content: &str, tool_calls: Option<&str>) -> Result<()> {
         let id = uuid::Uuid::new_v4().to_string();
-        let timestamp = now_iso8601();
+        let timestamp = now_rfc3339();
         self.conn.execute(
             "INSERT INTO conversations (id, timestamp, role, content, tool_calls) \
              VALUES (?1, ?2, ?3, ?4, ?5)",
             params![id, timestamp, role, content, tool_calls],
+        )?;
+        // Dual-write to FTS5 index for full-text search
+        self.conn.execute(
+            "INSERT INTO fts_conversations (id, role, content, timestamp) \
+             VALUES (?1, ?2, ?3, ?4)",
+            params![id, role, content, timestamp],
         )?;
         Ok(())
     }
@@ -135,11 +170,17 @@ impl Memory {
         details: Option<&str>,
     ) -> Result<()> {
         let id = uuid::Uuid::new_v4().to_string();
-        let timestamp = now_iso8601();
+        let timestamp = now_rfc3339();
         self.conn.execute(
             "INSERT INTO sensor_events (id, timestamp, node_name, event_type, details) \
              VALUES (?1, ?2, ?3, ?4, ?5)",
             params![id, timestamp, node_name, event_type, details],
+        )?;
+        // Dual-write to FTS5 index for full-text search
+        self.conn.execute(
+            "INSERT INTO fts_events (id, node_name, event_type, details, timestamp) \
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![id, node_name, event_type, details.unwrap_or(""), timestamp],
         )?;
         Ok(())
     }
@@ -263,18 +304,168 @@ impl Memory {
             .execute("DELETE FROM schedules WHERE name = ?1", params![name])?;
         Ok(())
     }
+
+    /// Delete conversations older than `days` days (both regular and FTS5 tables).
+    pub fn prune_old_conversations(&self, days: u32) -> Result<usize> {
+        let cutoff = (chrono::Utc::now() - chrono::Duration::days(days as i64))
+            .to_rfc3339_opts(SecondsFormat::Secs, true);
+        // Delete from FTS5 index first (matching by id via subquery)
+        self.conn.execute(
+            "DELETE FROM fts_conversations WHERE id IN \
+             (SELECT id FROM conversations WHERE timestamp < ?1)",
+            params![cutoff],
+        )?;
+        let count = self.conn.execute(
+            "DELETE FROM conversations WHERE timestamp < ?1",
+            params![cutoff],
+        )?;
+        Ok(count)
+    }
+
+    /// Delete sensor events older than `days` days (both regular and FTS5 tables).
+    pub fn prune_old_events(&self, days: u32) -> Result<usize> {
+        let cutoff = (chrono::Utc::now() - chrono::Duration::days(days as i64))
+            .to_rfc3339_opts(SecondsFormat::Secs, true);
+        // Delete from FTS5 index first (matching by id via subquery)
+        self.conn.execute(
+            "DELETE FROM fts_events WHERE id IN \
+             (SELECT id FROM sensor_events WHERE timestamp < ?1)",
+            params![cutoff],
+        )?;
+        let count = self.conn.execute(
+            "DELETE FROM sensor_events WHERE timestamp < ?1",
+            params![cutoff],
+        )?;
+        Ok(count)
+    }
+
+    /// Full-text search over conversations using FTS5 BM25 ranking.
+    pub fn search_conversations(&self, query: &str, limit: usize) -> Result<Vec<ConversationRow>> {
+        if query.is_empty() {
+            return Ok(Vec::new());
+        }
+        let sanitized = sanitize_fts5_query(query);
+        if sanitized.is_empty() {
+            return Ok(Vec::new());
+        }
+        let mut stmt = self.conn.prepare(
+            "SELECT f.id, f.timestamp, f.role, f.content, c.tool_calls \
+             FROM fts_conversations f \
+             JOIN conversations c ON c.id = f.id \
+             WHERE fts_conversations MATCH ?1 \
+             ORDER BY rank \
+             LIMIT ?2",
+        )?;
+        let rows = stmt.query_map(params![sanitized, limit as i64], |row| {
+            Ok(ConversationRow {
+                id: row.get(0)?,
+                timestamp: row.get(1)?,
+                role: row.get(2)?,
+                content: row.get(3)?,
+                tool_calls: row.get(4)?,
+            })
+        })?;
+        rows.collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(MemoryError::from)
+    }
+
+    /// Full-text search over sensor events using FTS5 BM25 ranking.
+    pub fn search_events(&self, query: &str, limit: usize) -> Result<Vec<SensorEvent>> {
+        if query.is_empty() {
+            return Ok(Vec::new());
+        }
+        let sanitized = sanitize_fts5_query(query);
+        if sanitized.is_empty() {
+            return Ok(Vec::new());
+        }
+        let mut stmt = self.conn.prepare(
+            "SELECT f.id, f.timestamp, f.node_name, f.event_type, f.details \
+             FROM fts_events f \
+             WHERE fts_events MATCH ?1 \
+             ORDER BY rank \
+             LIMIT ?2",
+        )?;
+        let rows = stmt.query_map(params![sanitized, limit as i64], |row| {
+            Ok(SensorEvent {
+                id: row.get(0)?,
+                timestamp: row.get(1)?,
+                node_name: row.get(2)?,
+                event_type: row.get(3)?,
+                details: row.get(4)?,
+            })
+        })?;
+        rows.collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(MemoryError::from)
+    }
+
+    /// Full-text search over indexed skills using FTS5 BM25 ranking.
+    pub fn search_skills(&self, query: &str, limit: usize) -> Result<Vec<SkillSearchResult>> {
+        if query.is_empty() {
+            return Ok(Vec::new());
+        }
+        let sanitized = sanitize_fts5_query(query);
+        if sanitized.is_empty() {
+            return Ok(Vec::new());
+        }
+        let mut stmt = self.conn.prepare(
+            "SELECT name, driver, body, rank \
+             FROM fts_skills \
+             WHERE fts_skills MATCH ?1 \
+             ORDER BY rank \
+             LIMIT ?2",
+        )?;
+        let rows = stmt.query_map(params![sanitized, limit as i64], |row| {
+            Ok(SkillSearchResult {
+                name: row.get(0)?,
+                driver: row.get(1)?,
+                body: row.get(2)?,
+                rank: row.get(3)?,
+            })
+        })?;
+        rows.collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(MemoryError::from)
+    }
+
+    /// Index skill bodies into FTS5 for full-text search.
+    ///
+    /// Clears existing skill entries and re-indexes from the provided list.
+    /// Called at agent startup after loading skills from disk.
+    pub fn index_skills(&self, skills: &[crate::skills::SkillConfig]) -> Result<()> {
+        self.conn.execute("DELETE FROM fts_skills", [])?;
+        let mut stmt = self.conn.prepare(
+            "INSERT INTO fts_skills (name, driver, body) VALUES (?1, ?2, ?3)",
+        )?;
+        for skill in skills {
+            if !skill.body.is_empty() {
+                stmt.execute(params![skill.name, skill.driver, skill.body])?;
+            }
+        }
+        Ok(())
+    }
 }
 
-/// ISO 8601 timestamp for the current time (UTC, no chrono dependency).
+/// Sanitize user input for FTS5 MATCH queries.
 ///
-/// Returns a string like `"1709136000"` (Unix epoch seconds), which is
-/// monotonically increasing and sufficient for ordering. A proper ISO 8601
-/// string (e.g. `"2024-02-28T16:00:00Z"`) would require the `chrono` crate.
-fn now_iso8601() -> String {
-    let duration = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default();
-    format!("{}", duration.as_secs())
+/// Wraps each word in double quotes to prevent FTS5 operator interpretation
+/// (AND, OR, NOT, *, etc.) and joins them with spaces (implicit OR).
+fn sanitize_fts5_query(query: &str) -> String {
+    query
+        .split_whitespace()
+        .take(30) // limit to 30 tokens to prevent very long queries
+        .map(|word| {
+            let escaped = word.replace('"', "\"\"");
+            format!("\"{}\"", escaped)
+        })
+        .collect::<Vec<_>>()
+        .join(" OR ")
+}
+
+/// RFC 3339 timestamp for the current time (UTC).
+///
+/// Returns a string like `"2026-02-28T16:00:00Z"` which is both
+/// human-readable and sorts lexicographically for correct ORDER BY.
+fn now_rfc3339() -> String {
+    chrono::Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true)
 }
 
 #[cfg(test)]
@@ -449,6 +640,149 @@ mod tests {
         }
         let msgs = mem.recent_conversations(3).unwrap();
         assert_eq!(msgs.len(), 3);
+    }
+
+    #[test]
+    fn now_rfc3339_returns_valid_format() {
+        let ts = now_rfc3339();
+        // Must look like "2026-02-28T16:00:00Z"
+        assert!(ts.ends_with('Z'), "timestamp should end with Z: {}", ts);
+        assert_eq!(ts.len(), 20, "RFC 3339 secs should be 20 chars: {}", ts);
+        // Verify chrono can parse it back
+        chrono::DateTime::parse_from_rfc3339(&ts).expect("should be valid RFC 3339");
+    }
+
+    #[test]
+    fn busy_timeout_is_set() {
+        let (mem, _dir) = test_memory();
+        let timeout: i64 = mem
+            .conn
+            .pragma_query_value(None, "busy_timeout", |row| row.get(0))
+            .unwrap();
+        assert_eq!(timeout, 5000);
+    }
+
+    #[test]
+    fn prune_old_conversations_deletes_old_rows() {
+        let (mem, _dir) = test_memory();
+        // Insert a row with an old timestamp (epoch string — lexicographically < any RFC 3339 date)
+        mem.conn
+            .execute(
+                "INSERT INTO conversations (id, timestamp, role, content) VALUES (?1, ?2, ?3, ?4)",
+                params!["old1", "1709136000", "user", "ancient message"],
+            )
+            .unwrap();
+        // Insert a current-timestamp row via the normal API
+        mem.log_message("user", "recent message", None).unwrap();
+
+        let pruned = mem.prune_old_conversations(30).unwrap();
+        assert_eq!(pruned, 1, "should prune the old epoch-timestamp row");
+
+        let remaining = mem.recent_conversations(10).unwrap();
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0].content, "recent message");
+    }
+
+    #[test]
+    fn prune_old_events_deletes_old_rows() {
+        let (mem, _dir) = test_memory();
+        // Insert a row with an old timestamp
+        mem.conn
+            .execute(
+                "INSERT INTO sensor_events (id, timestamp, node_name, event_type) VALUES (?1, ?2, ?3, ?4)",
+                params!["old1", "1709136000", "cam", "started"],
+            )
+            .unwrap();
+        // Insert a current-timestamp row
+        mem.log_event("cam", "health_ok", None).unwrap();
+
+        let pruned = mem.prune_old_events(30).unwrap();
+        assert_eq!(pruned, 1);
+
+        let remaining = mem.recent_events(10).unwrap();
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0].event_type, "health_ok");
+    }
+
+    #[test]
+    fn fts_conversations_search() {
+        let (mem, _dir) = test_memory();
+        mem.log_message("user", "the entrance camera keeps freezing", None).unwrap();
+        mem.log_message("user", "what is the weather today", None).unwrap();
+        mem.log_message("assistant", "I checked the camera status", None).unwrap();
+
+        let results = mem.search_conversations("camera", 10).unwrap();
+        assert_eq!(results.len(), 2, "should match 'camera' in two messages");
+        // BM25 rank means more relevant first
+        assert!(results[0].content.contains("camera"));
+    }
+
+    #[test]
+    fn fts_events_search() {
+        let (mem, _dir) = test_memory();
+        mem.log_event("rtsp-camera", "started", None).unwrap();
+        mem.log_event("rtsp-camera", "health_degraded", Some("frame_drop_rate=0.3")).unwrap();
+        mem.log_event("openmeteo", "started", None).unwrap();
+
+        let results = mem.search_events("camera", 10).unwrap();
+        assert_eq!(results.len(), 2, "should match 'camera' in node_name");
+
+        let results = mem.search_events("frame_drop", 10).unwrap();
+        assert_eq!(results.len(), 1, "should match in details");
+    }
+
+    #[test]
+    fn fts_skills_search() {
+        let (mem, _dir) = test_memory();
+        let skills = vec![
+            crate::skills::SkillConfig {
+                name: "entrance-cam".into(),
+                driver: "rtsp".into(),
+                config: Default::default(),
+                schedule: None,
+                actions: Vec::new(),
+                body: "# Entrance Camera\n\nTapo C200 monitoring the front door.".into(),
+            },
+            crate::skills::SkillConfig {
+                name: "weather-station".into(),
+                driver: "http-poll".into(),
+                config: Default::default(),
+                schedule: None,
+                actions: Vec::new(),
+                body: "# Weather\n\nOpenMeteo API for temperature and humidity.".into(),
+            },
+        ];
+        mem.index_skills(&skills).unwrap();
+
+        let results = mem.search_skills("camera entrance", 10).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].name, "entrance-cam");
+
+        let results = mem.search_skills("temperature", 10).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].name, "weather-station");
+    }
+
+    #[test]
+    fn fts_dual_write_consistency() {
+        let (mem, _dir) = test_memory();
+        mem.log_message("user", "check camera health", None).unwrap();
+
+        // Should be findable via both recency and search
+        let recent = mem.recent_conversations(10).unwrap();
+        assert_eq!(recent.len(), 1);
+        let searched = mem.search_conversations("camera health", 10).unwrap();
+        assert_eq!(searched.len(), 1);
+        assert_eq!(recent[0].id, searched[0].id);
+    }
+
+    #[test]
+    fn fts_empty_query_returns_empty() {
+        let (mem, _dir) = test_memory();
+        mem.log_message("user", "hello world", None).unwrap();
+
+        let results = mem.search_conversations("", 10).unwrap();
+        assert!(results.is_empty(), "empty query should return empty results");
     }
 
     #[cfg(unix)]

--- a/crates/bubbaloop/src/agent/mod.rs
+++ b/crates/bubbaloop/src/agent/mod.rs
@@ -1,2 +1,5 @@
+/// Raw reqwest Claude API client with tool_use support.
+pub mod claude;
+
 /// SQLite memory layer — conversations, sensor events, schedules.
 pub mod memory;

--- a/crates/bubbaloop/src/agent/mod.rs
+++ b/crates/bubbaloop/src/agent/mod.rs
@@ -10,6 +10,9 @@ pub mod memory;
 /// System prompt builder — injects live sensor inventory and schedules.
 pub mod prompt;
 
+/// Cron-based scheduler with Tier 1 built-in actions.
+pub mod scheduler;
+
 use crate::agent::claude::{ClaudeClient, ContentBlock, Message};
 use crate::agent::dispatch::Dispatcher;
 use crate::agent::memory::Memory;

--- a/crates/bubbaloop/src/agent/mod.rs
+++ b/crates/bubbaloop/src/agent/mod.rs
@@ -1,5 +1,8 @@
 /// Raw reqwest Claude API client with tool_use support.
 pub mod claude;
 
+/// Internal MCP tool dispatch — calls PlatformOperations directly.
+pub mod dispatch;
+
 /// SQLite memory layer — conversations, sensor events, schedules.
 pub mod memory;

--- a/crates/bubbaloop/src/agent/mod.rs
+++ b/crates/bubbaloop/src/agent/mod.rs
@@ -1,0 +1,2 @@
+/// SQLite memory layer — conversations, sensor events, schedules.
+pub mod memory;

--- a/crates/bubbaloop/src/agent/mod.rs
+++ b/crates/bubbaloop/src/agent/mod.rs
@@ -6,3 +6,192 @@ pub mod dispatch;
 
 /// SQLite memory layer — conversations, sensor events, schedules.
 pub mod memory;
+
+/// System prompt builder — injects live sensor inventory and schedules.
+pub mod prompt;
+
+use crate::agent::claude::{ClaudeClient, ContentBlock, Message};
+use crate::agent::dispatch::Dispatcher;
+use crate::agent::memory::Memory;
+use crate::agent::prompt::build_system_prompt;
+use crate::daemon::registry::get_bubbaloop_home;
+use crate::mcp::platform::DaemonPlatform;
+use std::sync::Arc;
+
+/// Configuration for the interactive agent session.
+pub struct AgentConfig {
+    /// Claude model override (uses default if None).
+    pub model: Option<String>,
+}
+
+/// Run the interactive agent REPL.
+///
+/// Connects to the Claude API, initialises the tool dispatcher and memory
+/// store, then loops reading user input from stdin. Each message is sent
+/// to Claude along with the live system prompt (sensor inventory, schedules,
+/// recent events). Tool-use responses are dispatched and fed back until
+/// the model produces a final text reply.
+pub async fn run_agent(
+    config: AgentConfig,
+    session: Arc<zenoh::Session>,
+    node_manager: Arc<crate::daemon::node_manager::NodeManager>,
+) -> anyhow::Result<()> {
+    // 1. Initialise Claude client from ANTHROPIC_API_KEY env var
+    let client = ClaudeClient::from_env(config.model.as_deref())?;
+
+    // 2. Create dispatcher with DaemonPlatform
+    let scope = std::env::var("BUBBALOOP_SCOPE").unwrap_or_else(|_| "local".to_string());
+    let machine_id = crate::daemon::util::get_machine_id();
+    let platform = Arc::new(DaemonPlatform {
+        node_manager,
+        session,
+        scope: scope.clone(),
+        machine_id: machine_id.clone(),
+    });
+    let dispatcher = Dispatcher::new(platform.clone(), scope, machine_id);
+
+    // 3. Get tool definitions
+    let tools = Dispatcher::<DaemonPlatform>::tool_definitions();
+
+    // 4. Open memory store
+    let memory_path = get_bubbaloop_home().join("memory.db");
+    let memory = Memory::open(&memory_path)?;
+
+    // 5. Welcome message
+    println!(
+        "Bubbaloop Agent ready ({} tools available). Type 'quit' or 'exit' to stop.",
+        tools.len()
+    );
+
+    // 6. Main REPL loop
+    let stdin = std::io::stdin();
+    let mut conversation: Vec<Message> = Vec::new();
+
+    loop {
+        // Read user input
+        print!("> ");
+        // Flush stdout so the prompt appears before blocking on stdin
+        use std::io::Write;
+        std::io::stdout().flush().ok();
+
+        let mut line = String::new();
+        let bytes_read = stdin.read_line(&mut line)?;
+
+        // EOF (Ctrl-D)
+        if bytes_read == 0 {
+            println!();
+            break;
+        }
+
+        let input = line.trim();
+        if input.is_empty() {
+            continue;
+        }
+        if input == "quit" || input == "exit" {
+            break;
+        }
+
+        // Build live system prompt
+        let inventory = dispatcher.get_node_inventory().await;
+        let schedules = memory.list_schedules().unwrap_or_default();
+        let recent_events = memory.recent_events(10).unwrap_or_default();
+        let system_prompt = build_system_prompt(&inventory, &schedules, &recent_events);
+
+        // Add user message
+        conversation.push(Message::user(input));
+
+        // Log user message to memory
+        if let Err(e) = memory.log_message("user", input, None) {
+            log::warn!("Failed to log user message: {}", e);
+        }
+
+        // Send to Claude and handle tool-use loop
+        loop {
+            let response = match client
+                .send(Some(&system_prompt), &conversation, &tools)
+                .await
+            {
+                Ok(r) => r,
+                Err(e) => {
+                    println!("Error: {}", e);
+                    log::error!("Claude API error: {}", e);
+                    break;
+                }
+            };
+
+            // Build assistant message from response content
+            let assistant_msg = Message {
+                role: "assistant".to_string(),
+                content: response.content.clone(),
+            };
+            conversation.push(assistant_msg);
+
+            // Print any text blocks
+            for block in &response.content {
+                if let ContentBlock::Text { text } = block {
+                    println!("{}", text);
+                }
+            }
+
+            // Check for tool calls
+            let tool_uses: Vec<_> = response
+                .content
+                .iter()
+                .filter_map(|b| match b {
+                    ContentBlock::ToolUse { id, name, input } => Some((id, name, input)),
+                    _ => None,
+                })
+                .collect();
+
+            if tool_uses.is_empty() {
+                // No tool calls — log assistant response and break
+                let response_text: String = response
+                    .content
+                    .iter()
+                    .filter_map(|b| match b {
+                        ContentBlock::Text { text } => Some(text.as_str()),
+                        _ => None,
+                    })
+                    .collect::<Vec<_>>()
+                    .join("");
+                if let Err(e) = memory.log_message("assistant", &response_text, None) {
+                    log::warn!("Failed to log assistant message: {}", e);
+                }
+                break;
+            }
+
+            // Dispatch tool calls
+            let mut tool_results = Vec::new();
+            for (id, name, input) in &tool_uses {
+                log::info!("[Agent] calling tool: {}", name);
+                let result = dispatcher.call_tool(id, name, input).await;
+                if let ContentBlock::ToolResult {
+                    tool_use_id,
+                    content,
+                    is_error,
+                } = &result
+                {
+                    tool_results.push((tool_use_id.clone(), content.clone(), *is_error));
+                }
+            }
+
+            // Log tool calls to memory
+            let tool_calls_json = serde_json::to_string(
+                &tool_uses
+                    .iter()
+                    .map(|(_, name, _)| name)
+                    .collect::<Vec<_>>(),
+            )
+            .unwrap_or_default();
+            if let Err(e) = memory.log_message("assistant", "", Some(&tool_calls_json)) {
+                log::warn!("Failed to log tool calls: {}", e);
+            }
+
+            // Add tool results to conversation
+            conversation.push(Message::tool_results(tool_results));
+        }
+    }
+
+    println!("Goodbye.");
+    Ok(())
+}

--- a/crates/bubbaloop/src/agent/prompt.rs
+++ b/crates/bubbaloop/src/agent/prompt.rs
@@ -1,0 +1,175 @@
+//! System prompt builder — injects live sensor inventory and schedules.
+
+use crate::agent::memory::{Schedule, SensorEvent};
+
+/// Build the system prompt with live sensor data injected.
+///
+/// Includes role description, current node inventory, active schedules,
+/// and recent sensor events. The prompt gives the Claude agent full
+/// context about the physical system it controls.
+pub fn build_system_prompt(
+    node_inventory: &str,
+    schedules: &[Schedule],
+    recent_events: &[SensorEvent],
+) -> String {
+    let mut parts = Vec::new();
+
+    // Role description
+    parts.push(
+        "You are Bubbaloop, an AI agent that controls physical sensors and hardware. \
+         You manage a fleet of sensor nodes (cameras, weather stations, telemetry devices) \
+         through the Bubbaloop skill runtime.\n\
+         \n\
+         You can list nodes, start/stop them, check their health, install new nodes from \
+         the marketplace, send commands, and query Zenoh topics. Always verify the current \
+         state before making changes.\n\
+         \n\
+         Be concise but informative. When you perform actions, report what you did and the result."
+            .to_string(),
+    );
+
+    // Current sensor inventory
+    parts.push(format!(
+        "\n## Current Sensor Inventory\n\n{}",
+        if node_inventory.is_empty() {
+            "No sensors installed."
+        } else {
+            node_inventory
+        }
+    ));
+
+    // Active schedules
+    if !schedules.is_empty() {
+        let mut schedule_lines = vec!["\n## Active Schedules\n".to_string()];
+        for sched in schedules {
+            let last = sched.last_run.as_deref().unwrap_or("never");
+            let next = sched.next_run.as_deref().unwrap_or("not scheduled");
+            schedule_lines.push(format!(
+                "- {} (cron: {}, tier: {}, last run: {}, next: {})",
+                sched.name, sched.cron, sched.tier, last, next
+            ));
+        }
+        parts.push(schedule_lines.join("\n"));
+    }
+
+    // Recent events (limit to 10)
+    if !recent_events.is_empty() {
+        let mut event_lines = vec!["\n## Recent Events\n".to_string()];
+        for event in recent_events.iter().take(10) {
+            let details = event.details.as_deref().unwrap_or("");
+            if details.is_empty() {
+                event_lines.push(format!(
+                    "- [{}] {} {}",
+                    event.timestamp, event.node_name, event.event_type
+                ));
+            } else {
+                event_lines.push(format!(
+                    "- [{}] {} {} ({})",
+                    event.timestamp, event.node_name, event.event_type, details
+                ));
+            }
+        }
+        parts.push(event_lines.join("\n"));
+    }
+
+    parts.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prompt_with_empty_inventory() {
+        let prompt = build_system_prompt("", &[], &[]);
+        assert!(prompt.contains("You are Bubbaloop"));
+        assert!(prompt.contains("No sensors installed."));
+        // Should not contain schedule or event sections
+        assert!(!prompt.contains("Active Schedules"));
+        assert!(!prompt.contains("Recent Events"));
+    }
+
+    #[test]
+    fn prompt_with_nodes() {
+        let inventory = "2 node(s) registered:\n  \
+                         - rtsp-camera [status=Running, health=Healthy]\n  \
+                         - openmeteo [status=Stopped, health=Unknown]";
+        let prompt = build_system_prompt(inventory, &[], &[]);
+        assert!(prompt.contains("You are Bubbaloop"));
+        assert!(prompt.contains("rtsp-camera"));
+        assert!(prompt.contains("openmeteo"));
+        assert!(prompt.contains("2 node(s) registered"));
+        // Empty inventory text should NOT appear
+        assert!(!prompt.contains("No sensors installed."));
+    }
+
+    #[test]
+    fn prompt_with_schedules() {
+        let schedules = vec![
+            Schedule {
+                id: "s1".into(),
+                name: "health-patrol".into(),
+                cron: "*/15 * * * *".into(),
+                actions: r#"["check_all_health"]"#.into(),
+                tier: 1,
+                last_run: Some("1709136000".into()),
+                next_run: Some("1709136900".into()),
+                created_by: "yaml".into(),
+            },
+            Schedule {
+                id: "s2".into(),
+                name: "daily-restart".into(),
+                cron: "0 3 * * *".into(),
+                actions: r#"["restart_all"]"#.into(),
+                tier: 2,
+                last_run: None,
+                next_run: None,
+                created_by: "agent".into(),
+            },
+        ];
+        let prompt = build_system_prompt("No nodes registered.", &schedules, &[]);
+        assert!(prompt.contains("Active Schedules"));
+        assert!(prompt.contains("health-patrol"));
+        assert!(prompt.contains("*/15 * * * *"));
+        assert!(prompt.contains("tier: 1"));
+        assert!(prompt.contains("last run: 1709136000"));
+        assert!(prompt.contains("daily-restart"));
+        assert!(prompt.contains("last run: never"));
+        assert!(prompt.contains("next: not scheduled"));
+    }
+
+    #[test]
+    fn prompt_with_events() {
+        let events: Vec<SensorEvent> = (0..15)
+            .map(|i| SensorEvent {
+                id: format!("e{}", i),
+                timestamp: format!("{}", 1709136000 + i),
+                node_name: "rtsp-camera".into(),
+                event_type: if i % 2 == 0 {
+                    "health_ok".into()
+                } else {
+                    "started".into()
+                },
+                details: if i == 0 {
+                    Some(r#"{"uptime":120}"#.into())
+                } else {
+                    None
+                },
+            })
+            .collect();
+
+        let prompt = build_system_prompt("No nodes registered.", &[], &events);
+        assert!(prompt.contains("Recent Events"));
+        assert!(prompt.contains("rtsp-camera"));
+        assert!(prompt.contains("health_ok"));
+        // First event should have details
+        assert!(prompt.contains(r#"{"uptime":120}"#));
+        // Should be limited to 10 events (we passed 15)
+        let event_count = prompt.matches("rtsp-camera").count();
+        assert_eq!(
+            event_count, 10,
+            "should limit to 10 events, got {}",
+            event_count
+        );
+    }
+}

--- a/crates/bubbaloop/src/agent/prompt.rs
+++ b/crates/bubbaloop/src/agent/prompt.rs
@@ -1,16 +1,22 @@
 //! System prompt builder — injects live sensor inventory and schedules.
 
-use crate::agent::memory::{Schedule, SensorEvent};
+use crate::agent::memory::{ConversationRow, Schedule, SensorEvent, SkillSearchResult};
+use crate::skills::SkillConfig;
 
 /// Build the system prompt with live sensor data injected.
 ///
-/// Includes role description, current node inventory, active schedules,
-/// and recent sensor events. The prompt gives the Claude agent full
-/// context about the physical system it controls.
+/// Includes role description, loaded skill instructions, current node
+/// inventory, active schedules, and recent sensor events. The prompt
+/// gives the Claude agent full context about the physical system it
+/// controls and the user's intent for each skill.
 pub fn build_system_prompt(
     node_inventory: &str,
     schedules: &[Schedule],
     recent_events: &[SensorEvent],
+    skills: &[SkillConfig],
+    relevant_convos: &[ConversationRow],
+    relevant_events: &[SensorEvent],
+    relevant_skills: &[SkillSearchResult],
 ) -> String {
     let mut parts = Vec::new();
 
@@ -27,6 +33,18 @@ pub fn build_system_prompt(
          Be concise but informative. When you perform actions, report what you did and the result."
             .to_string(),
     );
+
+    // Loaded skills — agent-readable instructions from ~/.bubbaloop/skills/
+    let skills_with_body: Vec<_> = skills.iter().filter(|s| !s.body.is_empty()).collect();
+    if !skills_with_body.is_empty() {
+        let mut skill_lines = vec!["\n## Skills\n".to_string()];
+        for skill in &skills_with_body {
+            skill_lines.push(format!("### {} (driver: {})\n", skill.name, skill.driver));
+            skill_lines.push(skill.body.clone());
+            skill_lines.push(String::new());
+        }
+        parts.push(skill_lines.join("\n"));
+    }
 
     // Current sensor inventory
     parts.push(format!(
@@ -72,6 +90,53 @@ pub fn build_system_prompt(
         parts.push(event_lines.join("\n"));
     }
 
+    // Relevant context from semantic search (FTS5)
+    if !relevant_convos.is_empty() || !relevant_events.is_empty() || !relevant_skills.is_empty() {
+        let mut ctx_lines = vec!["\n## Relevant Context (from past interactions)\n".to_string()];
+
+        if !relevant_convos.is_empty() {
+            ctx_lines.push("**Related conversations:**".to_string());
+            for conv in relevant_convos.iter().take(5) {
+                ctx_lines.push(format!("- [{}] {}: {}", conv.timestamp, conv.role, conv.content));
+            }
+            ctx_lines.push(String::new());
+        }
+
+        if !relevant_events.is_empty() {
+            ctx_lines.push("**Related events:**".to_string());
+            for event in relevant_events.iter().take(5) {
+                let details = event.details.as_deref().unwrap_or("");
+                if details.is_empty() {
+                    ctx_lines.push(format!(
+                        "- [{}] {} {}",
+                        event.timestamp, event.node_name, event.event_type
+                    ));
+                } else {
+                    ctx_lines.push(format!(
+                        "- [{}] {} {} ({})",
+                        event.timestamp, event.node_name, event.event_type, details
+                    ));
+                }
+            }
+            ctx_lines.push(String::new());
+        }
+
+        if !relevant_skills.is_empty() {
+            ctx_lines.push("**Related skills:**".to_string());
+            for skill in relevant_skills.iter().take(3) {
+                // Truncate body to first 200 chars for context
+                let body_preview: String = skill.body.chars().take(200).collect();
+                ctx_lines.push(format!(
+                    "- {} (driver: {}): {}",
+                    skill.name, skill.driver, body_preview
+                ));
+            }
+            ctx_lines.push(String::new());
+        }
+
+        parts.push(ctx_lines.join("\n"));
+    }
+
     parts.join("\n")
 }
 
@@ -81,7 +146,7 @@ mod tests {
 
     #[test]
     fn prompt_with_empty_inventory() {
-        let prompt = build_system_prompt("", &[], &[]);
+        let prompt = build_system_prompt("", &[], &[], &[], &[], &[], &[]);
         assert!(prompt.contains("You are Bubbaloop"));
         assert!(prompt.contains("No sensors installed."));
         // Should not contain schedule or event sections
@@ -94,7 +159,7 @@ mod tests {
         let inventory = "2 node(s) registered:\n  \
                          - rtsp-camera [status=Running, health=Healthy]\n  \
                          - openmeteo [status=Stopped, health=Unknown]";
-        let prompt = build_system_prompt(inventory, &[], &[]);
+        let prompt = build_system_prompt(inventory, &[], &[], &[], &[], &[], &[]);
         assert!(prompt.contains("You are Bubbaloop"));
         assert!(prompt.contains("rtsp-camera"));
         assert!(prompt.contains("openmeteo"));
@@ -127,7 +192,7 @@ mod tests {
                 created_by: "agent".into(),
             },
         ];
-        let prompt = build_system_prompt("No nodes registered.", &schedules, &[]);
+        let prompt = build_system_prompt("No nodes registered.", &schedules, &[], &[], &[], &[], &[]);
         assert!(prompt.contains("Active Schedules"));
         assert!(prompt.contains("health-patrol"));
         assert!(prompt.contains("*/15 * * * *"));
@@ -158,7 +223,7 @@ mod tests {
             })
             .collect();
 
-        let prompt = build_system_prompt("No nodes registered.", &[], &events);
+        let prompt = build_system_prompt("No nodes registered.", &[], &events, &[], &[], &[], &[]);
         assert!(prompt.contains("Recent Events"));
         assert!(prompt.contains("rtsp-camera"));
         assert!(prompt.contains("health_ok"));
@@ -171,5 +236,61 @@ mod tests {
             "should limit to 10 events, got {}",
             event_count
         );
+    }
+
+    #[test]
+    fn prompt_with_skills() {
+        let skills = vec![SkillConfig {
+            name: "entrance-cam".into(),
+            driver: "rtsp".into(),
+            config: Default::default(),
+            schedule: None,
+            actions: Vec::new(),
+            body: "# Entrance Camera\n\nTapo C200 at the front door.\nURL: rtsp://192.168.1.141:554/stream2".into(),
+        }];
+        let prompt = build_system_prompt("", &[], &[], &skills, &[], &[], &[]);
+        assert!(prompt.contains("## Skills"));
+        assert!(prompt.contains("entrance-cam (driver: rtsp)"));
+        assert!(prompt.contains("Entrance Camera"));
+        assert!(prompt.contains("front door"));
+    }
+
+    #[test]
+    fn prompt_skips_skills_without_body() {
+        let skills = vec![SkillConfig {
+            name: "legacy-cam".into(),
+            driver: "rtsp".into(),
+            config: Default::default(),
+            schedule: None,
+            actions: Vec::new(),
+            body: String::new(),
+        }];
+        let prompt = build_system_prompt("", &[], &[], &skills, &[], &[], &[]);
+        assert!(!prompt.contains("Skills"));
+    }
+
+    #[test]
+    fn prompt_with_relevant_context() {
+        let convos = vec![ConversationRow {
+            id: "c1".into(),
+            timestamp: "2026-02-28T10:00:00Z".into(),
+            role: "user".into(),
+            content: "The entrance camera keeps freezing".into(),
+            tool_calls: None,
+        }];
+        let events = vec![SensorEvent {
+            id: "e1".into(),
+            timestamp: "2026-02-28T09:55:00Z".into(),
+            node_name: "rtsp-camera".into(),
+            event_type: "health_degraded".into(),
+            details: Some("frame_drop_rate=0.3".into()),
+        }];
+        let prompt = build_system_prompt("", &[], &[], &[], &convos, &events, &[]);
+        assert!(prompt.contains("Relevant Context"));
+        assert!(prompt.contains("Related conversations"));
+        assert!(prompt.contains("entrance camera keeps freezing"));
+        assert!(prompt.contains("Related events"));
+        assert!(prompt.contains("health_degraded"));
+        assert!(prompt.contains("frame_drop_rate"));
     }
 }

--- a/crates/bubbaloop/src/agent/scheduler.rs
+++ b/crates/bubbaloop/src/agent/scheduler.rs
@@ -1,0 +1,453 @@
+//! Cron-based scheduler with Tier 1 built-in actions.
+//!
+//! Tier 1 actions run offline without an LLM — health checks, node
+//! start/stop, log events, etc. The scheduler reads schedules from
+//! the SQLite memory layer, evaluates cron expressions, and executes
+//! due actions on each tick (every 60 seconds).
+
+use crate::agent::memory::Memory;
+use crate::mcp::platform::{NodeCommand, PlatformOperations};
+use serde::Deserialize;
+use serde_json::Value;
+use std::str::FromStr;
+use std::sync::Arc;
+use tokio::sync::watch;
+
+/// Errors from scheduler operations.
+#[derive(Debug, thiserror::Error)]
+pub enum SchedulerError {
+    #[error("Memory error: {0}")]
+    Memory(#[from] crate::agent::memory::MemoryError),
+    #[error("Invalid cron expression: {0}")]
+    CronParse(String),
+    #[error("Action failed: {0}")]
+    Action(String),
+}
+
+type Result<T> = std::result::Result<T, SchedulerError>;
+
+/// A Tier 1 action that can be executed without an LLM.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "action")]
+pub enum Tier1Action {
+    /// Check health of all nodes and log results.
+    #[serde(rename = "check_all_health")]
+    CheckAllHealth,
+
+    /// Restart any unhealthy running nodes.
+    #[serde(rename = "restart")]
+    Restart,
+
+    /// Start a specific node.
+    #[serde(rename = "start_node")]
+    StartNode { node: String },
+
+    /// Stop a specific node.
+    #[serde(rename = "stop_node")]
+    StopNode { node: String },
+
+    /// Send a Zenoh command to a node.
+    #[serde(rename = "send_command")]
+    SendCommand {
+        node: String,
+        command: String,
+        params: Value,
+    },
+
+    /// Capture a frame from a camera node.
+    #[serde(rename = "capture_frame")]
+    CaptureFrame { node: String, params: Value },
+
+    /// Log an event to the memory store.
+    #[serde(rename = "log_event")]
+    LogEvent { message: String },
+
+    /// Print a notification to the terminal.
+    #[serde(rename = "notify")]
+    Notify { message: String },
+}
+
+/// Compute the next cron occurrence after the given epoch seconds.
+///
+/// The `cron` crate expects 6-field expressions (sec min hr dom month dow).
+/// Standard 5-field cron expressions are detected and "0 " is prepended
+/// automatically to pin the seconds field to zero.
+pub fn next_run_after(cron_expr: &str, after_epoch_secs: u64) -> Result<u64> {
+    // Detect standard 5-field cron and prepend "0 " for seconds.
+    let expr = normalize_cron_expr(cron_expr);
+
+    let schedule = cron::Schedule::from_str(&expr)
+        .map_err(|e| SchedulerError::CronParse(format!("{}: {}", cron_expr, e)))?;
+
+    let after_dt =
+        chrono::DateTime::from_timestamp(after_epoch_secs as i64, 0).ok_or_else(|| {
+            SchedulerError::CronParse(format!("invalid epoch seconds: {}", after_epoch_secs))
+        })?;
+
+    let next = schedule
+        .after(&after_dt)
+        .next()
+        .ok_or_else(|| SchedulerError::CronParse("no next occurrence".to_string()))?;
+
+    Ok(next.timestamp() as u64)
+}
+
+/// Normalise a cron expression to 6-field format.
+///
+/// Standard cron has 5 fields (min hr dom month dow). The `cron` crate
+/// expects 6 fields (sec min hr dom month dow). If the expression has
+/// exactly 5 whitespace-separated fields, we prepend "0 " to pin
+/// the seconds to zero.
+fn normalize_cron_expr(expr: &str) -> String {
+    let trimmed = expr.trim();
+    let fields: Vec<&str> = trimmed.split_whitespace().collect();
+    if fields.len() == 5 {
+        format!("0 {}", trimmed)
+    } else {
+        trimmed.to_string()
+    }
+}
+
+/// Execute a single Tier 1 action.
+pub async fn execute_tier1_action<P: PlatformOperations>(
+    action: &Tier1Action,
+    platform: &P,
+    memory: &Memory,
+    scope: &str,
+    machine_id: &str,
+) -> Result<()> {
+    match action {
+        Tier1Action::CheckAllHealth => {
+            let nodes = platform
+                .list_nodes()
+                .await
+                .map_err(|e| SchedulerError::Action(e.to_string()))?;
+            for node in &nodes {
+                log::info!(
+                    "[Scheduler] health check: node={} status={} health={}",
+                    node.name,
+                    node.status,
+                    node.health
+                );
+                let details = format!(
+                    r#"{{"status":"{}","health":"{}"}}"#,
+                    node.status, node.health
+                );
+                if let Err(e) = memory.log_event(&node.name, "health_check", Some(&details)) {
+                    log::warn!("[Scheduler] failed to log health event: {}", e);
+                }
+            }
+            Ok(())
+        }
+
+        Tier1Action::Restart => {
+            let nodes = platform
+                .list_nodes()
+                .await
+                .map_err(|e| SchedulerError::Action(e.to_string()))?;
+            for node in &nodes {
+                // Only restart nodes that are running but unhealthy
+                if node.status == "Running" && node.health != "Healthy" {
+                    log::info!(
+                        "[Scheduler] restarting unhealthy node: {} (health={})",
+                        node.name,
+                        node.health
+                    );
+                    if let Err(e) = platform
+                        .execute_command(&node.name, NodeCommand::Restart)
+                        .await
+                    {
+                        log::error!("[Scheduler] restart failed for {}: {}", node.name, e);
+                    }
+                }
+            }
+            Ok(())
+        }
+
+        Tier1Action::StartNode { node } => {
+            platform
+                .execute_command(node, NodeCommand::Start)
+                .await
+                .map_err(|e| SchedulerError::Action(e.to_string()))?;
+            log::info!("[Scheduler] started node: {}", node);
+            Ok(())
+        }
+
+        Tier1Action::StopNode { node } => {
+            platform
+                .execute_command(node, NodeCommand::Stop)
+                .await
+                .map_err(|e| SchedulerError::Action(e.to_string()))?;
+            log::info!("[Scheduler] stopped node: {}", node);
+            Ok(())
+        }
+
+        Tier1Action::SendCommand {
+            node,
+            command,
+            params,
+        } => {
+            let key_expr = format!(
+                "bubbaloop/{}/{}/{}/command/{}",
+                scope, machine_id, node, command
+            );
+            let payload =
+                serde_json::to_vec(params).map_err(|e| SchedulerError::Action(e.to_string()))?;
+            platform
+                .send_zenoh_query(&key_expr, payload)
+                .await
+                .map_err(|e| SchedulerError::Action(e.to_string()))?;
+            log::info!("[Scheduler] sent command {} to node {}", command, node);
+            Ok(())
+        }
+
+        Tier1Action::CaptureFrame { node, params } => {
+            let key_expr = format!(
+                "bubbaloop/{}/{}/{}/command/capture_frame",
+                scope, machine_id, node
+            );
+            let payload =
+                serde_json::to_vec(params).map_err(|e| SchedulerError::Action(e.to_string()))?;
+            platform
+                .send_zenoh_query(&key_expr, payload)
+                .await
+                .map_err(|e| SchedulerError::Action(e.to_string()))?;
+            log::info!("[Scheduler] capture_frame sent to node {}", node);
+            Ok(())
+        }
+
+        Tier1Action::LogEvent { message } => {
+            memory
+                .log_event("scheduler", "log_event", Some(message))
+                .map_err(SchedulerError::Memory)?;
+            log::info!("[Scheduler] logged event: {}", message);
+            Ok(())
+        }
+
+        Tier1Action::Notify { message } => {
+            println!("[Scheduler] {}", message);
+            log::info!("[Scheduler] notification: {}", message);
+            Ok(())
+        }
+    }
+}
+
+/// Run the scheduler background loop.
+///
+/// Ticks every 60 seconds, checking for due Tier 1 schedules.
+/// Exits cleanly when the shutdown signal fires.
+pub async fn run_scheduler<P: PlatformOperations>(
+    memory: Arc<Memory>,
+    platform: Arc<P>,
+    scope: String,
+    machine_id: String,
+    mut shutdown: watch::Receiver<()>,
+) {
+    log::info!("[Scheduler] starting background loop (60s interval)");
+
+    let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
+    // First tick fires immediately; consume it to avoid double-tick on startup.
+    interval.tick().await;
+
+    loop {
+        tokio::select! {
+            _ = interval.tick() => {
+                if let Err(e) = tick(&memory, &*platform, &scope, &machine_id).await {
+                    log::error!("[Scheduler] tick error: {}", e);
+                }
+            }
+            _ = shutdown.changed() => {
+                log::info!("[Scheduler] shutdown signal received, exiting");
+                break;
+            }
+        }
+    }
+}
+
+/// Check all schedules and execute due Tier 1 jobs.
+async fn tick<P: PlatformOperations>(
+    memory: &Memory,
+    platform: &P,
+    scope: &str,
+    machine_id: &str,
+) -> Result<()> {
+    let now_secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+
+    let schedules = memory.list_schedules()?;
+
+    for sched in &schedules {
+        // Only process Tier 1 schedules
+        if sched.tier != 1 {
+            continue;
+        }
+
+        // Determine if this schedule is due
+        let due = match &sched.next_run {
+            Some(next_run_str) => {
+                let next_run: u64 = next_run_str.parse().unwrap_or(0);
+                next_run <= now_secs
+            }
+            None => true, // Never run before — run now
+        };
+
+        if !due {
+            continue;
+        }
+
+        log::info!("[Scheduler] executing schedule: {}", sched.name);
+
+        // Parse actions JSON into Vec<Tier1Action>
+        let actions: Vec<Tier1Action> = serde_json::from_str(&sched.actions).map_err(|e| {
+            SchedulerError::Action(format!(
+                "failed to parse actions for schedule '{}': {}",
+                sched.name, e
+            ))
+        })?;
+
+        // Execute each action
+        for action in &actions {
+            if let Err(e) = execute_tier1_action(action, platform, memory, scope, machine_id).await
+            {
+                log::error!(
+                    "[Scheduler] action failed in schedule '{}': {}",
+                    sched.name,
+                    e
+                );
+            }
+        }
+
+        // Compute next run and update in memory
+        let last_run = format!("{}", now_secs);
+        match next_run_after(&sched.cron, now_secs) {
+            Ok(next) => {
+                let next_run = format!("{}", next);
+                if let Err(e) = memory.update_schedule_run(&sched.name, &last_run, &next_run) {
+                    log::error!(
+                        "[Scheduler] failed to update schedule '{}': {}",
+                        sched.name,
+                        e
+                    );
+                }
+            }
+            Err(e) => {
+                log::error!(
+                    "[Scheduler] failed to compute next run for '{}': {}",
+                    sched.name,
+                    e
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_tier1_actions() {
+        let json = r#"[
+            {"action": "check_all_health"},
+            {"action": "restart"},
+            {"action": "log_event", "message": "patrol complete"},
+            {"action": "notify", "message": "hello"}
+        ]"#;
+        let actions: Vec<Tier1Action> = serde_json::from_str(json).unwrap();
+        assert_eq!(actions.len(), 4);
+        assert!(matches!(actions[0], Tier1Action::CheckAllHealth));
+        assert!(matches!(actions[1], Tier1Action::Restart));
+        assert!(matches!(actions[2], Tier1Action::LogEvent { .. }));
+        assert!(matches!(actions[3], Tier1Action::Notify { .. }));
+    }
+
+    #[test]
+    fn parse_start_node_action() {
+        let json = r#"[{"action": "start_node", "node": "rtsp-camera"}]"#;
+        let actions: Vec<Tier1Action> = serde_json::from_str(json).unwrap();
+        assert_eq!(actions.len(), 1);
+        match &actions[0] {
+            Tier1Action::StartNode { node } => assert_eq!(node, "rtsp-camera"),
+            other => panic!("expected StartNode, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_send_command_action() {
+        let json = r#"[{
+            "action": "send_command",
+            "node": "rtsp-camera",
+            "command": "set_exposure",
+            "params": {"value": 100}
+        }]"#;
+        let actions: Vec<Tier1Action> = serde_json::from_str(json).unwrap();
+        assert_eq!(actions.len(), 1);
+        match &actions[0] {
+            Tier1Action::SendCommand {
+                node,
+                command,
+                params,
+            } => {
+                assert_eq!(node, "rtsp-camera");
+                assert_eq!(command, "set_exposure");
+                assert_eq!(params["value"], 100);
+            }
+            other => panic!("expected SendCommand, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_unknown_action_fails() {
+        let json = r#"[{"action": "nonexistent_action"}]"#;
+        let result: std::result::Result<Vec<Tier1Action>, _> = serde_json::from_str(json);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn next_run_after_valid_cron() {
+        // Standard 5-field: every 15 minutes
+        let after = 1_700_000_000; // 2023-11-14T22:13:20Z
+        let next = next_run_after("*/15 * * * *", after).unwrap();
+        assert!(next > after, "next ({}) should be after ({})", next, after);
+        // Should be within 15 minutes
+        assert!(
+            next <= after + 15 * 60,
+            "next ({}) should be within 15 minutes of after ({})",
+            next,
+            after
+        );
+    }
+
+    #[test]
+    fn next_run_after_six_field_cron() {
+        // 6-field cron: every 30 seconds
+        let after = 1_700_000_000;
+        let next = next_run_after("*/30 * * * * *", after).unwrap();
+        assert!(next > after);
+        assert!(next <= after + 30);
+    }
+
+    #[test]
+    fn next_run_after_invalid_cron() {
+        let result = next_run_after("not a cron expression", 1_700_000_000);
+        assert!(result.is_err());
+        match result {
+            Err(SchedulerError::CronParse(_)) => {}
+            other => panic!("expected CronParse error, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn normalize_prepends_seconds_for_5_fields() {
+        assert_eq!(normalize_cron_expr("*/15 * * * *"), "0 */15 * * * *");
+    }
+
+    #[test]
+    fn normalize_keeps_6_fields_unchanged() {
+        assert_eq!(normalize_cron_expr("0 */15 * * * *"), "0 */15 * * * *");
+    }
+}

--- a/crates/bubbaloop/src/agent/scheduler.rs
+++ b/crates/bubbaloop/src/agent/scheduler.rs
@@ -311,12 +311,7 @@ fn collect_due_schedules(
 }
 
 /// Update schedule run timestamps in the memory DB (sync, under lock).
-fn update_schedule_after_run(
-    memory: &Mutex<Memory>,
-    name: &str,
-    now_secs: u64,
-    cron_expr: &str,
-) {
+fn update_schedule_after_run(memory: &Mutex<Memory>, name: &str, now_secs: u64, cron_expr: &str) {
     let last_run = format!("{}", now_secs);
     match next_run_after(cron_expr, now_secs) {
         Ok(next) => {
@@ -372,8 +367,7 @@ async fn tick<P: PlatformOperations>(
 
         // Execute each action — memory is locked briefly inside each action
         for action in &actions {
-            if let Err(e) =
-                execute_tier1_action(action, platform, memory, scope, machine_id).await
+            if let Err(e) = execute_tier1_action(action, platform, memory, scope, machine_id).await
             {
                 log::error!(
                     "[Scheduler] action failed in schedule '{}': {}",

--- a/crates/bubbaloop/src/api.rs
+++ b/crates/bubbaloop/src/api.rs
@@ -1,0 +1,274 @@
+//! REST API for CLI → daemon communication.
+//!
+//! Lightweight HTTP endpoints that expose `PlatformOperations` to the CLI client.
+//! These run alongside MCP on the same axum router (port 8088) and are
+//! localhost-only, unauthenticated (same security model as the /health endpoint).
+
+use axum::extract::{Path, State};
+use axum::routing::{delete, get, post};
+use axum::{Json, Router};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+use crate::mcp::platform::{NodeCommand, PlatformOperations};
+
+/// Node state returned by the list endpoint.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ApiNodeState {
+    pub name: String,
+    pub status: String,
+    pub health: String,
+    pub node_type: String,
+    pub installed: bool,
+    pub is_built: bool,
+}
+
+/// Response from the list nodes endpoint.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ApiNodeListResponse {
+    pub nodes: Vec<ApiNodeState>,
+}
+
+/// Response from command/add/remove endpoints.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ApiCommandResponse {
+    pub success: bool,
+    pub message: String,
+    #[serde(default)]
+    pub output: String,
+}
+
+/// Request body for the command endpoint.
+#[derive(Debug, Deserialize)]
+struct CommandRequest {
+    command: String,
+}
+
+/// Request body for the add-node endpoint.
+#[derive(Debug, Deserialize)]
+struct AddNodeRequest {
+    source: String,
+    #[serde(default)]
+    name: Option<String>,
+}
+
+/// Request body for the marketplace install endpoint.
+#[derive(Debug, Deserialize)]
+struct InstallMarketplaceRequest {
+    name: String,
+}
+
+fn command_response(result: Result<String, impl std::fmt::Display>) -> Json<ApiCommandResponse> {
+    match result {
+        Ok(msg) => Json(ApiCommandResponse {
+            success: true,
+            message: msg,
+            output: String::new(),
+        }),
+        Err(e) => Json(ApiCommandResponse {
+            success: false,
+            message: e.to_string(),
+            output: String::new(),
+        }),
+    }
+}
+
+async fn list_nodes<P: PlatformOperations>(
+    State(platform): State<Arc<P>>,
+) -> Json<ApiNodeListResponse> {
+    match platform.list_nodes().await {
+        Ok(nodes) => {
+            let api_nodes = nodes
+                .into_iter()
+                .map(|n| ApiNodeState {
+                    name: n.name,
+                    status: n.status,
+                    health: n.health,
+                    node_type: n.node_type,
+                    installed: n.installed,
+                    is_built: n.is_built,
+                })
+                .collect();
+            Json(ApiNodeListResponse { nodes: api_nodes })
+        }
+        Err(e) => {
+            log::error!("[API] list_nodes error: {}", e);
+            Json(ApiNodeListResponse { nodes: vec![] })
+        }
+    }
+}
+
+async fn node_command<P: PlatformOperations>(
+    State(platform): State<Arc<P>>,
+    Path(name): Path<String>,
+    Json(req): Json<CommandRequest>,
+) -> Json<ApiCommandResponse> {
+    if let Err(e) = crate::validation::validate_node_name(&name) {
+        return Json(ApiCommandResponse {
+            success: false,
+            message: format!("Invalid node name: {}", e),
+            output: String::new(),
+        });
+    }
+
+    let cmd = match parse_command(&req.command) {
+        Some(c) => c,
+        None => {
+            return Json(ApiCommandResponse {
+                success: false,
+                message: format!("Unknown command: {}", req.command),
+                output: String::new(),
+            });
+        }
+    };
+
+    command_response(platform.execute_command(&name, cmd).await)
+}
+
+async fn add_node<P: PlatformOperations>(
+    State(platform): State<Arc<P>>,
+    Json(req): Json<AddNodeRequest>,
+) -> Json<ApiCommandResponse> {
+    if let Err(e) = crate::validation::validate_install_source(&req.source) {
+        return Json(ApiCommandResponse {
+            success: false,
+            message: format!("Invalid source: {}", e),
+            output: String::new(),
+        });
+    }
+    if let Some(ref name) = req.name {
+        if let Err(e) = crate::validation::validate_node_name(name) {
+            return Json(ApiCommandResponse {
+                success: false,
+                message: format!("Invalid node name: {}", e),
+                output: String::new(),
+            });
+        }
+    }
+
+    command_response(platform.install_node(&req.source).await)
+}
+
+async fn install_marketplace<P: PlatformOperations>(
+    State(platform): State<Arc<P>>,
+    Json(req): Json<InstallMarketplaceRequest>,
+) -> Json<ApiCommandResponse> {
+    if let Err(e) = crate::validation::validate_node_name(&req.name) {
+        return Json(ApiCommandResponse {
+            success: false,
+            message: format!("Invalid marketplace name: {}", e),
+            output: String::new(),
+        });
+    }
+    command_response(platform.install_from_marketplace(&req.name).await)
+}
+
+async fn remove_node<P: PlatformOperations>(
+    State(platform): State<Arc<P>>,
+    Path(name): Path<String>,
+) -> Json<ApiCommandResponse> {
+    if let Err(e) = crate::validation::validate_node_name(&name) {
+        return Json(ApiCommandResponse {
+            success: false,
+            message: format!("Invalid node name: {}", e),
+            output: String::new(),
+        });
+    }
+    command_response(platform.remove_node(&name).await)
+}
+
+/// Build the `/api/v1` router. Caller nests this under `/api/v1`.
+pub fn api_router<P: PlatformOperations>(platform: Arc<P>) -> Router {
+    Router::new()
+        .route("/nodes", get(list_nodes::<P>))
+        .route("/nodes/{name}/command", post(node_command::<P>))
+        .route("/nodes/add", post(add_node::<P>))
+        .route("/nodes/install", post(install_marketplace::<P>))
+        .route("/nodes/{name}", delete(remove_node::<P>))
+        .with_state(platform)
+}
+
+fn parse_command(s: &str) -> Option<NodeCommand> {
+    match s {
+        "start" => Some(NodeCommand::Start),
+        "stop" => Some(NodeCommand::Stop),
+        "restart" => Some(NodeCommand::Restart),
+        "build" => Some(NodeCommand::Build),
+        "logs" => Some(NodeCommand::GetLogs),
+        "install" => Some(NodeCommand::Install),
+        "uninstall" => Some(NodeCommand::Uninstall),
+        "clean" => Some(NodeCommand::Clean),
+        "enable" => Some(NodeCommand::EnableAutostart),
+        "disable" => Some(NodeCommand::DisableAutostart),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_command_valid() {
+        assert!(matches!(parse_command("start"), Some(NodeCommand::Start)));
+        assert!(matches!(parse_command("stop"), Some(NodeCommand::Stop)));
+        assert!(matches!(
+            parse_command("restart"),
+            Some(NodeCommand::Restart)
+        ));
+        assert!(matches!(parse_command("build"), Some(NodeCommand::Build)));
+        assert!(matches!(parse_command("logs"), Some(NodeCommand::GetLogs)));
+        assert!(matches!(
+            parse_command("install"),
+            Some(NodeCommand::Install)
+        ));
+        assert!(matches!(
+            parse_command("uninstall"),
+            Some(NodeCommand::Uninstall)
+        ));
+        assert!(matches!(parse_command("clean"), Some(NodeCommand::Clean)));
+        assert!(matches!(
+            parse_command("enable"),
+            Some(NodeCommand::EnableAutostart)
+        ));
+        assert!(matches!(
+            parse_command("disable"),
+            Some(NodeCommand::DisableAutostart)
+        ));
+    }
+
+    #[test]
+    fn test_parse_command_invalid() {
+        assert!(parse_command("unknown").is_none());
+        assert!(parse_command("").is_none());
+    }
+
+    #[test]
+    fn test_api_command_response_serialization() {
+        let resp = ApiCommandResponse {
+            success: true,
+            message: "Node started".into(),
+            output: String::new(),
+        };
+        let json = serde_json::to_string(&resp).unwrap();
+        assert!(json.contains("\"success\":true"));
+        assert!(json.contains("Node started"));
+    }
+
+    #[test]
+    fn test_api_node_list_response_serialization() {
+        let resp = ApiNodeListResponse {
+            nodes: vec![ApiNodeState {
+                name: "test".into(),
+                status: "Running".into(),
+                health: "Healthy".into(),
+                node_type: "rust".into(),
+                installed: true,
+                is_built: true,
+            }],
+        };
+        let json = serde_json::to_string(&resp).unwrap();
+        assert!(json.contains("\"name\":\"test\""));
+        assert!(json.contains("\"status\":\"Running\""));
+    }
+}

--- a/crates/bubbaloop/src/bin/bubbaloop.rs
+++ b/crates/bubbaloop/src/bin/bubbaloop.rs
@@ -19,7 +19,7 @@
 
 use argh::FromArgs;
 use bubbaloop::cli::launch::LaunchCommand;
-use bubbaloop::cli::{DebugCommand, MarketplaceCommand, NodeCommand};
+use bubbaloop::cli::{DebugCommand, MarketplaceCommand, NodeCommand, UpCommand};
 
 /// Bubbaloop - AI-native orchestration for Physical AI
 #[derive(FromArgs)]
@@ -43,6 +43,7 @@ enum Command {
     Launch(LaunchCommand),
     Marketplace(MarketplaceCommand),
     Debug(DebugCommand),
+    Up(UpCommand),
     InitTls(InitTlsArgs),
 }
 
@@ -206,6 +207,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             eprintln!("              (default: ~/.bubbaloop/launch.yaml)");
             eprintln!("  marketplace  Manage marketplace sources:");
             eprintln!("              list, add, remove, enable, disable");
+            eprintln!("  up        Load skills and ensure sensor nodes are running:");
+            eprintln!("              -s, --skills-dir <path>: Skills directory");
+            eprintln!("              --dry-run: Show what would be done");
             eprintln!("  debug     Debug Zenoh connectivity:");
             eprintln!("              info, topics, query, subscribe");
             eprintln!("  init-tls  Print TLS/mTLS certificate generation guide");
@@ -247,6 +251,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Some(Command::Debug(cmd)) => {
             cmd.run()
                 .await
+                .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)?;
+        }
+        Some(Command::Up(cmd)) => {
+            cmd.run()
                 .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)?;
         }
         Some(Command::InitTls(args)) => {

--- a/crates/bubbaloop/src/bin/bubbaloop.rs
+++ b/crates/bubbaloop/src/bin/bubbaloop.rs
@@ -19,7 +19,10 @@
 
 use argh::FromArgs;
 use bubbaloop::cli::launch::LaunchCommand;
-use bubbaloop::cli::{AgentCommand, DebugCommand, MarketplaceCommand, NodeCommand, UpCommand};
+use bubbaloop::cli::{
+    AgentCommand, DebugCommand, LoginCommand, LogoutCommand, MarketplaceCommand, NodeCommand,
+    UpCommand,
+};
 
 /// Bubbaloop - AI-native orchestration for Physical AI
 #[derive(FromArgs)]
@@ -36,6 +39,8 @@ struct Args {
 #[argh(subcommand)]
 enum Command {
     Agent(AgentCommand),
+    Login(LoginCommand),
+    Logout(LogoutCommand),
     Status(StatusArgs),
     Doctor(DoctorArgs),
     Daemon(DaemonArgs),
@@ -208,6 +213,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             eprintln!("              (default: ~/.bubbaloop/launch.yaml)");
             eprintln!("  marketplace  Manage marketplace sources:");
             eprintln!("              list, add, remove, enable, disable");
+            eprintln!("  login     Authenticate with Anthropic API:");
+            eprintln!("              --status: Show current auth status");
+            eprintln!("  logout    Remove saved Anthropic API key");
             eprintln!("  agent     Chat with your hardware via Claude AI:");
             eprintln!("              -m, --model <model>: Claude model");
             eprintln!("              -z, --zenoh-endpoint <endpoint>: Zenoh endpoint");
@@ -219,6 +227,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             eprintln!("  init-tls  Print TLS/mTLS certificate generation guide");
             eprintln!("\nRun 'bubbaloop <command> --help' for more information.");
             return Ok(());
+        }
+        Some(Command::Login(cmd)) => {
+            if let Err(e) = cmd.run().await {
+                eprintln!("Error: {}", e);
+            }
+        }
+        Some(Command::Logout(cmd)) => {
+            if let Err(e) = cmd.run() {
+                eprintln!("Error: {}", e);
+            }
         }
         Some(Command::Status(status_args)) => {
             bubbaloop::cli::status::run(&status_args.format).await?;

--- a/crates/bubbaloop/src/cli/agent.rs
+++ b/crates/bubbaloop/src/cli/agent.rs
@@ -1,0 +1,14 @@
+use argh::FromArgs;
+
+/// Start the interactive AI agent for hardware control
+#[derive(FromArgs, PartialEq, Debug)]
+#[argh(subcommand, name = "agent")]
+pub struct AgentCommand {
+    /// claude model to use (default: claude-sonnet-4-20250514)
+    #[argh(option, short = 'm')]
+    pub model: Option<String>,
+
+    /// zenoh endpoint to connect to (default: auto-discover)
+    #[argh(option, short = 'z')]
+    pub zenoh_endpoint: Option<String>,
+}

--- a/crates/bubbaloop/src/cli/daemon_client.rs
+++ b/crates/bubbaloop/src/cli/daemon_client.rs
@@ -1,0 +1,194 @@
+//! HTTP client for CLI → daemon REST API communication.
+//!
+//! Replaces the old Zenoh-based CLI → daemon path with simple HTTP requests
+//! to the REST API running on the same port as MCP (default 8088).
+
+use crate::api::{ApiCommandResponse, ApiNodeListResponse};
+use serde::Deserialize;
+
+/// Error type for daemon client operations.
+#[derive(Debug, thiserror::Error)]
+pub enum DaemonClientError {
+    #[error("Daemon not reachable at localhost:{0}. Is it running?")]
+    NotReachable(u16),
+    #[error("Request failed: {0}")]
+    Request(String),
+    #[error("Invalid response: {0}")]
+    InvalidResponse(String),
+}
+
+pub type Result<T> = std::result::Result<T, DaemonClientError>;
+
+/// Health response from /health endpoint.
+#[derive(Debug, Deserialize)]
+pub struct HealthResponse {
+    pub status: String,
+    #[serde(default)]
+    pub version: String,
+    #[serde(default)]
+    pub nodes_total: usize,
+    #[serde(default)]
+    pub nodes_running: usize,
+}
+
+/// HTTP client for daemon REST API.
+pub struct DaemonClient {
+    port: u16,
+    client: reqwest::Client,
+}
+
+impl Default for DaemonClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DaemonClient {
+    /// Create a new client. Reads BUBBALOOP_MCP_PORT env var, defaults to 8088.
+    pub fn new() -> Self {
+        let port = std::env::var("BUBBALOOP_MCP_PORT")
+            .ok()
+            .and_then(|p| p.parse().ok())
+            .unwrap_or(crate::mcp::MCP_PORT);
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .expect("Failed to create HTTP client");
+        Self { port, client }
+    }
+
+    fn base_url(&self) -> String {
+        format!("http://127.0.0.1:{}/api/v1", self.port)
+    }
+
+    fn health_url(&self) -> String {
+        format!("http://127.0.0.1:{}/health", self.port)
+    }
+
+    /// Check daemon health via GET /health.
+    pub async fn health(&self) -> Result<HealthResponse> {
+        let resp = self
+            .client
+            .get(self.health_url())
+            .send()
+            .await
+            .map_err(|_| DaemonClientError::NotReachable(self.port))?;
+        resp.json::<HealthResponse>()
+            .await
+            .map_err(|e| DaemonClientError::InvalidResponse(e.to_string()))
+    }
+
+    /// List all registered nodes via GET /api/v1/nodes.
+    pub async fn list_nodes(&self) -> Result<ApiNodeListResponse> {
+        let url = format!("{}/nodes", self.base_url());
+        let resp = self
+            .client
+            .get(&url)
+            .send()
+            .await
+            .map_err(|_| DaemonClientError::NotReachable(self.port))?;
+        resp.json::<ApiNodeListResponse>()
+            .await
+            .map_err(|e| DaemonClientError::InvalidResponse(e.to_string()))
+    }
+
+    /// Send a command to a node via POST /api/v1/nodes/{name}/command.
+    pub async fn send_command(&self, name: &str, command: &str) -> Result<ApiCommandResponse> {
+        let url = format!("{}/nodes/{}/command", self.base_url(), name);
+        let resp = self
+            .client
+            .post(&url)
+            .json(&serde_json::json!({ "command": command }))
+            .send()
+            .await
+            .map_err(|_| DaemonClientError::NotReachable(self.port))?;
+        resp.json::<ApiCommandResponse>()
+            .await
+            .map_err(|e| DaemonClientError::InvalidResponse(e.to_string()))
+    }
+
+    /// Add a node from a source path via POST /api/v1/nodes/add.
+    pub async fn add_node(
+        &self,
+        source: &str,
+        name: Option<&str>,
+        config: Option<&str>,
+    ) -> Result<ApiCommandResponse> {
+        let url = format!("{}/nodes/add", self.base_url());
+        let mut body = serde_json::json!({ "source": source });
+        if let Some(n) = name {
+            body["name"] = serde_json::Value::String(n.to_string());
+        }
+        if let Some(c) = config {
+            body["config"] = serde_json::Value::String(c.to_string());
+        }
+        let resp = self
+            .client
+            .post(&url)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|_| DaemonClientError::NotReachable(self.port))?;
+        resp.json::<ApiCommandResponse>()
+            .await
+            .map_err(|e| DaemonClientError::InvalidResponse(e.to_string()))
+    }
+
+    /// Install from marketplace via POST /api/v1/nodes/install.
+    pub async fn install_marketplace(&self, name: &str) -> Result<ApiCommandResponse> {
+        let url = format!("{}/nodes/install", self.base_url());
+        let resp = self
+            .client
+            .post(&url)
+            .json(&serde_json::json!({ "name": name }))
+            .send()
+            .await
+            .map_err(|_| DaemonClientError::NotReachable(self.port))?;
+        resp.json::<ApiCommandResponse>()
+            .await
+            .map_err(|e| DaemonClientError::InvalidResponse(e.to_string()))
+    }
+
+    /// Remove a node via DELETE /api/v1/nodes/{name}.
+    pub async fn remove_node(&self, name: &str) -> Result<ApiCommandResponse> {
+        let url = format!("{}/nodes/{}", self.base_url(), name);
+        let resp = self
+            .client
+            .delete(&url)
+            .send()
+            .await
+            .map_err(|_| DaemonClientError::NotReachable(self.port))?;
+        resp.json::<ApiCommandResponse>()
+            .await
+            .map_err(|e| DaemonClientError::InvalidResponse(e.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_daemon_client_default_port() {
+        // Should use default port 8088 when env var is not set
+        let client = DaemonClient::new();
+        assert_eq!(client.base_url(), "http://127.0.0.1:8088/api/v1");
+    }
+
+    #[test]
+    fn test_health_response_deserialization() {
+        let json = r#"{"status": "ok", "version": "0.0.6", "nodes_total": 5, "nodes_running": 3}"#;
+        let resp: HealthResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.status, "ok");
+        assert_eq!(resp.nodes_total, 5);
+        assert_eq!(resp.nodes_running, 3);
+    }
+
+    #[test]
+    fn test_health_response_minimal() {
+        let json = r#"{"status": "ok"}"#;
+        let resp: HealthResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.status, "ok");
+        assert_eq!(resp.nodes_total, 0);
+    }
+}

--- a/crates/bubbaloop/src/cli/login.rs
+++ b/crates/bubbaloop/src/cli/login.rs
@@ -1,0 +1,344 @@
+//! Login and logout commands for managing the Anthropic API key.
+//!
+//! `bubbaloop login`  — interactive browser + paste + validate + save flow
+//! `bubbaloop logout` — remove saved key
+
+use std::path::PathBuf;
+
+// ── Errors ──────────────────────────────────────────────────────────
+
+#[derive(Debug, thiserror::Error)]
+pub enum LoginError {
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("HTTP error: {0}")]
+    Http(#[from] reqwest::Error),
+
+    #[error("invalid API key: {0}")]
+    InvalidKey(String),
+
+    #[error("no API key configured")]
+    NoKeyConfigured,
+
+    #[error("cannot determine home directory")]
+    NoHomeDir,
+}
+
+type Result<T> = std::result::Result<T, LoginError>;
+
+// ── Commands ────────────────────────────────────────────────────────
+
+/// Authenticate with Anthropic API
+#[derive(argh::FromArgs)]
+#[argh(subcommand, name = "login")]
+pub struct LoginCommand {
+    /// show current authentication status
+    #[argh(switch)]
+    pub status: bool,
+}
+
+/// Remove saved Anthropic API key
+#[derive(argh::FromArgs)]
+#[argh(subcommand, name = "logout")]
+pub struct LogoutCommand {}
+
+// ── Constants ───────────────────────────────────────────────────────
+
+const CONSOLE_URL: &str = "https://console.anthropic.com/settings/keys";
+const MODELS_URL: &str = "https://api.anthropic.com/v1/models?limit=1";
+const API_VERSION: &str = "2023-06-01";
+const KEY_FILENAME: &str = "anthropic-key";
+
+// ── Public API ──────────────────────────────────────────────────────
+
+impl LoginCommand {
+    pub async fn run(&self) -> Result<()> {
+        if self.status {
+            show_status().await
+        } else {
+            run_login().await
+        }
+    }
+}
+
+impl LogoutCommand {
+    pub fn run(&self) -> Result<()> {
+        let path = key_file_path()?;
+        if path.exists() {
+            std::fs::remove_file(&path)?;
+            println!("Removed API key from {}", path.display());
+        } else {
+            println!("No API key file found at {}", path.display());
+        }
+
+        if std::env::var("ANTHROPIC_API_KEY").is_ok() {
+            println!(
+                "\nNote: ANTHROPIC_API_KEY environment variable is still set.\n\
+                 Unset it to fully log out: unset ANTHROPIC_API_KEY"
+            );
+        }
+
+        Ok(())
+    }
+}
+
+// ── Interactive login flow ──────────────────────────────────────────
+
+async fn run_login() -> Result<()> {
+    println!("\n  Bubbaloop Login\n");
+    println!("  To use the agent, you need an Anthropic API key.\n");
+
+    // Step 1: Open browser
+    println!("  1. Opening {}", CONSOLE_URL);
+    if open::that(CONSOLE_URL).is_err() {
+        println!("     (Could not open browser — copy the URL above)");
+    }
+
+    println!("\n  2. Create a new API key and copy it.\n");
+
+    // Step 2: Prompt for key (hidden input, requires real terminal)
+    let key = match rpassword::prompt_password("  Paste your API key: ") {
+        Ok(k) => k.trim().to_string(),
+        Err(_) => {
+            return Err(LoginError::Io(std::io::Error::other(
+                "this command requires an interactive terminal",
+            )));
+        }
+    };
+
+    if key.is_empty() {
+        return Err(LoginError::InvalidKey("empty input".to_string()));
+    }
+
+    // Step 3: Validate
+    print!("\n  Validating... ");
+    match validate_api_key(&key).await {
+        Ok(model_name) => {
+            println!("Key is valid ({} available)", model_name);
+        }
+        Err(LoginError::InvalidKey(msg)) => {
+            println!("Invalid key: {}", msg);
+            return Err(LoginError::InvalidKey(msg));
+        }
+        Err(e) => {
+            // Network error — save anyway, warn user
+            println!(
+                "Could not validate ({})\n  Saving key anyway — check later with: bubbaloop login --status",
+                e
+            );
+        }
+    }
+
+    // Step 4: Save
+    let path = key_file_path()?;
+    save_key_file(&path, &key)?;
+    println!("\n  Saved to {}\n", path.display());
+    println!("  You're all set! Run 'bubbaloop agent' to start chatting.\n");
+
+    Ok(())
+}
+
+// ── Status check ────────────────────────────────────────────────────
+
+async fn show_status() -> Result<()> {
+    let path = key_file_path()?;
+
+    // Check env var first
+    if let Ok(env_key) = std::env::var("ANTHROPIC_API_KEY") {
+        println!("API key source: ANTHROPIC_API_KEY environment variable");
+        print!("Validating... ");
+        match validate_api_key(&env_key).await {
+            Ok(model) => println!("Valid ({} available)", model),
+            Err(LoginError::InvalidKey(msg)) => println!("Invalid: {}", msg),
+            Err(e) => println!("Could not validate: {}", e),
+        }
+        return Ok(());
+    }
+
+    // Check file
+    if !path.exists() {
+        println!("No API key configured.");
+        println!("Run 'bubbaloop login' to set up your API key.");
+        return Ok(());
+    }
+
+    let content = std::fs::read_to_string(&path)?;
+    let key = content.lines().next().unwrap_or("").trim();
+    if key.is_empty() {
+        println!("Key file exists but is empty: {}", path.display());
+        println!("Run 'bubbaloop login' to set up your API key.");
+        return Ok(());
+    }
+
+    println!("API key source: {}", path.display());
+    let masked = mask_key(key);
+    println!("Key: {}", masked);
+    print!("Validating... ");
+    match validate_api_key(key).await {
+        Ok(model) => println!("Valid ({} available)", model),
+        Err(LoginError::InvalidKey(msg)) => println!("Invalid: {}", msg),
+        Err(e) => println!("Could not validate: {}", e),
+    }
+
+    Ok(())
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+/// Validate an API key by hitting GET /v1/models (free, no token cost).
+/// Returns the first model name on success.
+async fn validate_api_key(key: &str) -> Result<String> {
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(MODELS_URL)
+        .header("x-api-key", key)
+        .header("anthropic-version", API_VERSION)
+        .send()
+        .await?;
+
+    let status = resp.status().as_u16();
+    if status == 401 {
+        return Err(LoginError::InvalidKey(
+            "authentication failed (401)".to_string(),
+        ));
+    }
+    if status == 403 {
+        return Err(LoginError::InvalidKey("access denied (403)".to_string()));
+    }
+    if !resp.status().is_success() {
+        return Err(LoginError::InvalidKey(format!(
+            "unexpected status {}",
+            status
+        )));
+    }
+
+    // Parse response to extract a model name
+    let body: serde_json::Value = resp.json().await?;
+    let model_name = body
+        .get("data")
+        .and_then(|d| d.as_array())
+        .and_then(|arr| arr.first())
+        .and_then(|m| m.get("id"))
+        .and_then(|id| id.as_str())
+        .unwrap_or("models endpoint reachable")
+        .to_string();
+
+    Ok(model_name)
+}
+
+/// Write the key to disk with 0600 permissions.
+fn save_key_file(path: &PathBuf, key: &str) -> Result<()> {
+    // Ensure parent directory exists
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    #[cfg(unix)]
+    {
+        use std::io::Write;
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(path)?;
+        write!(file, "{}", key)?;
+    }
+
+    #[cfg(not(unix))]
+    {
+        std::fs::write(path, key)?;
+    }
+
+    Ok(())
+}
+
+/// Get the path to the API key file: `~/.bubbaloop/anthropic-key`.
+fn key_file_path() -> Result<PathBuf> {
+    let home = dirs::home_dir().ok_or(LoginError::NoHomeDir)?;
+    Ok(home.join(".bubbaloop").join(KEY_FILENAME))
+}
+
+/// Mask an API key for display: show first 8 and last 4 chars.
+fn mask_key(key: &str) -> String {
+    if key.len() <= 12 {
+        return "****".to_string();
+    }
+    let prefix = &key[..8];
+    let suffix = &key[key.len() - 4..];
+    format!("{}...{}", prefix, suffix)
+}
+
+// ── Tests ───────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_key_file_path() {
+        let path = key_file_path().unwrap();
+        assert!(path.ends_with(".bubbaloop/anthropic-key"));
+    }
+
+    #[test]
+    fn test_mask_key_normal() {
+        let masked = mask_key("sk-ant-api03-1234567890abcdef");
+        assert_eq!(masked, "sk-ant-a...cdef");
+    }
+
+    #[test]
+    fn test_mask_key_short() {
+        assert_eq!(mask_key("short"), "****");
+    }
+
+    #[test]
+    fn test_save_and_read_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("anthropic-key");
+
+        save_key_file(&path, "sk-ant-test-key-123").unwrap();
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(content, "sk-ant-test-key-123");
+    }
+
+    #[test]
+    fn test_save_creates_parent_dirs() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nested").join("dir").join("key");
+
+        save_key_file(&path, "test-key").unwrap();
+
+        assert!(path.exists());
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "test-key");
+    }
+
+    #[test]
+    fn test_save_overwrites_existing() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("key");
+
+        save_key_file(&path, "first-key").unwrap();
+        save_key_file(&path, "second-key").unwrap();
+
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "second-key");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_save_file_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("key");
+
+        save_key_file(&path, "test-key").unwrap();
+
+        let metadata = std::fs::metadata(&path).unwrap();
+        let mode = metadata.permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "key file should have 0600 permissions");
+    }
+}

--- a/crates/bubbaloop/src/cli/mod.rs
+++ b/crates/bubbaloop/src/cli/mod.rs
@@ -4,6 +4,7 @@ pub mod agent;
 pub mod debug;
 pub mod doctor;
 pub mod launch;
+pub mod login;
 pub mod marketplace;
 pub mod node;
 pub mod status;
@@ -11,6 +12,7 @@ pub mod up;
 
 pub use agent::AgentCommand;
 pub use debug::{DebugCommand, DebugError};
+pub use login::{LoginCommand, LogoutCommand};
 pub use marketplace::MarketplaceCommand;
 pub use node::{NodeCommand, NodeError};
 pub use up::UpCommand;

--- a/crates/bubbaloop/src/cli/mod.rs
+++ b/crates/bubbaloop/src/cli/mod.rs
@@ -1,5 +1,6 @@
 //! CLI module for Bubbaloop commands
 
+pub mod agent;
 pub mod debug;
 pub mod doctor;
 pub mod launch;
@@ -8,6 +9,7 @@ pub mod node;
 pub mod status;
 pub mod up;
 
+pub use agent::AgentCommand;
 pub use debug::{DebugCommand, DebugError};
 pub use marketplace::MarketplaceCommand;
 pub use node::{NodeCommand, NodeError};

--- a/crates/bubbaloop/src/cli/mod.rs
+++ b/crates/bubbaloop/src/cli/mod.rs
@@ -6,7 +6,9 @@ pub mod launch;
 pub mod marketplace;
 pub mod node;
 pub mod status;
+pub mod up;
 
 pub use debug::{DebugCommand, DebugError};
 pub use marketplace::MarketplaceCommand;
 pub use node::{NodeCommand, NodeError};
+pub use up::UpCommand;

--- a/crates/bubbaloop/src/cli/mod.rs
+++ b/crates/bubbaloop/src/cli/mod.rs
@@ -1,6 +1,7 @@
 //! CLI module for Bubbaloop commands
 
 pub mod agent;
+pub mod daemon_client;
 pub mod debug;
 pub mod doctor;
 pub mod launch;

--- a/crates/bubbaloop/src/cli/node/build.rs
+++ b/crates/bubbaloop/src/cli/node/build.rs
@@ -1,6 +1,6 @@
 //! Node build commands.
 
-use super::{Result, send_command};
+use super::{send_command, Result};
 
 pub(crate) async fn build_node(name: &str) -> Result<()> {
     send_command(name, "build").await

--- a/crates/bubbaloop/src/cli/node/install.rs
+++ b/crates/bubbaloop/src/cli/node/install.rs
@@ -5,9 +5,9 @@ use std::process::Command;
 
 use zenoh::query::QueryTarget;
 
-use crate::registry;
-use super::{CommandResponse, InstallArgs, NodeError, NodeListResponse, Result};
 use super::{get_zenoh_session, send_command};
+use super::{CommandResponse, InstallArgs, NodeError, NodeListResponse, Result};
+use crate::registry;
 
 /// Copy canonical header.proto to a node's protos/ directory if it exists.
 /// This ensures nodes use the correct version of header.proto.
@@ -53,17 +53,15 @@ pub(crate) fn normalize_git_url(source: &str) -> String {
 pub(crate) fn is_git_url(source: &str) -> bool {
     source.starts_with("https://github.com/")
         || source.starts_with("git@github.com:")
-        || (source.contains("github.com/")
-            && !source.starts_with('/')
-            && !source.starts_with('.'))
+        || (source.contains("github.com/") && !source.starts_with('/') && !source.starts_with('.'))
 }
 
 pub(crate) fn extract_node_name(path: &str) -> Result<String> {
     let node_yaml = Path::new(path).join("node.yaml");
     if node_yaml.exists() {
         let content = std::fs::read_to_string(&node_yaml)?;
-        let manifest: serde_yaml::Value = serde_yaml::from_str(&content)
-            .map_err(|e| NodeError::CommandFailed(e.to_string()))?;
+        let manifest: serde_yaml::Value =
+            serde_yaml::from_str(&content).map_err(|e| NodeError::CommandFailed(e.to_string()))?;
         if let Some(name) = manifest.get("name").and_then(|v| v.as_str()) {
             return Ok(name.to_string());
         }
@@ -75,11 +73,7 @@ pub(crate) fn extract_node_name(path: &str) -> Result<String> {
         .ok_or_else(|| NodeError::CommandFailed("Cannot extract node name".into()))
 }
 
-pub(crate) fn clone_from_github(
-    url: &str,
-    output: Option<&str>,
-    branch: &str,
-) -> Result<String> {
+pub(crate) fn clone_from_github(url: &str, output: Option<&str>, branch: &str) -> Result<String> {
     // Prevent argument injection via branch or URL starting with '-'
     if branch.starts_with('-') {
         return Err(NodeError::InvalidUrl(format!(
@@ -510,8 +504,7 @@ mod tests {
     #[test]
     fn test_clone_rejects_branch_argument_injection() {
         // Branch starting with '-' could be interpreted as a git flag
-        let result =
-            clone_from_github("https://github.com/user/repo", None, "--upload-pack=evil");
+        let result = clone_from_github("https://github.com/user/repo", None, "--upload-pack=evil");
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(err.contains("Invalid branch name"));

--- a/crates/bubbaloop/src/cli/node/lifecycle.rs
+++ b/crates/bubbaloop/src/cli/node/lifecycle.rs
@@ -4,8 +4,8 @@ use std::process::Command;
 
 use zenoh::query::QueryTarget;
 
-use super::{LogsArgs, LogsResponse, NodeError, Result};
 use super::{get_zenoh_session, send_command};
+use super::{LogsArgs, LogsResponse, NodeError, Result};
 
 pub(crate) async fn start_node(name: &str) -> Result<()> {
     send_command(name, "start").await

--- a/crates/bubbaloop/src/cli/up.rs
+++ b/crates/bubbaloop/src/cli/up.rs
@@ -163,15 +163,18 @@ impl UpCommand {
         let mem = match crate::agent::memory::Memory::open(&db_path) {
             Ok(m) => m,
             Err(e) => {
-                log::warn!("Could not open memory DB, skipping schedule registration: {}", e);
+                log::warn!(
+                    "Could not open memory DB, skipping schedule registration: {}",
+                    e
+                );
                 return Ok(());
             }
         };
         for skill in &skill_configs {
             if let Some(ref schedule_expr) = skill.schedule {
                 if !skill.actions.is_empty() {
-                    let actions_json = serde_json::to_string(&skill.actions)
-                        .unwrap_or_else(|_| "[]".to_string());
+                    let actions_json =
+                        serde_json::to_string(&skill.actions).unwrap_or_else(|_| "[]".to_string());
                     let sched = crate::agent::memory::Schedule {
                         id: uuid::Uuid::new_v4().to_string(),
                         name: skill.name.clone(),
@@ -190,10 +193,7 @@ impl UpCommand {
                     } else if let Err(e) = mem.upsert_schedule(&sched) {
                         println!("  [warn] Failed to register schedule: {}", e);
                     } else {
-                        println!(
-                            "  Registered schedule: {} ({})",
-                            skill.name, schedule_expr
-                        );
+                        println!("  Registered schedule: {} ({})", skill.name, schedule_expr);
                     }
                 }
             }

--- a/crates/bubbaloop/src/cli/up.rs
+++ b/crates/bubbaloop/src/cli/up.rs
@@ -1,0 +1,313 @@
+//! `bubbaloop up` — Load all skills and ensure sensor nodes are running.
+//!
+//! Reads all YAML skill files from `~/.bubbaloop/skills/`, resolves the
+//! corresponding marketplace nodes, installs missing nodes, injects
+//! per-skill config, and prints a summary of what was done.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use argh::FromArgs;
+use thiserror::Error;
+
+use crate::daemon::registry::get_bubbaloop_home;
+use crate::registry;
+use crate::{marketplace, skills};
+
+/// Errors for the `up` command.
+#[derive(Debug, Error)]
+pub enum UpError {
+    #[error("Skill load error: {0}")]
+    SkillLoad(#[from] skills::SkillError),
+    #[error("Marketplace error: {0}")]
+    Marketplace(#[from] marketplace::MarketplaceError),
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("Registry error: {0}")]
+    Registry(String),
+}
+
+pub type Result<T> = std::result::Result<T, UpError>;
+
+/// Load all skills and ensure sensor nodes are running
+#[derive(FromArgs, PartialEq, Debug)]
+#[argh(subcommand, name = "up")]
+pub struct UpCommand {
+    /// path to skills directory (default: ~/.bubbaloop/skills)
+    #[argh(option, short = 's')]
+    pub skills_dir: Option<String>,
+
+    /// dry run — show what would be done without doing it
+    #[argh(switch)]
+    pub dry_run: bool,
+}
+
+impl UpCommand {
+    pub fn run(&self) -> Result<()> {
+        // 1. Resolve skills directory
+        let skills_dir = match &self.skills_dir {
+            Some(p) => PathBuf::from(p),
+            None => get_bubbaloop_home().join("skills"),
+        };
+
+        println!("Loading skills from: {}", skills_dir.display());
+
+        if !skills_dir.exists() {
+            println!("Skills directory not found: {}", skills_dir.display());
+            println!("Create it with: mkdir -p {}", skills_dir.display());
+            return Ok(());
+        }
+
+        if self.dry_run {
+            println!("[dry-run] No changes will be made.");
+        }
+
+        // 2. Load all YAML skills
+        let skill_configs = skills::load_skills(&skills_dir)?;
+        if skill_configs.is_empty() {
+            println!("No skills found in {}", skills_dir.display());
+            return Ok(());
+        }
+
+        println!("Found {} skill(s)", skill_configs.len());
+
+        // 3. Load marketplace registry (refresh cache if empty)
+        let mut registry_nodes = registry::load_cached_registry();
+        if registry_nodes.is_empty() {
+            log::info!("Registry cache empty, refreshing from upstream...");
+            registry::refresh_cache().map_err(UpError::Registry)?;
+            registry_nodes = registry::load_cached_registry();
+        }
+
+        // 4. Process each skill
+        let mut installed_count: usize = 0;
+        let mut already_installed: usize = 0;
+        let mut skipped_count: usize = 0;
+
+        for skill in &skill_configs {
+            println!("\n  skill:  {}", skill.name);
+            println!("  driver: {}", skill.driver);
+
+            // Resolve driver name → DriverEntry (marketplace node + description)
+            let driver_entry = match skills::resolve_driver(&skill.driver) {
+                Some(d) => d,
+                None => {
+                    println!(
+                        "  [warn] Unknown driver '{}', skipping",
+                        skill.driver
+                    );
+                    skipped_count += 1;
+                    continue;
+                }
+            };
+
+            let marketplace_node = &driver_entry.marketplace_node;
+            println!("  node:   {}", marketplace_node);
+
+            // Find the registry entry for this node
+            let registry_node = match registry::find_by_name(&registry_nodes, marketplace_node) {
+                Some(n) => n,
+                None => {
+                    println!(
+                        "  [warn] Node '{}' not in registry, skipping",
+                        marketplace_node
+                    );
+                    skipped_count += 1;
+                    continue;
+                }
+            };
+
+            // Check installation status and install if needed
+            if is_node_installed(marketplace_node) {
+                println!("  [ok] Already installed");
+                already_installed += 1;
+            } else if self.dry_run {
+                println!("  [dry-run] Would install {}", marketplace_node);
+            } else {
+                println!("  Installing {}...", marketplace_node);
+                let node_dir = marketplace::download_precompiled(&registry_node)?;
+                println!("  Installed to {}", node_dir);
+                installed_count += 1;
+            }
+
+            // Inject skill config into node directory
+            if !skill.config.is_empty() {
+                let node_dir = resolve_node_dir(&registry_node);
+                if self.dry_run {
+                    println!(
+                        "  [dry-run] Would write config to {}",
+                        node_dir.display()
+                    );
+                } else {
+                    match write_node_config(&node_dir, &skill.config) {
+                        Ok(()) => {
+                            println!("  Config written to {}", node_dir.display())
+                        }
+                        Err(e) => println!("  [warn] Config write failed: {}", e),
+                    }
+                }
+            }
+
+            // Print start hint (full systemd integration wired in by daemon)
+            if !self.dry_run {
+                println!("  Hint: bubbaloop node start {}", marketplace_node);
+            }
+        }
+
+        // 5. Summary
+        println!();
+        println!(
+            "Done: {} skill(s) loaded | {} installed | {} already present | {} skipped",
+            skill_configs.len(),
+            installed_count,
+            already_installed,
+            skipped_count
+        );
+
+        Ok(())
+    }
+}
+
+/// Return true if a node directory for `node_name` exists under `~/.bubbaloop/nodes/`.
+///
+/// The layout is `~/.bubbaloop/nodes/<repo>/<subdir>` so we search two levels deep.
+pub fn is_node_installed(node_name: &str) -> bool {
+    let nodes_dir = get_bubbaloop_home().join("nodes");
+    if !nodes_dir.exists() {
+        return false;
+    }
+
+    // Walk: ~/.bubbaloop/nodes/<repo>/<subdir>
+    let Ok(repo_entries) = std::fs::read_dir(&nodes_dir) else {
+        return false;
+    };
+    for repo_entry in repo_entries.flatten() {
+        let repo_path = repo_entry.path();
+        if !repo_path.is_dir() {
+            continue;
+        }
+        let Ok(node_entries) = std::fs::read_dir(&repo_path) else {
+            continue;
+        };
+        for node_entry in node_entries.flatten() {
+            if node_entry.file_name().to_string_lossy() == node_name {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Write the skill `config:` section as `config.yaml` into the node directory.
+pub fn write_node_config(
+    node_dir: &Path,
+    config: &HashMap<String, serde_yaml::Value>,
+) -> std::io::Result<()> {
+    std::fs::create_dir_all(node_dir)?;
+    let yaml = serde_yaml::to_string(config)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    let dest = node_dir.join("config.yaml");
+    std::fs::write(&dest, yaml)?;
+    log::info!("Wrote node config to {}", dest.display());
+    Ok(())
+}
+
+/// Compute the installed node directory from registry metadata.
+///
+/// Matches the layout created by `marketplace::download_precompiled`.
+fn resolve_node_dir(entry: &registry::RegistryNode) -> PathBuf {
+    let repo_name = entry
+        .repo
+        .rsplit('/')
+        .next()
+        .unwrap_or("bubbaloop-nodes-official");
+    get_bubbaloop_home()
+        .join("nodes")
+        .join(repo_name)
+        .join(&entry.subdir)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn up_command_struct_defaults() {
+        let cmd = UpCommand {
+            skills_dir: None,
+            dry_run: false,
+        };
+        assert!(cmd.skills_dir.is_none());
+        assert!(!cmd.dry_run);
+    }
+
+    #[test]
+    fn up_command_struct_with_options() {
+        let cmd = UpCommand {
+            skills_dir: Some("/tmp/skills".to_string()),
+            dry_run: true,
+        };
+        assert_eq!(cmd.skills_dir.as_deref(), Some("/tmp/skills"));
+        assert!(cmd.dry_run);
+    }
+
+    #[test]
+    fn is_node_installed_returns_false_for_nonexistent() {
+        assert!(!is_node_installed("definitely-not-installed-xyz-9999"));
+    }
+
+    #[test]
+    fn write_node_config_creates_valid_yaml() {
+        use tempfile::tempdir;
+
+        let dir = tempdir().unwrap();
+        let node_dir = dir.path().join("test-node");
+
+        let mut config = HashMap::new();
+        config.insert(
+            "url".to_string(),
+            serde_yaml::Value::String("rtsp://example.com/stream".to_string()),
+        );
+        config.insert(
+            "fps".to_string(),
+            serde_yaml::Value::Number(serde_yaml::Number::from(30)),
+        );
+
+        write_node_config(&node_dir, &config).unwrap();
+
+        let config_path = node_dir.join("config.yaml");
+        assert!(config_path.exists());
+        let content = std::fs::read_to_string(&config_path).unwrap();
+        assert!(content.contains("rtsp://example.com/stream"));
+        assert!(content.contains("30"));
+    }
+
+    #[test]
+    fn write_node_config_empty_config() {
+        use tempfile::tempdir;
+
+        let dir = tempdir().unwrap();
+        let node_dir = dir.path().join("empty-node");
+        let config: HashMap<String, serde_yaml::Value> = HashMap::new();
+
+        write_node_config(&node_dir, &config).unwrap();
+        assert!(node_dir.join("config.yaml").exists());
+    }
+
+    #[test]
+    fn write_node_config_creates_intermediate_dirs() {
+        use tempfile::tempdir;
+
+        let dir = tempdir().unwrap();
+        let node_dir = dir.path().join("a").join("b").join("c");
+
+        let mut config = HashMap::new();
+        config.insert(
+            "key".to_string(),
+            serde_yaml::Value::String("val".to_string()),
+        );
+
+        write_node_config(&node_dir, &config).unwrap();
+        assert!(node_dir.join("config.yaml").exists());
+    }
+}

--- a/crates/bubbaloop/src/lib.rs
+++ b/crates/bubbaloop/src/lib.rs
@@ -29,6 +29,9 @@ pub mod validation;
 /// YAML skill loader — driver catalog and config parsing
 pub mod skills;
 
+/// Agent layer: Claude API chat, SQLite memory, scheduling
+pub mod agent;
+
 /// Protobuf schemas for bubbaloop
 pub mod schemas {
     pub mod header {

--- a/crates/bubbaloop/src/lib.rs
+++ b/crates/bubbaloop/src/lib.rs
@@ -26,6 +26,9 @@ pub mod mcp;
 /// Shared input validation for trust boundaries
 pub mod validation;
 
+/// YAML skill loader — driver catalog and config parsing
+pub mod skills;
+
 /// Protobuf schemas for bubbaloop
 pub mod schemas {
     pub mod header {

--- a/crates/bubbaloop/src/lib.rs
+++ b/crates/bubbaloop/src/lib.rs
@@ -23,6 +23,9 @@ pub mod marketplace;
 /// MCP server for AI agent integration
 pub mod mcp;
 
+/// REST API for CLI → daemon communication
+pub mod api;
+
 /// Shared input validation for trust boundaries
 pub mod validation;
 

--- a/crates/bubbaloop/src/mcp/mod.rs
+++ b/crates/bubbaloop/src/mcp/mod.rs
@@ -925,6 +925,8 @@ pub async fn run_mcp_server(
         machine_id: machine_id.clone(),
     });
 
+    let api_router = crate::api::api_router(platform.clone());
+
     let mcp_service = StreamableHttpService::new(
         move || {
             Ok(BubbaLoopMcpServer::new(
@@ -981,6 +983,7 @@ pub async fn run_mcp_server(
                 }
             }),
         )
+        .nest("/api/v1", api_router)
         .nest_service("/mcp", mcp_service)
         .layer(tower_governor::GovernorLayer::new(governor_conf));
 

--- a/crates/bubbaloop/src/skills/mod.rs
+++ b/crates/bubbaloop/src/skills/mod.rs
@@ -1,0 +1,396 @@
+//! YAML Skill Loader — configure sensors with 5-line YAML files.
+//!
+//! Skills map a human-readable driver name to a marketplace node,
+//! letting users express sensor configuration without writing Rust.
+//!
+//! Example skill file (`~/.bubbaloop/skills/my-camera.yaml`):
+//! ```yaml
+//! name: my-camera
+//! driver: rtsp
+//! config:
+//!   url: rtsp://192.168.1.10/stream
+//! ```
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::Path;
+
+/// Errors from skill loading and validation operations.
+#[derive(Debug, thiserror::Error)]
+pub enum SkillError {
+    #[error("Skill name is invalid: {0}")]
+    InvalidName(String),
+    #[error("Unknown driver '{0}' — run `bubbaloop skill drivers` to see available drivers")]
+    UnknownDriver(String),
+    #[error("Skill file '{path}' failed to parse: {source}")]
+    ParseError {
+        path: String,
+        source: serde_yaml::Error,
+    },
+    #[error("IO error reading skills directory: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+pub type Result<T> = std::result::Result<T, SkillError>;
+
+/// A skill configuration parsed from a YAML file.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct SkillConfig {
+    /// Node name — must satisfy `[a-zA-Z0-9_-]{1,64}`.
+    pub name: String,
+    /// Driver identifier (e.g. `rtsp`, `v4l2`, `serial`).
+    pub driver: String,
+    /// Driver-specific key/value parameters.
+    #[serde(default)]
+    pub config: HashMap<String, serde_yaml::Value>,
+    /// Optional cron-style schedule (Phase 4 placeholder).
+    #[serde(default)]
+    pub schedule: Option<String>,
+    /// Declarative actions list (Phase 4 placeholder).
+    #[serde(default)]
+    pub actions: Vec<serde_yaml::Value>,
+}
+
+/// Maps a driver name to the corresponding marketplace node.
+#[derive(Debug, Clone, Copy)]
+pub struct DriverEntry {
+    pub driver_name: &'static str,
+    pub marketplace_node: &'static str,
+    pub description: &'static str,
+}
+
+/// Built-in driver catalog.
+pub static DRIVER_CATALOG: &[DriverEntry] = &[
+    DriverEntry {
+        driver_name: "rtsp",
+        marketplace_node: "rtsp-camera",
+        description: "IP cameras, NVRs",
+    },
+    DriverEntry {
+        driver_name: "v4l2",
+        marketplace_node: "v4l2-camera",
+        description: "USB webcams, CSI cameras",
+    },
+    DriverEntry {
+        driver_name: "serial",
+        marketplace_node: "serial-bridge",
+        description: "Arduino, UART, RS-485",
+    },
+    DriverEntry {
+        driver_name: "gpio",
+        marketplace_node: "gpio-controller",
+        description: "Buttons, LEDs, relays",
+    },
+    DriverEntry {
+        driver_name: "http-poll",
+        marketplace_node: "http-sensor",
+        description: "REST APIs, weather services",
+    },
+    DriverEntry {
+        driver_name: "mqtt",
+        marketplace_node: "mqtt-bridge",
+        description: "Home automation, industrial",
+    },
+    DriverEntry {
+        driver_name: "modbus",
+        marketplace_node: "modbus-bridge",
+        description: "Industrial IoT, PLCs",
+    },
+    DriverEntry {
+        driver_name: "system",
+        marketplace_node: "system-telemetry",
+        description: "CPU, RAM, disk, temperature",
+    },
+];
+
+/// Look up a driver by name in the built-in catalog.
+pub fn resolve_driver(name: &str) -> Option<&'static DriverEntry> {
+    DRIVER_CATALOG
+        .iter()
+        .find(|e| e.driver_name == name)
+}
+
+/// Validate a skill config against naming rules and the driver catalog.
+pub fn validate_skill(skill: &SkillConfig) -> Result<()> {
+    crate::validation::validate_node_name(&skill.name)
+        .map_err(SkillError::InvalidName)?;
+
+    if resolve_driver(&skill.driver).is_none() {
+        return Err(SkillError::UnknownDriver(skill.driver.clone()));
+    }
+
+    Ok(())
+}
+
+/// Load all `*.yaml` skill files from the given directory.
+///
+/// Files that fail to parse are logged and skipped. An empty or missing
+/// directory returns an empty `Vec` rather than an error.
+pub fn load_skills(skills_dir: &Path) -> Result<Vec<SkillConfig>> {
+    if !skills_dir.exists() {
+        log::debug!(
+            "Skills directory '{}' does not exist — no skills loaded",
+            skills_dir.display()
+        );
+        return Ok(Vec::new());
+    }
+
+    let mut skills = Vec::new();
+
+    for entry in std::fs::read_dir(skills_dir)? {
+        let entry = entry?;
+        let path = entry.path();
+
+        if path.extension().and_then(|e| e.to_str()) != Some("yaml") {
+            continue;
+        }
+
+        let raw = match std::fs::read_to_string(&path) {
+            Ok(s) => s,
+            Err(err) => {
+                log::warn!("Failed to read skill file '{}': {}", path.display(), err);
+                continue;
+            }
+        };
+
+        let skill: SkillConfig = match serde_yaml::from_str(&raw) {
+            Ok(s) => s,
+            Err(source) => {
+                let path_str = path.display().to_string();
+                log::warn!("Failed to parse skill file '{}': {}", path_str, source);
+                return Err(SkillError::ParseError {
+                    path: path_str,
+                    source,
+                });
+            }
+        };
+
+        match validate_skill(&skill) {
+            Ok(()) => {
+                log::debug!(
+                    "Loaded skill '{}' (driver: {})",
+                    skill.name,
+                    skill.driver
+                );
+                skills.push(skill);
+            }
+            Err(err) => {
+                log::warn!(
+                    "Skill file '{}' failed validation: {}",
+                    path.display(),
+                    err
+                );
+            }
+        }
+    }
+
+    Ok(skills)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    // ── SkillConfig YAML parsing ─────────────────────────────────────────────
+
+    #[test]
+    fn parse_full_yaml() {
+        let yaml = r#"
+name: my-camera
+driver: rtsp
+config:
+  url: rtsp://192.168.1.10/stream
+  fps: 30
+schedule: "0 * * * *"
+actions:
+  - record
+"#;
+        let skill: SkillConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(skill.name, "my-camera");
+        assert_eq!(skill.driver, "rtsp");
+        assert_eq!(
+            skill.config["url"],
+            serde_yaml::Value::String("rtsp://192.168.1.10/stream".into())
+        );
+        assert_eq!(skill.schedule.as_deref(), Some("0 * * * *"));
+        assert_eq!(skill.actions.len(), 1);
+    }
+
+    #[test]
+    fn parse_minimal_yaml() {
+        let yaml = "name: webcam\ndriver: v4l2\n";
+        let skill: SkillConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(skill.name, "webcam");
+        assert_eq!(skill.driver, "v4l2");
+        assert!(skill.config.is_empty());
+        assert!(skill.schedule.is_none());
+        assert!(skill.actions.is_empty());
+    }
+
+    #[test]
+    fn parse_missing_name_fails() {
+        let yaml = "driver: rtsp\n";
+        let result: std::result::Result<SkillConfig, _> = serde_yaml::from_str(yaml);
+        assert!(result.is_err(), "expected parse error for missing name");
+    }
+
+    #[test]
+    fn parse_missing_driver_fails() {
+        let yaml = "name: my-camera\n";
+        let result: std::result::Result<SkillConfig, _> = serde_yaml::from_str(yaml);
+        assert!(result.is_err(), "expected parse error for missing driver");
+    }
+
+    // ── resolve_driver ───────────────────────────────────────────────────────
+
+    #[test]
+    fn resolve_all_builtin_drivers() {
+        let cases = [
+            ("rtsp", "rtsp-camera"),
+            ("v4l2", "v4l2-camera"),
+            ("serial", "serial-bridge"),
+            ("gpio", "gpio-controller"),
+            ("http-poll", "http-sensor"),
+            ("mqtt", "mqtt-bridge"),
+            ("modbus", "modbus-bridge"),
+            ("system", "system-telemetry"),
+        ];
+        for (driver, node) in cases {
+            let entry = resolve_driver(driver)
+                .unwrap_or_else(|| panic!("driver '{}' not found in catalog", driver));
+            assert_eq!(entry.marketplace_node, node);
+        }
+    }
+
+    #[test]
+    fn resolve_unknown_driver_returns_none() {
+        assert!(resolve_driver("not-a-driver").is_none());
+        assert!(resolve_driver("").is_none());
+        assert!(resolve_driver("RTSP").is_none()); // case-sensitive
+    }
+
+    // ── validate_skill ───────────────────────────────────────────────────────
+
+    #[test]
+    fn validate_valid_skill() {
+        let skill = SkillConfig {
+            name: "my-camera".into(),
+            driver: "rtsp".into(),
+            config: HashMap::new(),
+            schedule: None,
+            actions: Vec::new(),
+        };
+        assert!(validate_skill(&skill).is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_invalid_name() {
+        let skill = SkillConfig {
+            name: "bad name!".into(),
+            driver: "rtsp".into(),
+            config: HashMap::new(),
+            schedule: None,
+            actions: Vec::new(),
+        };
+        assert!(matches!(validate_skill(&skill), Err(SkillError::InvalidName(_))));
+    }
+
+    #[test]
+    fn validate_rejects_empty_name() {
+        let skill = SkillConfig {
+            name: "".into(),
+            driver: "rtsp".into(),
+            config: HashMap::new(),
+            schedule: None,
+            actions: Vec::new(),
+        };
+        assert!(matches!(validate_skill(&skill), Err(SkillError::InvalidName(_))));
+    }
+
+    #[test]
+    fn validate_rejects_unknown_driver() {
+        let skill = SkillConfig {
+            name: "my-sensor".into(),
+            driver: "unknown-driver".into(),
+            config: HashMap::new(),
+            schedule: None,
+            actions: Vec::new(),
+        };
+        assert!(matches!(
+            validate_skill(&skill),
+            Err(SkillError::UnknownDriver(_))
+        ));
+    }
+
+    // ── load_skills ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn load_skills_missing_dir_returns_empty() {
+        let dir = tempdir().unwrap();
+        let missing = dir.path().join("nonexistent");
+        let skills = load_skills(&missing).unwrap();
+        assert!(skills.is_empty());
+    }
+
+    #[test]
+    fn load_skills_empty_dir_returns_empty() {
+        let dir = tempdir().unwrap();
+        let skills = load_skills(dir.path()).unwrap();
+        assert!(skills.is_empty());
+    }
+
+    #[test]
+    fn load_skills_ignores_non_yaml_files() {
+        let dir = tempdir().unwrap();
+        std::fs::write(dir.path().join("readme.txt"), "not yaml").unwrap();
+        std::fs::write(dir.path().join("config.toml"), "[section]").unwrap();
+        let skills = load_skills(dir.path()).unwrap();
+        assert!(skills.is_empty());
+    }
+
+    #[test]
+    fn load_skills_loads_valid_files() {
+        let dir = tempdir().unwrap();
+        let yaml = "name: cam1\ndriver: rtsp\n";
+        std::fs::write(dir.path().join("cam1.yaml"), yaml).unwrap();
+        let skills = load_skills(dir.path()).unwrap();
+        assert_eq!(skills.len(), 1);
+        assert_eq!(skills[0].name, "cam1");
+        assert_eq!(skills[0].driver, "rtsp");
+    }
+
+    #[test]
+    fn load_skills_skips_invalid_validation() {
+        let dir = tempdir().unwrap();
+        // Invalid name (spaces not allowed) but valid YAML
+        let bad = "name: \"bad name\"\ndriver: rtsp\n";
+        std::fs::write(dir.path().join("bad.yaml"), bad).unwrap();
+        // Valid skill
+        let good = "name: good-cam\ndriver: v4l2\n";
+        std::fs::write(dir.path().join("good.yaml"), good).unwrap();
+
+        let skills = load_skills(dir.path()).unwrap();
+        assert_eq!(skills.len(), 1);
+        assert_eq!(skills[0].name, "good-cam");
+    }
+
+    #[test]
+    fn load_skills_errors_on_malformed_yaml() {
+        let dir = tempdir().unwrap();
+        std::fs::write(dir.path().join("broken.yaml"), ": : : invalid").unwrap();
+        let result = load_skills(dir.path());
+        assert!(matches!(result, Err(SkillError::ParseError { .. })));
+    }
+
+    #[test]
+    fn load_skills_loads_multiple_files() {
+        let dir = tempdir().unwrap();
+        for (i, driver) in ["rtsp", "v4l2", "system"].iter().enumerate() {
+            let yaml = format!("name: sensor-{i}\ndriver: {driver}\n");
+            std::fs::write(dir.path().join(format!("s{i}.yaml")), yaml).unwrap();
+        }
+        let skills = load_skills(dir.path()).unwrap();
+        assert_eq!(skills.len(), 3);
+    }
+}

--- a/crates/bubbaloop/src/skills/mod.rs
+++ b/crates/bubbaloop/src/skills/mod.rs
@@ -105,15 +105,12 @@ pub static DRIVER_CATALOG: &[DriverEntry] = &[
 
 /// Look up a driver by name in the built-in catalog.
 pub fn resolve_driver(name: &str) -> Option<&'static DriverEntry> {
-    DRIVER_CATALOG
-        .iter()
-        .find(|e| e.driver_name == name)
+    DRIVER_CATALOG.iter().find(|e| e.driver_name == name)
 }
 
 /// Validate a skill config against naming rules and the driver catalog.
 pub fn validate_skill(skill: &SkillConfig) -> Result<()> {
-    crate::validation::validate_node_name(&skill.name)
-        .map_err(SkillError::InvalidName)?;
+    crate::validation::validate_node_name(&skill.name).map_err(SkillError::InvalidName)?;
 
     if resolve_driver(&skill.driver).is_none() {
         return Err(SkillError::UnknownDriver(skill.driver.clone()));
@@ -167,19 +164,11 @@ pub fn load_skills(skills_dir: &Path) -> Result<Vec<SkillConfig>> {
 
         match validate_skill(&skill) {
             Ok(()) => {
-                log::debug!(
-                    "Loaded skill '{}' (driver: {})",
-                    skill.name,
-                    skill.driver
-                );
+                log::debug!("Loaded skill '{}' (driver: {})", skill.name, skill.driver);
                 skills.push(skill);
             }
             Err(err) => {
-                log::warn!(
-                    "Skill file '{}' failed validation: {}",
-                    path.display(),
-                    err
-                );
+                log::warn!("Skill file '{}' failed validation: {}", path.display(), err);
             }
         }
     }
@@ -293,7 +282,10 @@ actions:
             schedule: None,
             actions: Vec::new(),
         };
-        assert!(matches!(validate_skill(&skill), Err(SkillError::InvalidName(_))));
+        assert!(matches!(
+            validate_skill(&skill),
+            Err(SkillError::InvalidName(_))
+        ));
     }
 
     #[test]
@@ -305,7 +297,10 @@ actions:
             schedule: None,
             actions: Vec::new(),
         };
-        assert!(matches!(validate_skill(&skill), Err(SkillError::InvalidName(_))));
+        assert!(matches!(
+            validate_skill(&skill),
+            Err(SkillError::InvalidName(_))
+        ));
     }
 
     #[test]

--- a/docs/plans/2026-02-28-agent-implementation-design.md
+++ b/docs/plans/2026-02-28-agent-implementation-design.md
@@ -1,0 +1,187 @@
+# Agent Implementation Design (Phases 2-4)
+
+**Date:** 2026-02-28
+**Status:** Approved, ready for implementation
+**Builds on:** `2026-02-27-hardware-ai-agent-design.md`
+
+---
+
+## Scope
+
+Implement all three remaining phases in sequence:
+- **Phase 2**: Agent Loop (Claude API + internal MCP tool dispatch)
+- **Phase 3**: SQLite Memory (conversations, sensor events, schedules)
+- **Phase 4**: Scheduling (Tier 1 offline cron + Tier 2 LLM-driven)
+
+## Module Structure
+
+```
+crates/bubbaloop/src/
+├── agent/
+│   ├── mod.rs          # AgentConfig, run_agent(), system prompt builder
+│   ├── claude.rs       # Claude API client (raw reqwest, tool_use)
+│   ├── dispatch.rs     # Internal MCP tool dispatch (no HTTP)
+│   ├── memory.rs       # SQLite: conversations, sensor_events, schedules
+│   └── scheduler.rs    # Cron executor (Tier 1 + Tier 2)
+├── cli/
+│   └── agent.rs        # `bubbaloop agent` CLI command (terminal chat)
+```
+
+## Phase 2: Agent Loop
+
+### claude.rs — Claude API Client
+
+Raw reqwest to `https://api.anthropic.com/v1/messages`:
+- API key from `ANTHROPIC_API_KEY` env var (never persisted)
+- Model: `claude-sonnet-4-20250514` (configurable)
+- Tool definitions: generated from the 23 MCP tool schemas
+- Multi-turn loop: user → Claude → tool_use → tool results → Claude → response
+- Streaming not required for v1 (simplifies implementation)
+
+Key types:
+```rust
+pub struct ClaudeClient { client: reqwest::Client, api_key: String, model: String }
+pub struct Message { role: String, content: Vec<ContentBlock> }
+pub enum ContentBlock { Text { text: String }, ToolUse { id, name, input }, ToolResult { tool_use_id, content } }
+```
+
+### dispatch.rs — Internal MCP Tool Dispatch
+
+Calls MCP tools without HTTP round-trip:
+- Creates `BubbaLoopMcpServer<DaemonPlatform>` instance
+- Maps Claude tool_use `name` + `input` → `CallToolRequestParams`
+- Calls `server.call_tool(params)` directly
+- Returns `CallToolResult` text content back to Claude as `ToolResult`
+
+### agent/mod.rs — Orchestrator
+
+```rust
+pub async fn run_agent(config: AgentConfig, session: Session, node_manager: NodeManager) {
+    // 1. Build system prompt (sensor inventory, schedules)
+    // 2. Read user input (stdin readline)
+    // 3. Send to Claude with tools
+    // 4. If tool_use: dispatch internally, append results, loop
+    // 5. If text: display response, log to memory
+    // 6. Repeat
+}
+```
+
+System prompt includes live data on every turn:
+- Sensor inventory from `list_nodes()`
+- Active schedules from SQLite (Phase 3)
+- Recent events summary (Phase 3)
+
+### cli/agent.rs — CLI Command
+
+```rust
+#[derive(FromArgs)]
+#[argh(subcommand, name = "agent")]
+pub struct AgentCommand {
+    #[argh(option, short = 'm')]
+    pub model: Option<String>,  // default: claude-sonnet-4-20250514
+}
+```
+
+Wired into `bin/bubbaloop.rs` Command enum. Requires Zenoh session + NodeManager (like daemon/mcp commands).
+
+## Phase 3: SQLite Memory
+
+### memory.rs — Database Layer
+
+`rusqlite` with bundled SQLite3. DB at `~/.bubbaloop/memory.db` (0600 permissions).
+
+Schema (from approved design doc):
+```sql
+CREATE TABLE conversations (
+    id TEXT PRIMARY KEY, timestamp TEXT NOT NULL,
+    role TEXT NOT NULL, content TEXT NOT NULL, tool_calls TEXT
+);
+CREATE TABLE sensor_events (
+    id TEXT PRIMARY KEY, timestamp TEXT NOT NULL,
+    node_name TEXT NOT NULL, event_type TEXT NOT NULL, details TEXT
+);
+CREATE TABLE schedules (
+    id TEXT PRIMARY KEY, name TEXT NOT NULL UNIQUE,
+    cron TEXT NOT NULL, actions TEXT NOT NULL,
+    tier INTEGER NOT NULL DEFAULT 1,
+    last_run TEXT, next_run TEXT, created_by TEXT NOT NULL
+);
+```
+
+Key interface:
+```rust
+pub struct Memory { conn: rusqlite::Connection }
+impl Memory {
+    pub fn open(path: &Path) -> Result<Self>;       // creates tables if missing
+    pub fn log_message(&self, role, content, tool_calls) -> Result<()>;
+    pub fn log_event(&self, node_name, event_type, details) -> Result<()>;
+    pub fn recent_events(&self, limit: usize) -> Result<Vec<SensorEvent>>;
+    pub fn recent_conversations(&self, limit: usize) -> Result<Vec<ConversationRow>>;
+    pub fn upsert_schedule(&self, schedule: &Schedule) -> Result<()>;
+    pub fn list_schedules(&self) -> Result<Vec<Schedule>>;
+    pub fn update_last_run(&self, id: &str, last_run: &str, next_run: &str) -> Result<()>;
+}
+```
+
+### Event Hook
+
+In `NodeManager::emit_event()`, add an optional `Memory` subscriber:
+```rust
+// Existing: broadcast to watchers
+let _ = self.event_tx.send(event.clone());
+// New: persist to SQLite (non-blocking, log-and-continue on error)
+if let Some(memory) = &self.memory {
+    if let Err(e) = memory.log_event(&event.node_name, &event.event_type, &details) {
+        log::warn!("Failed to write event to memory: {}", e);
+    }
+}
+```
+
+## Phase 4: Scheduling
+
+### scheduler.rs — Cron Executor
+
+Background tokio task that checks `schedules` table every 60 seconds.
+
+```rust
+pub struct Scheduler { memory: Arc<Memory>, platform: Arc<dyn PlatformOperations> }
+impl Scheduler {
+    pub async fn run(&self, mut shutdown: watch::Receiver<()>);
+    fn execute_tier1(&self, schedule: &Schedule) -> Result<()>;    // no LLM
+    async fn execute_tier2(&self, schedule: &Schedule, claude: &ClaudeClient) -> Result<()>;
+}
+```
+
+**Tier 1 built-in actions** (closed set, no arbitrary code):
+- `check_all_health` — query health for all running nodes
+- `restart` — restart unhealthy nodes
+- `capture_frame` — send capture command to camera node
+- `start_node` / `stop_node` — node lifecycle
+- `send_command` — generic command dispatch
+- `log_event` / `store_event` — write to sensor_events
+- `notify` — print to terminal / notification queue
+
+**Tier 2**: Invokes Claude API with schedule context. Rate-limited (configurable max calls/day, default 100).
+
+### Skill Integration
+
+`bubbaloop up` already loads skills with `schedule` and `actions` fields. At daemon startup, skills with schedules register as Tier 1 jobs in the `schedules` table (created_by = "yaml").
+
+## New Dependencies
+
+| Crate | Purpose | Binary Impact |
+|-------|---------|---------------|
+| `rusqlite` (bundled) | Embedded SQLite | +1-2 MB |
+| `cron` | Cron expression parsing | ~50 KB |
+
+`reqwest` already in dep tree via zenoh. Target binary: ~12-13 MB.
+
+## Implementation Order
+
+1. Phase 2a: `claude.rs` + `dispatch.rs` — get a working chat loop
+2. Phase 2b: `cli/agent.rs` + `agent/mod.rs` — wire into binary, test end-to-end
+3. Phase 3a: `memory.rs` — SQLite schema + CRUD operations
+4. Phase 3b: Hook memory into agent loop + daemon events
+5. Phase 4a: `scheduler.rs` — Tier 1 cron executor with built-in actions
+6. Phase 4b: Tier 2 LLM scheduling + skill YAML integration
+7. Update ROADMAP.md checkboxes

--- a/docs/plans/2026-02-28-agent-implementation.md
+++ b/docs/plans/2026-02-28-agent-implementation.md
@@ -1,0 +1,2069 @@
+# Agent Implementation Plan (Phases 2-4)
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add `bubbaloop agent` — a terminal chat interface that connects Claude to the 24 existing MCP tools, backed by SQLite memory and an offline-capable scheduler.
+
+**Architecture:** Agent layer sits ON TOP of existing MCP server. `dispatch.rs` creates a `BubbaLoopMcpServer<DaemonPlatform>` and calls `call_tool()` directly (no HTTP). Claude API via raw `reqwest`. SQLite at `~/.bubbaloop/memory.db`. Scheduler checks cron expressions every 60s in a background tokio task.
+
+**Tech Stack:** `reqwest` (Claude API), `rusqlite` (bundled SQLite3), `cron` crate (expression parsing), existing `rmcp`/`argh`/`tokio`/`serde_json`.
+
+---
+
+## Task 1: Add Dependencies
+
+**Files:**
+- Modify: `/home/nvidia/bubbaloop/Cargo.toml` (workspace deps)
+- Modify: `/home/nvidia/bubbaloop/crates/bubbaloop/Cargo.toml` (crate deps)
+
+**Step 1: Add workspace dependencies**
+
+In `/home/nvidia/bubbaloop/Cargo.toml`, add after the existing `anyhow = "1"` line:
+
+```toml
+# HTTP client (Claude API)
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
+
+# Embedded database (memory layer)
+rusqlite = { version = "0.33", features = ["bundled"] }
+
+# Cron expression parsing (scheduler)
+cron = "0.15"
+```
+
+**Step 2: Add crate dependencies**
+
+In `/home/nvidia/bubbaloop/crates/bubbaloop/Cargo.toml`, add in `[dependencies]`:
+
+```toml
+reqwest.workspace = true
+rusqlite.workspace = true
+cron.workspace = true
+```
+
+**Step 3: Verify compilation**
+
+Run: `pixi run check`
+Expected: Compiles with new deps (may take a while first time to download/compile rusqlite bundled)
+
+**Step 4: Commit**
+
+```bash
+git add Cargo.toml crates/bubbaloop/Cargo.toml Cargo.lock
+git commit -m "chore: add reqwest, rusqlite, cron dependencies for agent"
+```
+
+---
+
+## Task 2: SQLite Memory Module
+
+**Files:**
+- Create: `crates/bubbaloop/src/agent/mod.rs`
+- Create: `crates/bubbaloop/src/agent/memory.rs`
+- Modify: `crates/bubbaloop/src/lib.rs` (add `pub mod agent;`)
+
+**Step 1: Create agent module root**
+
+Create `crates/bubbaloop/src/agent/mod.rs`:
+
+```rust
+//! Agent layer — Claude API chat, SQLite memory, scheduling.
+
+pub mod memory;
+```
+
+**Step 2: Register agent module in lib.rs**
+
+In `crates/bubbaloop/src/lib.rs`, add after `pub mod skills;`:
+
+```rust
+/// Agent layer: Claude API chat, SQLite memory, scheduling
+pub mod agent;
+```
+
+**Step 3: Write memory tests first**
+
+Create `crates/bubbaloop/src/agent/memory.rs` with the test module:
+
+```rust
+//! SQLite memory layer — conversations, sensor events, schedules.
+//!
+//! Stores agent conversation history, sensor lifecycle events, and
+//! scheduled jobs in a single SQLite database at `~/.bubbaloop/memory.db`.
+
+use rusqlite::{params, Connection};
+use std::path::Path;
+
+#[derive(Debug, thiserror::Error)]
+pub enum MemoryError {
+    #[error("SQLite error: {0}")]
+    Sqlite(#[from] rusqlite::Error),
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+pub type Result<T> = std::result::Result<T, MemoryError>;
+
+/// A conversation message row.
+#[derive(Debug, Clone)]
+pub struct ConversationRow {
+    pub id: String,
+    pub timestamp: String,
+    pub role: String,
+    pub content: String,
+    pub tool_calls: Option<String>,
+}
+
+/// A sensor event row.
+#[derive(Debug, Clone)]
+pub struct SensorEvent {
+    pub id: String,
+    pub timestamp: String,
+    pub node_name: String,
+    pub event_type: String,
+    pub details: Option<String>,
+}
+
+/// A scheduled job row.
+#[derive(Debug, Clone)]
+pub struct Schedule {
+    pub id: String,
+    pub name: String,
+    pub cron: String,
+    pub actions: String,
+    pub tier: i32,
+    pub last_run: Option<String>,
+    pub next_run: Option<String>,
+    pub created_by: String,
+}
+
+/// SQLite-backed memory store.
+pub struct Memory {
+    conn: Connection,
+}
+
+impl Memory {
+    /// Open (or create) the memory database at the given path.
+    ///
+    /// Creates all tables if they don't exist. Sets file permissions to 0600.
+    pub fn open(path: &Path) -> Result<Self> {
+        // Ensure parent directory exists
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        let conn = Connection::open(path)?;
+
+        // WAL mode for better concurrent read performance
+        conn.pragma_update(None, "journal_mode", "WAL")?;
+
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS conversations (
+                id          TEXT PRIMARY KEY,
+                timestamp   TEXT NOT NULL,
+                role        TEXT NOT NULL,
+                content     TEXT NOT NULL,
+                tool_calls  TEXT
+            );
+            CREATE INDEX IF NOT EXISTS idx_conv_ts ON conversations(timestamp);
+
+            CREATE TABLE IF NOT EXISTS sensor_events (
+                id          TEXT PRIMARY KEY,
+                timestamp   TEXT NOT NULL,
+                node_name   TEXT NOT NULL,
+                event_type  TEXT NOT NULL,
+                details     TEXT
+            );
+            CREATE INDEX IF NOT EXISTS idx_events_node_ts ON sensor_events(node_name, timestamp);
+
+            CREATE TABLE IF NOT EXISTS schedules (
+                id          TEXT PRIMARY KEY,
+                name        TEXT NOT NULL UNIQUE,
+                cron        TEXT NOT NULL,
+                actions     TEXT NOT NULL,
+                tier        INTEGER NOT NULL DEFAULT 1,
+                last_run    TEXT,
+                next_run    TEXT,
+                created_by  TEXT NOT NULL
+            );",
+        )?;
+
+        // Set file permissions to 0600 (owner read/write only)
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            if path.exists() {
+                let perms = std::fs::Permissions::from_mode(0o600);
+                std::fs::set_permissions(path, perms)?;
+            }
+        }
+
+        Ok(Self { conn })
+    }
+
+    /// Log a conversation message (user, assistant, or tool).
+    pub fn log_message(
+        &self,
+        role: &str,
+        content: &str,
+        tool_calls: Option<&str>,
+    ) -> Result<()> {
+        let id = uuid::Uuid::new_v4().to_string();
+        let timestamp = now_iso8601();
+        self.conn.execute(
+            "INSERT INTO conversations (id, timestamp, role, content, tool_calls) VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![id, timestamp, role, content, tool_calls],
+        )?;
+        Ok(())
+    }
+
+    /// Log a sensor event (health change, started, stopped, etc.).
+    pub fn log_event(
+        &self,
+        node_name: &str,
+        event_type: &str,
+        details: Option<&str>,
+    ) -> Result<()> {
+        let id = uuid::Uuid::new_v4().to_string();
+        let timestamp = now_iso8601();
+        self.conn.execute(
+            "INSERT INTO sensor_events (id, timestamp, node_name, event_type, details) VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![id, timestamp, node_name, event_type, details],
+        )?;
+        Ok(())
+    }
+
+    /// Get recent conversation messages (most recent first).
+    pub fn recent_conversations(&self, limit: usize) -> Result<Vec<ConversationRow>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, timestamp, role, content, tool_calls FROM conversations ORDER BY timestamp DESC LIMIT ?1",
+        )?;
+        let rows = stmt.query_map(params![limit as i64], |row| {
+            Ok(ConversationRow {
+                id: row.get(0)?,
+                timestamp: row.get(1)?,
+                role: row.get(2)?,
+                content: row.get(3)?,
+                tool_calls: row.get(4)?,
+            })
+        })?;
+        rows.collect::<std::result::Result<Vec<_>, _>>().map_err(MemoryError::from)
+    }
+
+    /// Get recent sensor events (most recent first).
+    pub fn recent_events(&self, limit: usize) -> Result<Vec<SensorEvent>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, timestamp, node_name, event_type, details FROM sensor_events ORDER BY timestamp DESC LIMIT ?1",
+        )?;
+        let rows = stmt.query_map(params![limit as i64], |row| {
+            Ok(SensorEvent {
+                id: row.get(0)?,
+                timestamp: row.get(1)?,
+                node_name: row.get(2)?,
+                event_type: row.get(3)?,
+                details: row.get(4)?,
+            })
+        })?;
+        rows.collect::<std::result::Result<Vec<_>, _>>().map_err(MemoryError::from)
+    }
+
+    /// Get events for a specific node.
+    pub fn events_for_node(
+        &self,
+        node_name: &str,
+        limit: usize,
+    ) -> Result<Vec<SensorEvent>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, timestamp, node_name, event_type, details FROM sensor_events WHERE node_name = ?1 ORDER BY timestamp DESC LIMIT ?2",
+        )?;
+        let rows = stmt.query_map(params![node_name, limit as i64], |row| {
+            Ok(SensorEvent {
+                id: row.get(0)?,
+                timestamp: row.get(1)?,
+                node_name: row.get(2)?,
+                event_type: row.get(3)?,
+                details: row.get(4)?,
+            })
+        })?;
+        rows.collect::<std::result::Result<Vec<_>, _>>().map_err(MemoryError::from)
+    }
+
+    /// Insert or update a schedule.
+    pub fn upsert_schedule(&self, schedule: &Schedule) -> Result<()> {
+        self.conn.execute(
+            "INSERT INTO schedules (id, name, cron, actions, tier, last_run, next_run, created_by)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+             ON CONFLICT(name) DO UPDATE SET
+                cron = excluded.cron,
+                actions = excluded.actions,
+                tier = excluded.tier,
+                next_run = excluded.next_run",
+            params![
+                schedule.id,
+                schedule.name,
+                schedule.cron,
+                schedule.actions,
+                schedule.tier,
+                schedule.last_run,
+                schedule.next_run,
+                schedule.created_by,
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// List all schedules.
+    pub fn list_schedules(&self) -> Result<Vec<Schedule>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, name, cron, actions, tier, last_run, next_run, created_by FROM schedules ORDER BY name",
+        )?;
+        let rows = stmt.query_map([], |row| {
+            Ok(Schedule {
+                id: row.get(0)?,
+                name: row.get(1)?,
+                cron: row.get(2)?,
+                actions: row.get(3)?,
+                tier: row.get(4)?,
+                last_run: row.get(5)?,
+                next_run: row.get(6)?,
+                created_by: row.get(7)?,
+            })
+        })?;
+        rows.collect::<std::result::Result<Vec<_>, _>>().map_err(MemoryError::from)
+    }
+
+    /// Update last_run and next_run for a schedule.
+    pub fn update_schedule_run(
+        &self,
+        name: &str,
+        last_run: &str,
+        next_run: &str,
+    ) -> Result<()> {
+        self.conn.execute(
+            "UPDATE schedules SET last_run = ?1, next_run = ?2 WHERE name = ?3",
+            params![last_run, next_run, name],
+        )?;
+        Ok(())
+    }
+
+    /// Delete a schedule by name.
+    pub fn delete_schedule(&self, name: &str) -> Result<()> {
+        self.conn
+            .execute("DELETE FROM schedules WHERE name = ?1", params![name])?;
+        Ok(())
+    }
+}
+
+/// ISO 8601 timestamp for the current time.
+fn now_iso8601() -> String {
+    // Use std::time to avoid chrono dependency
+    let duration = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default();
+    let secs = duration.as_secs();
+    // Simple UTC format: seconds since epoch as ISO-ish string
+    // For proper ISO 8601 we'd need chrono, but this is sufficient for ordering
+    format!("{}", secs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn test_memory() -> Memory {
+        let dir = tempdir().unwrap();
+        Memory::open(&dir.path().join("test.db")).unwrap()
+    }
+
+    #[test]
+    fn open_creates_tables() {
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+        let mem = Memory::open(&db_path).unwrap();
+        // Verify tables exist by running a query on each
+        mem.recent_conversations(1).unwrap();
+        mem.recent_events(1).unwrap();
+        mem.list_schedules().unwrap();
+    }
+
+    #[test]
+    fn open_twice_is_idempotent() {
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+        Memory::open(&db_path).unwrap();
+        Memory::open(&db_path).unwrap(); // should not error
+    }
+
+    #[test]
+    fn log_and_retrieve_messages() {
+        let mem = test_memory();
+        mem.log_message("user", "hello", None).unwrap();
+        mem.log_message("assistant", "hi there", None).unwrap();
+        mem.log_message("assistant", "tool result", Some(r#"[{"name":"list_nodes"}]"#))
+            .unwrap();
+
+        let msgs = mem.recent_conversations(10).unwrap();
+        assert_eq!(msgs.len(), 3);
+        // Most recent first
+        assert_eq!(msgs[0].role, "assistant");
+        assert!(msgs[0].tool_calls.is_some());
+        assert_eq!(msgs[2].role, "user");
+    }
+
+    #[test]
+    fn log_and_retrieve_events() {
+        let mem = test_memory();
+        mem.log_event("rtsp-camera", "started", None).unwrap();
+        mem.log_event("rtsp-camera", "health_ok", Some(r#"{"uptime":120}"#))
+            .unwrap();
+        mem.log_event("system-telemetry", "started", None).unwrap();
+
+        let all = mem.recent_events(10).unwrap();
+        assert_eq!(all.len(), 3);
+
+        let cam = mem.events_for_node("rtsp-camera", 10).unwrap();
+        assert_eq!(cam.len(), 2);
+    }
+
+    #[test]
+    fn upsert_and_list_schedules() {
+        let mem = test_memory();
+        let sched = Schedule {
+            id: "s1".into(),
+            name: "health-patrol".into(),
+            cron: "*/15 * * * *".into(),
+            actions: r#"["check_all_health"]"#.into(),
+            tier: 1,
+            last_run: None,
+            next_run: Some("1709136000".into()),
+            created_by: "yaml".into(),
+        };
+        mem.upsert_schedule(&sched).unwrap();
+
+        let list = mem.list_schedules().unwrap();
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].name, "health-patrol");
+        assert_eq!(list[0].tier, 1);
+    }
+
+    #[test]
+    fn upsert_schedule_updates_existing() {
+        let mem = test_memory();
+        let sched1 = Schedule {
+            id: "s1".into(),
+            name: "patrol".into(),
+            cron: "*/15 * * * *".into(),
+            actions: r#"["check_all_health"]"#.into(),
+            tier: 1,
+            last_run: None,
+            next_run: None,
+            created_by: "yaml".into(),
+        };
+        mem.upsert_schedule(&sched1).unwrap();
+
+        // Update cron
+        let sched2 = Schedule {
+            id: "s2".into(),
+            name: "patrol".into(),
+            cron: "*/5 * * * *".into(),
+            actions: r#"["check_all_health","restart"]"#.into(),
+            tier: 1,
+            last_run: None,
+            next_run: None,
+            created_by: "yaml".into(),
+        };
+        mem.upsert_schedule(&sched2).unwrap();
+
+        let list = mem.list_schedules().unwrap();
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].cron, "*/5 * * * *");
+    }
+
+    #[test]
+    fn update_schedule_run() {
+        let mem = test_memory();
+        let sched = Schedule {
+            id: "s1".into(),
+            name: "patrol".into(),
+            cron: "*/15 * * * *".into(),
+            actions: "[]".into(),
+            tier: 1,
+            last_run: None,
+            next_run: None,
+            created_by: "yaml".into(),
+        };
+        mem.upsert_schedule(&sched).unwrap();
+        mem.update_schedule_run("patrol", "1709136000", "1709136900")
+            .unwrap();
+
+        let list = mem.list_schedules().unwrap();
+        assert_eq!(list[0].last_run.as_deref(), Some("1709136000"));
+        assert_eq!(list[0].next_run.as_deref(), Some("1709136900"));
+    }
+
+    #[test]
+    fn delete_schedule() {
+        let mem = test_memory();
+        let sched = Schedule {
+            id: "s1".into(),
+            name: "patrol".into(),
+            cron: "*/15 * * * *".into(),
+            actions: "[]".into(),
+            tier: 1,
+            last_run: None,
+            next_run: None,
+            created_by: "yaml".into(),
+        };
+        mem.upsert_schedule(&sched).unwrap();
+        mem.delete_schedule("patrol").unwrap();
+
+        let list = mem.list_schedules().unwrap();
+        assert!(list.is_empty());
+    }
+
+    #[test]
+    fn conversation_limit_works() {
+        let mem = test_memory();
+        for i in 0..10 {
+            mem.log_message("user", &format!("msg {}", i), None)
+                .unwrap();
+        }
+        let msgs = mem.recent_conversations(3).unwrap();
+        assert_eq!(msgs.len(), 3);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn file_permissions_are_0600() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("secure.db");
+        Memory::open(&db_path).unwrap();
+        let perms = std::fs::metadata(&db_path).unwrap().permissions();
+        assert_eq!(perms.mode() & 0o777, 0o600);
+    }
+}
+```
+
+**Step 4: Run tests**
+
+Run: `pixi run test`
+Expected: All existing tests pass + new memory tests pass
+
+**Step 5: Commit**
+
+```bash
+git add crates/bubbaloop/src/agent/ crates/bubbaloop/src/lib.rs
+git commit -m "feat: add SQLite memory module with conversations, events, schedules"
+```
+
+---
+
+## Task 3: Claude API Client
+
+**Files:**
+- Create: `crates/bubbaloop/src/agent/claude.rs`
+- Modify: `crates/bubbaloop/src/agent/mod.rs`
+
+**Step 1: Write Claude client tests**
+
+Create `crates/bubbaloop/src/agent/claude.rs`:
+
+```rust
+//! Claude API client — raw reqwest to the Messages API with tool_use support.
+//!
+//! Does NOT use an SDK. Sends JSON to `https://api.anthropic.com/v1/messages`
+//! and parses the response, including tool_use content blocks.
+
+use serde::{Deserialize, Serialize};
+
+const API_URL: &str = "https://api.anthropic.com/v1/messages";
+const API_VERSION: &str = "2023-06-01";
+const DEFAULT_MODEL: &str = "claude-sonnet-4-20250514";
+const MAX_TOKENS: u32 = 4096;
+
+#[derive(Debug, thiserror::Error)]
+pub enum ClaudeError {
+    #[error("HTTP error: {0}")]
+    Http(#[from] reqwest::Error),
+    #[error("API error ({status}): {message}")]
+    Api { status: u16, message: String },
+    #[error("Missing ANTHROPIC_API_KEY environment variable")]
+    MissingApiKey,
+    #[error("Unexpected response format: {0}")]
+    Format(String),
+}
+
+pub type Result<T> = std::result::Result<T, ClaudeError>;
+
+/// A content block in a Claude message.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum ContentBlock {
+    #[serde(rename = "text")]
+    Text { text: String },
+    #[serde(rename = "tool_use")]
+    ToolUse {
+        id: String,
+        name: String,
+        input: serde_json::Value,
+    },
+    #[serde(rename = "tool_result")]
+    ToolResult {
+        tool_use_id: String,
+        content: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        is_error: Option<bool>,
+    },
+}
+
+/// A message in the conversation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Message {
+    pub role: String,
+    pub content: Vec<ContentBlock>,
+}
+
+impl Message {
+    pub fn user(text: &str) -> Self {
+        Self {
+            role: "user".into(),
+            content: vec![ContentBlock::Text {
+                text: text.to_string(),
+            }],
+        }
+    }
+
+    pub fn tool_results(results: Vec<ContentBlock>) -> Self {
+        Self {
+            role: "user".into(),
+            content: results,
+        }
+    }
+
+    /// Extract all text content from the message.
+    pub fn text(&self) -> String {
+        self.content
+            .iter()
+            .filter_map(|b| match b {
+                ContentBlock::Text { text } => Some(text.as_str()),
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("")
+    }
+
+    /// Extract all tool_use blocks from the message.
+    pub fn tool_uses(&self) -> Vec<(&str, &str, &serde_json::Value)> {
+        self.content
+            .iter()
+            .filter_map(|b| match b {
+                ContentBlock::ToolUse { id, name, input } => {
+                    Some((id.as_str(), name.as_str(), input))
+                }
+                _ => None,
+            })
+            .collect()
+    }
+}
+
+/// A tool definition for the Claude API.
+#[derive(Debug, Clone, Serialize)]
+pub struct ToolDefinition {
+    pub name: String,
+    pub description: String,
+    pub input_schema: serde_json::Value,
+}
+
+/// Claude API request body.
+#[derive(Debug, Serialize)]
+struct ApiRequest {
+    model: String,
+    max_tokens: u32,
+    system: String,
+    messages: Vec<Message>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    tools: Vec<ToolDefinition>,
+}
+
+/// Claude API response body.
+#[derive(Debug, Deserialize)]
+pub struct ApiResponse {
+    pub id: String,
+    pub content: Vec<ContentBlock>,
+    pub stop_reason: Option<String>,
+    pub usage: Usage,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Usage {
+    pub input_tokens: u32,
+    pub output_tokens: u32,
+}
+
+/// Claude API client.
+pub struct ClaudeClient {
+    client: reqwest::Client,
+    api_key: String,
+    model: String,
+}
+
+impl ClaudeClient {
+    /// Create a new client. Reads `ANTHROPIC_API_KEY` from environment.
+    pub fn from_env(model: Option<&str>) -> Result<Self> {
+        let api_key =
+            std::env::var("ANTHROPIC_API_KEY").map_err(|_| ClaudeError::MissingApiKey)?;
+        Ok(Self {
+            client: reqwest::Client::new(),
+            api_key,
+            model: model.unwrap_or(DEFAULT_MODEL).to_string(),
+        })
+    }
+
+    /// Send a messages request to Claude.
+    pub async fn send(
+        &self,
+        system: &str,
+        messages: &[Message],
+        tools: &[ToolDefinition],
+    ) -> Result<ApiResponse> {
+        let body = ApiRequest {
+            model: self.model.clone(),
+            max_tokens: MAX_TOKENS,
+            system: system.to_string(),
+            messages: messages.to_vec(),
+            tools: tools.to_vec(),
+        };
+
+        let resp = self
+            .client
+            .post(API_URL)
+            .header("x-api-key", &self.api_key)
+            .header("anthropic-version", API_VERSION)
+            .header("content-type", "application/json")
+            .json(&body)
+            .send()
+            .await?;
+
+        let status = resp.status().as_u16();
+        if status != 200 {
+            let text = resp.text().await.unwrap_or_default();
+            return Err(ClaudeError::Api {
+                status,
+                message: text,
+            });
+        }
+
+        let response: ApiResponse = resp.json().await?;
+        Ok(response)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn message_user_constructor() {
+        let msg = Message::user("hello");
+        assert_eq!(msg.role, "user");
+        assert_eq!(msg.text(), "hello");
+    }
+
+    #[test]
+    fn message_text_concatenation() {
+        let msg = Message {
+            role: "assistant".into(),
+            content: vec![
+                ContentBlock::Text {
+                    text: "Hello ".into(),
+                },
+                ContentBlock::Text {
+                    text: "world".into(),
+                },
+            ],
+        };
+        assert_eq!(msg.text(), "Hello world");
+    }
+
+    #[test]
+    fn message_tool_uses_extraction() {
+        let msg = Message {
+            role: "assistant".into(),
+            content: vec![
+                ContentBlock::Text {
+                    text: "Let me check".into(),
+                },
+                ContentBlock::ToolUse {
+                    id: "tu_1".into(),
+                    name: "list_nodes".into(),
+                    input: serde_json::json!({}),
+                },
+                ContentBlock::ToolUse {
+                    id: "tu_2".into(),
+                    name: "start_node".into(),
+                    input: serde_json::json!({"node_name": "cam1"}),
+                },
+            ],
+        };
+        let uses = msg.tool_uses();
+        assert_eq!(uses.len(), 2);
+        assert_eq!(uses[0].1, "list_nodes");
+        assert_eq!(uses[1].1, "start_node");
+    }
+
+    #[test]
+    fn tool_result_message() {
+        let msg = Message::tool_results(vec![ContentBlock::ToolResult {
+            tool_use_id: "tu_1".into(),
+            content: "2 nodes running".into(),
+            is_error: None,
+        }]);
+        assert_eq!(msg.role, "user");
+        assert_eq!(msg.content.len(), 1);
+    }
+
+    #[test]
+    fn content_block_serde_text() {
+        let block = ContentBlock::Text {
+            text: "hello".into(),
+        };
+        let json = serde_json::to_string(&block).unwrap();
+        assert!(json.contains(r#""type":"text""#));
+        let parsed: ContentBlock = serde_json::from_str(&json).unwrap();
+        match parsed {
+            ContentBlock::Text { text } => assert_eq!(text, "hello"),
+            _ => panic!("expected Text"),
+        }
+    }
+
+    #[test]
+    fn content_block_serde_tool_use() {
+        let json = r#"{"type":"tool_use","id":"tu_1","name":"list_nodes","input":{}}"#;
+        let block: ContentBlock = serde_json::from_str(json).unwrap();
+        match block {
+            ContentBlock::ToolUse { id, name, input } => {
+                assert_eq!(id, "tu_1");
+                assert_eq!(name, "list_nodes");
+                assert!(input.is_object());
+            }
+            _ => panic!("expected ToolUse"),
+        }
+    }
+
+    #[test]
+    fn content_block_serde_tool_result() {
+        let block = ContentBlock::ToolResult {
+            tool_use_id: "tu_1".into(),
+            content: "result".into(),
+            is_error: Some(true),
+        };
+        let json = serde_json::to_string(&block).unwrap();
+        assert!(json.contains("tool_result"));
+        assert!(json.contains("is_error"));
+    }
+
+    #[test]
+    fn api_response_deserialization() {
+        let json = r#"{
+            "id": "msg_123",
+            "content": [{"type": "text", "text": "Hello!"}],
+            "stop_reason": "end_turn",
+            "usage": {"input_tokens": 10, "output_tokens": 5}
+        }"#;
+        let resp: ApiResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.id, "msg_123");
+        assert_eq!(resp.content.len(), 1);
+        assert_eq!(resp.usage.input_tokens, 10);
+    }
+
+    #[test]
+    fn api_response_with_tool_use() {
+        let json = r#"{
+            "id": "msg_456",
+            "content": [
+                {"type": "text", "text": "Let me check."},
+                {"type": "tool_use", "id": "tu_1", "name": "list_nodes", "input": {}}
+            ],
+            "stop_reason": "tool_use",
+            "usage": {"input_tokens": 50, "output_tokens": 30}
+        }"#;
+        let resp: ApiResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.stop_reason.as_deref(), Some("tool_use"));
+        assert_eq!(resp.content.len(), 2);
+    }
+
+    #[test]
+    fn client_from_env_missing_key() {
+        // Temporarily remove the key if set
+        let original = std::env::var("ANTHROPIC_API_KEY").ok();
+        std::env::remove_var("ANTHROPIC_API_KEY");
+        let result = ClaudeClient::from_env(None);
+        assert!(matches!(result, Err(ClaudeError::MissingApiKey)));
+        // Restore
+        if let Some(key) = original {
+            std::env::set_var("ANTHROPIC_API_KEY", key);
+        }
+    }
+
+    #[test]
+    fn tool_definition_serialization() {
+        let tool = ToolDefinition {
+            name: "list_nodes".into(),
+            description: "List all registered nodes".into(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {},
+                "required": []
+            }),
+        };
+        let json = serde_json::to_string(&tool).unwrap();
+        assert!(json.contains("list_nodes"));
+        assert!(json.contains("input_schema"));
+    }
+}
+```
+
+**Step 2: Add module to agent/mod.rs**
+
+Update `crates/bubbaloop/src/agent/mod.rs`:
+
+```rust
+//! Agent layer — Claude API chat, SQLite memory, scheduling.
+
+pub mod claude;
+pub mod memory;
+```
+
+**Step 3: Run tests**
+
+Run: `pixi run test`
+Expected: All tests pass
+
+**Step 4: Commit**
+
+```bash
+git add crates/bubbaloop/src/agent/claude.rs crates/bubbaloop/src/agent/mod.rs
+git commit -m "feat: add Claude API client with tool_use support"
+```
+
+---
+
+## Task 4: Internal MCP Tool Dispatch
+
+**Files:**
+- Create: `crates/bubbaloop/src/agent/dispatch.rs`
+- Modify: `crates/bubbaloop/src/agent/mod.rs`
+
+**Step 1: Write dispatch module**
+
+Create `crates/bubbaloop/src/agent/dispatch.rs`:
+
+```rust
+//! Internal MCP tool dispatch — calls MCP tools without HTTP round-trip.
+//!
+//! Creates a `BubbaLoopMcpServer<DaemonPlatform>` and invokes `call_tool()`
+//! directly. Generates Claude-compatible tool definitions from the MCP tool
+//! router's schema metadata.
+
+use std::sync::Arc;
+
+use crate::agent::claude::{ContentBlock, ToolDefinition};
+use crate::mcp::platform::{DaemonPlatform, NodeInfo, PlatformOperations};
+use crate::mcp::BubbaLoopMcpServer;
+
+#[derive(Debug, thiserror::Error)]
+pub enum DispatchError {
+    #[error("Tool call failed: {0}")]
+    ToolError(String),
+    #[error("MCP error: {0}")]
+    Mcp(String),
+}
+
+pub type Result<T> = std::result::Result<T, DispatchError>;
+
+/// Internal tool dispatcher — calls MCP tools in-process.
+pub struct Dispatcher {
+    server: BubbaLoopMcpServer<DaemonPlatform>,
+}
+
+impl Dispatcher {
+    /// Create a dispatcher backed by a real daemon platform.
+    pub fn new(
+        node_manager: Arc<crate::daemon::node_manager::NodeManager>,
+        session: Arc<zenoh::Session>,
+    ) -> Self {
+        let scope =
+            std::env::var("BUBBALOOP_SCOPE").unwrap_or_else(|_| "local".to_string());
+        let machine_id = crate::daemon::util::get_machine_id();
+
+        let platform = Arc::new(DaemonPlatform {
+            node_manager,
+            session,
+            scope: scope.clone(),
+            machine_id: machine_id.clone(),
+        });
+
+        let server = BubbaLoopMcpServer::new(platform, None, scope, machine_id);
+        Self { server }
+    }
+
+    /// Generate Claude-compatible tool definitions from the MCP tool router.
+    ///
+    /// This reads the tool schemas registered via `#[tool(...)]` macros and
+    /// converts them to the format Claude expects in the `tools` array.
+    pub fn tool_definitions(&self) -> Vec<ToolDefinition> {
+        let tools = self.server.list_tool_definitions();
+        tools
+            .into_iter()
+            .map(|t| ToolDefinition {
+                name: t.name.to_string(),
+                description: t.description.unwrap_or_default().to_string(),
+                input_schema: t.input_schema,
+            })
+            .collect()
+    }
+
+    /// Dispatch a single tool call and return the result as a ContentBlock.
+    ///
+    /// Takes the tool name and JSON input from Claude's `tool_use` block,
+    /// calls the MCP tool internally, and returns a `ToolResult` block.
+    pub async fn call_tool(
+        &self,
+        tool_use_id: &str,
+        name: &str,
+        input: &serde_json::Value,
+    ) -> ContentBlock {
+        let params = rmcp::model::CallToolRequestParams {
+            name: name.into(),
+            arguments: Some(
+                input
+                    .as_object()
+                    .cloned()
+                    .unwrap_or_default()
+                    .into_iter()
+                    .collect(),
+            ),
+            meta: None,
+        };
+
+        // Create a minimal request context for the tool router
+        let context = rmcp::service::RequestContext::default();
+
+        match self.server.call_tool(params, context).await {
+            Ok(result) => {
+                let text = result
+                    .content
+                    .iter()
+                    .filter_map(|c| match c {
+                        rmcp::model::Content::Text(t) => Some(t.text.as_str()),
+                        _ => None,
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n");
+
+                ContentBlock::ToolResult {
+                    tool_use_id: tool_use_id.to_string(),
+                    content: text,
+                    is_error: if result.is_error.unwrap_or(false) {
+                        Some(true)
+                    } else {
+                        None
+                    },
+                }
+            }
+            Err(e) => ContentBlock::ToolResult {
+                tool_use_id: tool_use_id.to_string(),
+                content: format!("Error: {}", e.message),
+                is_error: Some(true),
+            },
+        }
+    }
+
+    /// Get current node inventory for system prompt.
+    pub async fn get_node_inventory(&self) -> String {
+        // Call list_nodes via platform directly for efficiency
+        let input = serde_json::json!({});
+        let result = self.call_tool("_inventory", "list_nodes", &input).await;
+        match result {
+            ContentBlock::ToolResult { content, .. } => content,
+            _ => "No sensors found.".to_string(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tool_definition_has_required_fields() {
+        let def = ToolDefinition {
+            name: "list_nodes".into(),
+            description: "List all nodes".into(),
+            input_schema: serde_json::json!({"type": "object", "properties": {}}),
+        };
+        let json = serde_json::to_value(&def).unwrap();
+        assert!(json.get("name").is_some());
+        assert!(json.get("description").is_some());
+        assert!(json.get("input_schema").is_some());
+    }
+}
+```
+
+**Note:** The `Dispatcher` depends on `BubbaLoopMcpServer` having a public `list_tool_definitions()` method and `ServerHandler::call_tool()`. We need to expose these. Add a helper method to the MCP server.
+
+**Step 2: Expose tool listing on BubbaLoopMcpServer**
+
+In `crates/bubbaloop/src/mcp/mod.rs`, add this method to the `impl<P: PlatformOperations> BubbaLoopMcpServer<P>` block (near `fn new()`):
+
+```rust
+    /// Get all tool definitions for external use (e.g., Claude API tool schemas).
+    pub fn list_tool_definitions(&self) -> Vec<rmcp::model::Tool> {
+        self.tool_router.list_all()
+    }
+```
+
+**Step 3: Add module to agent/mod.rs**
+
+```rust
+//! Agent layer — Claude API chat, SQLite memory, scheduling.
+
+pub mod claude;
+pub mod dispatch;
+pub mod memory;
+```
+
+**Step 4: Run check (may need adjustments for rmcp types)**
+
+Run: `pixi run check`
+
+The `rmcp::service::RequestContext::default()` and `ServerHandler::call_tool()` signatures may need adjustment based on the actual rmcp API. If `RequestContext` doesn't implement `Default`, create it differently — check `rmcp` docs. The key pattern is: we're calling the same `call_tool` that the HTTP/stdio transports call.
+
+If `call_tool` requires a real context that can't be easily mocked, an alternative approach is to call the platform methods directly (bypassing the MCP server layer):
+
+```rust
+// Fallback: call platform directly instead of through MCP server
+pub async fn call_tool_direct(
+    &self,
+    name: &str,
+    input: &serde_json::Value,
+) -> Result<String> {
+    match name {
+        "list_nodes" => {
+            let nodes = self.platform.list_nodes().await
+                .map_err(|e| DispatchError::ToolError(e.to_string()))?;
+            Ok(serde_json::to_string_pretty(&nodes)
+                .unwrap_or_else(|_| "[]".to_string()))
+        }
+        "start_node" => {
+            let node_name = input["node_name"].as_str()
+                .ok_or_else(|| DispatchError::ToolError("missing node_name".into()))?;
+            self.platform.execute_command(node_name, NodeCommand::Start).await
+                .map_err(|e| DispatchError::ToolError(e.to_string()))
+        }
+        // ... map all 24 tools
+        _ => Err(DispatchError::ToolError(format!("unknown tool: {}", name))),
+    }
+}
+```
+
+Choose whichever approach compiles. The tool_router approach is cleaner but depends on rmcp internals.
+
+**Step 5: Run tests**
+
+Run: `pixi run test`
+Expected: All tests pass
+
+**Step 6: Commit**
+
+```bash
+git add crates/bubbaloop/src/agent/dispatch.rs crates/bubbaloop/src/agent/mod.rs crates/bubbaloop/src/mcp/mod.rs
+git commit -m "feat: add internal MCP tool dispatch for agent"
+```
+
+---
+
+## Task 5: Agent Orchestrator and CLI Command
+
+**Files:**
+- Create: `crates/bubbaloop/src/agent/prompt.rs`
+- Modify: `crates/bubbaloop/src/agent/mod.rs`
+- Create: `crates/bubbaloop/src/cli/agent.rs`
+- Modify: `crates/bubbaloop/src/cli/mod.rs`
+- Modify: `crates/bubbaloop/src/bin/bubbaloop.rs`
+
+**Step 1: Create system prompt builder**
+
+Create `crates/bubbaloop/src/agent/prompt.rs`:
+
+```rust
+//! System prompt builder — injects live sensor inventory and schedules.
+
+use crate::agent::memory::{Memory, Schedule, SensorEvent};
+
+/// Build the system prompt with live sensor data.
+pub fn build_system_prompt(
+    node_inventory: &str,
+    schedules: &[Schedule],
+    recent_events: &[SensorEvent],
+) -> String {
+    let mut prompt = String::from(
+        "You are Bubbaloop, an AI agent that controls physical sensors and hardware. \
+         You have MCP tools to discover, install, start, stop, and monitor sensor nodes.\n\n\
+         Be concise. When a user asks to do something, use the appropriate tool. \
+         When creating scheduled jobs, prefer Tier 1 (offline, no LLM) for simple \
+         health checks and restarts. Use Tier 2 (LLM-powered) only for tasks that \
+         need reasoning.\n",
+    );
+
+    // Sensor inventory
+    prompt.push_str("\n## Current Sensors\n\n");
+    if node_inventory.is_empty() || node_inventory == "[]" {
+        prompt.push_str("No sensors installed yet. Use install_node to add sensors.\n");
+    } else {
+        prompt.push_str(node_inventory);
+        prompt.push('\n');
+    }
+
+    // Schedules
+    if !schedules.is_empty() {
+        prompt.push_str("\n## Active Schedules\n\n");
+        for s in schedules {
+            prompt.push_str(&format!(
+                "- {} (Tier {}, cron: {})\n",
+                s.name, s.tier, s.cron
+            ));
+        }
+    }
+
+    // Recent events
+    if !recent_events.is_empty() {
+        prompt.push_str("\n## Recent Events\n\n");
+        for e in recent_events.iter().take(10) {
+            prompt.push_str(&format!(
+                "- [{}] {} {}\n",
+                e.timestamp, e.node_name, e.event_type
+            ));
+        }
+    }
+
+    prompt
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prompt_with_empty_inventory() {
+        let prompt = build_system_prompt("", &[], &[]);
+        assert!(prompt.contains("No sensors installed"));
+        assert!(prompt.contains("Bubbaloop"));
+    }
+
+    #[test]
+    fn prompt_with_nodes() {
+        let prompt = build_system_prompt(
+            "rtsp-camera: Running, Healthy\nsystem-telemetry: Running, Healthy",
+            &[],
+            &[],
+        );
+        assert!(prompt.contains("rtsp-camera"));
+        assert!(prompt.contains("system-telemetry"));
+    }
+
+    #[test]
+    fn prompt_with_schedules() {
+        let schedules = vec![Schedule {
+            id: "s1".into(),
+            name: "health-patrol".into(),
+            cron: "*/15 * * * *".into(),
+            actions: "[]".into(),
+            tier: 1,
+            last_run: None,
+            next_run: None,
+            created_by: "yaml".into(),
+        }];
+        let prompt = build_system_prompt("", &schedules, &[]);
+        assert!(prompt.contains("health-patrol"));
+        assert!(prompt.contains("Tier 1"));
+    }
+
+    #[test]
+    fn prompt_with_events() {
+        let events = vec![SensorEvent {
+            id: "e1".into(),
+            timestamp: "1709136000".into(),
+            node_name: "cam1".into(),
+            event_type: "health_ok".into(),
+            details: None,
+        }];
+        let prompt = build_system_prompt("", &[], &events);
+        assert!(prompt.contains("cam1"));
+        assert!(prompt.contains("health_ok"));
+    }
+}
+```
+
+**Step 2: Create the run_agent orchestrator**
+
+Update `crates/bubbaloop/src/agent/mod.rs`:
+
+```rust
+//! Agent layer — Claude API chat, SQLite memory, scheduling.
+
+pub mod claude;
+pub mod dispatch;
+pub mod memory;
+pub mod prompt;
+
+use std::io::{self, BufRead, Write};
+use std::sync::Arc;
+
+use claude::{ClaudeClient, ContentBlock, Message};
+use dispatch::Dispatcher;
+use memory::Memory;
+
+/// Configuration for the agent.
+pub struct AgentConfig {
+    pub model: Option<String>,
+}
+
+/// Run the interactive agent loop.
+///
+/// Connects to Claude API, dispatches MCP tools internally, persists
+/// conversations and events to SQLite.
+pub async fn run_agent(
+    config: AgentConfig,
+    session: Arc<zenoh::Session>,
+    node_manager: Arc<crate::daemon::node_manager::NodeManager>,
+) -> anyhow::Result<()> {
+    // Initialize components
+    let client = ClaudeClient::from_env(config.model.as_deref())?;
+    let dispatcher = Dispatcher::new(node_manager, session);
+    let tools = dispatcher.tool_definitions();
+
+    let db_path = crate::daemon::registry::get_bubbaloop_home().join("memory.db");
+    let mem = Memory::open(&db_path)?;
+
+    let mut messages: Vec<Message> = Vec::new();
+
+    println!("Bubbaloop Agent (type 'quit' to exit)");
+    println!("Connected to Claude. {} MCP tools available.\n", tools.len());
+
+    let stdin = io::stdin();
+    let mut stdout = io::stdout();
+
+    loop {
+        // Prompt
+        print!("> ");
+        stdout.flush()?;
+
+        // Read user input
+        let mut input = String::new();
+        if stdin.lock().read_line(&mut input)? == 0 {
+            break; // EOF
+        }
+        let input = input.trim();
+        if input.is_empty() {
+            continue;
+        }
+        if input == "quit" || input == "exit" {
+            break;
+        }
+
+        // Log user message
+        mem.log_message("user", input, None).ok();
+        messages.push(Message::user(input));
+
+        // Build system prompt with live data
+        let inventory = dispatcher.get_node_inventory().await;
+        let schedules = mem.list_schedules().unwrap_or_default();
+        let events = mem.recent_events(10).unwrap_or_default();
+        let system = prompt::build_system_prompt(&inventory, &schedules, &events);
+
+        // Conversation loop (handles multi-step tool use)
+        loop {
+            let response = client.send(&system, &messages, &tools).await?;
+
+            // Check for tool use
+            let assistant_msg = Message {
+                role: "assistant".into(),
+                content: response.content,
+            };
+
+            let tool_calls = assistant_msg.tool_uses();
+            let has_tools = !tool_calls.is_empty();
+
+            // Print text portions
+            let text = assistant_msg.text();
+            if !text.is_empty() {
+                println!("\n{}\n", text);
+            }
+
+            messages.push(assistant_msg.clone());
+
+            if has_tools {
+                // Dispatch each tool call
+                let mut results = Vec::new();
+                for (id, name, input) in &tool_calls {
+                    log::info!("[agent] tool call: {} ({})", name, id);
+                    let result = dispatcher.call_tool(id, name, input).await;
+                    results.push(result);
+                }
+
+                // Log tool calls
+                let tool_json = serde_json::to_string(&tool_calls).ok();
+                mem.log_message("assistant", &text, tool_json.as_deref()).ok();
+
+                messages.push(Message::tool_results(results));
+            } else {
+                // Final response — log and break inner loop
+                mem.log_message("assistant", &text, None).ok();
+                break;
+            }
+
+            // If stop_reason is not "tool_use", break
+            if response.stop_reason.as_deref() != Some("tool_use") {
+                break;
+            }
+        }
+    }
+
+    println!("Goodbye.");
+    Ok(())
+}
+```
+
+**Step 3: Create CLI command**
+
+Create `crates/bubbaloop/src/cli/agent.rs`:
+
+```rust
+//! `bubbaloop agent` — interactive AI chat for hardware control.
+
+use argh::FromArgs;
+
+/// Start the interactive AI agent for hardware control
+#[derive(FromArgs, PartialEq, Debug)]
+#[argh(subcommand, name = "agent")]
+pub struct AgentCommand {
+    /// Claude model to use (default: claude-sonnet-4-20250514)
+    #[argh(option, short = 'm')]
+    pub model: Option<String>,
+
+    /// zenoh endpoint to connect to (default: auto-discover)
+    #[argh(option, short = 'z')]
+    pub zenoh_endpoint: Option<String>,
+}
+```
+
+**Step 4: Wire into CLI**
+
+In `crates/bubbaloop/src/cli/mod.rs`, add:
+
+```rust
+pub mod agent;
+```
+
+And add re-export:
+
+```rust
+pub use agent::AgentCommand;
+```
+
+**Step 5: Wire into binary**
+
+In `crates/bubbaloop/src/bin/bubbaloop.rs`:
+
+1. Add import:
+```rust
+use bubbaloop::cli::{DebugCommand, MarketplaceCommand, NodeCommand, UpCommand, AgentCommand};
+```
+
+2. Add variant to `Command` enum:
+```rust
+    Agent(AgentCommand),
+```
+
+3. Add help text in the `None` arm:
+```rust
+            eprintln!("  agent     Chat with your hardware via Claude AI:");
+            eprintln!("              -m, --model <model>: Claude model");
+            eprintln!("              -z, --zenoh-endpoint <endpoint>: Zenoh endpoint");
+```
+
+4. Add dispatch arm (after the `Up` arm):
+```rust
+        Some(Command::Agent(cmd)) => {
+            // Re-initialize logging for agent (info level)
+            drop(
+                env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
+                    .try_init(),
+            );
+
+            // Connect to Zenoh
+            log::info!("Connecting to Zenoh...");
+            let session = bubbaloop::daemon::create_session(cmd.zenoh_endpoint.as_deref())
+                .await
+                .map_err(|e| e as Box<dyn std::error::Error>)?;
+
+            // Create node manager
+            log::info!("Initializing node manager...");
+            let node_manager = bubbaloop::daemon::NodeManager::new().await?;
+
+            // Run agent
+            bubbaloop::agent::run_agent(
+                bubbaloop::agent::AgentConfig {
+                    model: cmd.model,
+                },
+                session,
+                node_manager,
+            )
+            .await?;
+        }
+```
+
+**Step 6: Run check**
+
+Run: `pixi run check`
+Expected: Compiles (may need minor adjustments to type imports)
+
+**Step 7: Run tests**
+
+Run: `pixi run test`
+Expected: All tests pass
+
+**Step 8: Commit**
+
+```bash
+git add crates/bubbaloop/src/agent/ crates/bubbaloop/src/cli/agent.rs crates/bubbaloop/src/cli/mod.rs crates/bubbaloop/src/bin/bubbaloop.rs
+git commit -m "feat: add bubbaloop agent command with Claude chat loop"
+```
+
+---
+
+## Task 6: Scheduler
+
+**Files:**
+- Create: `crates/bubbaloop/src/agent/scheduler.rs`
+- Modify: `crates/bubbaloop/src/agent/mod.rs`
+
+**Step 1: Write scheduler with Tier 1 built-in actions**
+
+Create `crates/bubbaloop/src/agent/scheduler.rs`:
+
+```rust
+//! Cron scheduler — Tier 1 (offline, no LLM) + Tier 2 (LLM-driven).
+//!
+//! Runs as a background tokio task. Every 60 seconds, checks the `schedules`
+//! table for jobs whose `next_run` has passed, executes them, and updates
+//! `last_run` / `next_run`.
+
+use std::sync::Arc;
+
+use crate::agent::memory::{Memory, Schedule};
+use crate::mcp::platform::{NodeCommand, PlatformOperations};
+
+#[derive(Debug, thiserror::Error)]
+pub enum SchedulerError {
+    #[error("Memory error: {0}")]
+    Memory(#[from] crate::agent::memory::MemoryError),
+    #[error("Cron parse error: {0}")]
+    CronParse(String),
+    #[error("Action error: {0}")]
+    Action(String),
+}
+
+pub type Result<T> = std::result::Result<T, SchedulerError>;
+
+/// Built-in Tier 1 actions (closed set, no arbitrary code execution).
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(tag = "action")]
+pub enum Tier1Action {
+    #[serde(rename = "check_all_health")]
+    CheckAllHealth,
+    #[serde(rename = "restart")]
+    Restart,
+    #[serde(rename = "start_node")]
+    StartNode { node: String },
+    #[serde(rename = "stop_node")]
+    StopNode { node: String },
+    #[serde(rename = "send_command")]
+    SendCommand {
+        node: String,
+        command: String,
+        #[serde(default)]
+        params: serde_json::Value,
+    },
+    #[serde(rename = "capture_frame")]
+    CaptureFrame {
+        node: String,
+        #[serde(default)]
+        params: serde_json::Value,
+    },
+    #[serde(rename = "log_event")]
+    LogEvent { message: String },
+    #[serde(rename = "notify")]
+    Notify { message: String },
+}
+
+/// Parse a cron expression and compute the next run time from now.
+pub fn next_run_after(cron_expr: &str, after_epoch_secs: u64) -> Result<u64> {
+    use cron::Schedule as CronSchedule;
+    use std::str::FromStr;
+
+    let schedule = CronSchedule::from_str(cron_expr)
+        .map_err(|e| SchedulerError::CronParse(format!("{}: {}", cron_expr, e)))?;
+
+    let after = chrono_from_epoch(after_epoch_secs);
+    let next = schedule
+        .after(&after)
+        .next()
+        .ok_or_else(|| SchedulerError::CronParse("no next occurrence".into()))?;
+
+    Ok(next.timestamp() as u64)
+}
+
+/// Convert epoch seconds to a chrono DateTime for cron evaluation.
+fn chrono_from_epoch(secs: u64) -> chrono::DateTime<chrono::Utc> {
+    chrono::DateTime::from_timestamp(secs as i64, 0).unwrap_or_default()
+}
+
+/// Get the current epoch seconds.
+fn now_epoch() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+/// Execute a single Tier 1 action against the platform.
+pub async fn execute_tier1_action<P: PlatformOperations>(
+    action: &Tier1Action,
+    platform: &P,
+    memory: &Memory,
+) -> Result<()> {
+    match action {
+        Tier1Action::CheckAllHealth => {
+            let nodes = platform
+                .list_nodes()
+                .await
+                .map_err(|e| SchedulerError::Action(e.to_string()))?;
+            for node in &nodes {
+                log::info!("[scheduler] health: {} = {}", node.name, node.health);
+            }
+            Ok(())
+        }
+        Tier1Action::Restart => {
+            // Restart unhealthy nodes
+            let nodes = platform
+                .list_nodes()
+                .await
+                .map_err(|e| SchedulerError::Action(e.to_string()))?;
+            for node in &nodes {
+                if node.health != "Healthy" && node.status == "Running" {
+                    log::info!("[scheduler] restarting unhealthy node: {}", node.name);
+                    platform
+                        .execute_command(&node.name, NodeCommand::Restart)
+                        .await
+                        .map_err(|e| SchedulerError::Action(e.to_string()))?;
+                    memory
+                        .log_event(&node.name, "scheduled_restart", None)
+                        .ok();
+                }
+            }
+            Ok(())
+        }
+        Tier1Action::StartNode { node } => {
+            platform
+                .execute_command(node, NodeCommand::Start)
+                .await
+                .map_err(|e| SchedulerError::Action(e.to_string()))?;
+            Ok(())
+        }
+        Tier1Action::StopNode { node } => {
+            platform
+                .execute_command(node, NodeCommand::Stop)
+                .await
+                .map_err(|e| SchedulerError::Action(e.to_string()))?;
+            Ok(())
+        }
+        Tier1Action::SendCommand {
+            node,
+            command,
+            params,
+        } => {
+            let payload = serde_json::json!({
+                "command": command,
+                "params": params,
+            });
+            let key = format!(
+                "bubbaloop/*/*/{}/command",
+                node
+            );
+            platform
+                .send_zenoh_query(&key, serde_json::to_vec(&payload).unwrap_or_default())
+                .await
+                .map_err(|e| SchedulerError::Action(e.to_string()))?;
+            Ok(())
+        }
+        Tier1Action::CaptureFrame { node, params } => {
+            let payload = serde_json::json!({
+                "command": "capture_frame",
+                "params": params,
+            });
+            let key = format!(
+                "bubbaloop/*/*/{}/command",
+                node
+            );
+            platform
+                .send_zenoh_query(&key, serde_json::to_vec(&payload).unwrap_or_default())
+                .await
+                .map_err(|e| SchedulerError::Action(e.to_string()))?;
+            Ok(())
+        }
+        Tier1Action::LogEvent { message } => {
+            memory
+                .log_event("scheduler", "log_event", Some(message))
+                .map_err(|e| SchedulerError::Action(e.to_string()))?;
+            Ok(())
+        }
+        Tier1Action::Notify { message } => {
+            println!("[bubbaloop] {}", message);
+            Ok(())
+        }
+    }
+}
+
+/// Run the scheduler loop. Checks every 60 seconds for due jobs.
+pub async fn run_scheduler<P: PlatformOperations>(
+    memory: Arc<Memory>,
+    platform: Arc<P>,
+    mut shutdown: tokio::sync::watch::Receiver<()>,
+) {
+    log::info!("[scheduler] started");
+
+    loop {
+        tokio::select! {
+            _ = shutdown.changed() => {
+                log::info!("[scheduler] shutting down");
+                break;
+            }
+            _ = tokio::time::sleep(std::time::Duration::from_secs(60)) => {
+                if let Err(e) = tick(&memory, &*platform).await {
+                    log::warn!("[scheduler] tick error: {}", e);
+                }
+            }
+        }
+    }
+}
+
+/// Single scheduler tick — check and execute due jobs.
+async fn tick<P: PlatformOperations>(memory: &Memory, platform: &P) -> Result<()> {
+    let schedules = memory.list_schedules()?;
+    let now = now_epoch();
+
+    for schedule in &schedules {
+        // Only process Tier 1 schedules in the background loop
+        if schedule.tier != 1 {
+            continue;
+        }
+
+        // Check if due
+        let next_run = schedule
+            .next_run
+            .as_deref()
+            .and_then(|s| s.parse::<u64>().ok())
+            .unwrap_or(0);
+
+        if next_run > now {
+            continue; // Not due yet
+        }
+
+        log::info!("[scheduler] executing: {}", schedule.name);
+
+        // Parse actions JSON
+        let actions: Vec<Tier1Action> = match serde_json::from_str(&schedule.actions) {
+            Ok(a) => a,
+            Err(e) => {
+                log::warn!(
+                    "[scheduler] failed to parse actions for '{}': {}",
+                    schedule.name,
+                    e
+                );
+                continue;
+            }
+        };
+
+        // Execute each action
+        for action in &actions {
+            if let Err(e) = execute_tier1_action(action, platform, memory).await {
+                log::warn!(
+                    "[scheduler] action error in '{}': {}",
+                    schedule.name,
+                    e
+                );
+            }
+        }
+
+        // Compute next run and update
+        let last_run = format!("{}", now);
+        match next_run_after(&schedule.cron, now) {
+            Ok(next) => {
+                let next_str = format!("{}", next);
+                memory
+                    .update_schedule_run(&schedule.name, &last_run, &next_str)
+                    .ok();
+            }
+            Err(e) => {
+                log::warn!(
+                    "[scheduler] failed to compute next run for '{}': {}",
+                    schedule.name,
+                    e
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_tier1_actions() {
+        let json = r#"[
+            {"action": "check_all_health"},
+            {"action": "restart"},
+            {"action": "log_event", "message": "health check done"}
+        ]"#;
+        let actions: Vec<Tier1Action> = serde_json::from_str(json).unwrap();
+        assert_eq!(actions.len(), 3);
+    }
+
+    #[test]
+    fn parse_start_node_action() {
+        let json = r#"{"action": "start_node", "node": "rtsp-camera"}"#;
+        let action: Tier1Action = serde_json::from_str(json).unwrap();
+        match action {
+            Tier1Action::StartNode { node } => assert_eq!(node, "rtsp-camera"),
+            _ => panic!("expected StartNode"),
+        }
+    }
+
+    #[test]
+    fn parse_send_command_action() {
+        let json =
+            r#"{"action": "send_command", "node": "cam1", "command": "capture_frame", "params": {"resolution": "1080p"}}"#;
+        let action: Tier1Action = serde_json::from_str(json).unwrap();
+        match action {
+            Tier1Action::SendCommand {
+                node,
+                command,
+                params,
+            } => {
+                assert_eq!(node, "cam1");
+                assert_eq!(command, "capture_frame");
+                assert!(params.get("resolution").is_some());
+            }
+            _ => panic!("expected SendCommand"),
+        }
+    }
+
+    #[test]
+    fn parse_unknown_action_fails() {
+        let json = r#"{"action": "drop_database"}"#;
+        let result: std::result::Result<Tier1Action, _> = serde_json::from_str(json);
+        assert!(result.is_err());
+    }
+}
+```
+
+**Note:** The `cron` crate may pull in `chrono` as a transitive dependency. If so, that's fine — it's lightweight. If `cron` 0.15 doesn't use chrono, adjust the `chrono_from_epoch` function accordingly. Check `cron` crate docs for the exact API.
+
+**Step 2: Add chrono as dependency if needed**
+
+If the `cron` crate requires chrono, add to workspace deps:
+
+```toml
+chrono = { version = "0.4", default-features = false, features = ["std"] }
+```
+
+And in `crates/bubbaloop/Cargo.toml`:
+```toml
+chrono.workspace = true
+```
+
+**Step 3: Update agent/mod.rs**
+
+Add `pub mod scheduler;` to the module declarations.
+
+**Step 4: Run check + tests**
+
+Run: `pixi run check && pixi run test`
+
+**Step 5: Commit**
+
+```bash
+git add crates/bubbaloop/src/agent/scheduler.rs crates/bubbaloop/src/agent/mod.rs
+git commit -m "feat: add Tier 1 cron scheduler with built-in actions"
+```
+
+---
+
+## Task 7: Integration — Wire Scheduler into Agent + Skill Loader
+
+**Files:**
+- Modify: `crates/bubbaloop/src/agent/mod.rs` (start scheduler on agent launch)
+- Modify: `crates/bubbaloop/src/cli/up.rs` (register skill schedules in SQLite)
+
+**Step 1: Start scheduler alongside agent**
+
+In `agent/mod.rs`, update `run_agent()` to spawn the scheduler:
+
+After initializing the `Dispatcher`, add:
+
+```rust
+    // Start scheduler in background
+    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(());
+    let sched_memory = Arc::new(Memory::open(&db_path)?);
+    let sched_platform = Arc::new(DaemonPlatform { /* same fields */ });
+    tokio::spawn(scheduler::run_scheduler(
+        sched_memory,
+        sched_platform,
+        shutdown_rx,
+    ));
+```
+
+And drop `shutdown_tx` when the agent loop ends (implicit on function return).
+
+**Step 2: Register skill schedules at startup**
+
+In `crates/bubbaloop/src/cli/up.rs`, after processing skills, register any that have `schedule` + `actions` fields into the SQLite `schedules` table.
+
+Add to `UpCommand::run()` after the skill processing loop:
+
+```rust
+        // 6. Register skill schedules in memory DB
+        let db_path = get_bubbaloop_home().join("memory.db");
+        if let Ok(mem) = crate::agent::memory::Memory::open(&db_path) {
+            for skill in &skill_configs {
+                if let Some(ref schedule_expr) = skill.schedule {
+                    if !skill.actions.is_empty() {
+                        let actions_json = serde_json::to_string(&skill.actions)
+                            .unwrap_or_else(|_| "[]".to_string());
+                        let sched = crate::agent::memory::Schedule {
+                            id: uuid::Uuid::new_v4().to_string(),
+                            name: skill.name.clone(),
+                            cron: schedule_expr.clone(),
+                            actions: actions_json,
+                            tier: 1,
+                            last_run: None,
+                            next_run: None,
+                            created_by: "yaml".to_string(),
+                        };
+                        if self.dry_run {
+                            println!("  [dry-run] Would register schedule: {} ({})", skill.name, schedule_expr);
+                        } else if let Err(e) = mem.upsert_schedule(&sched) {
+                            println!("  [warn] Failed to register schedule: {}", e);
+                        } else {
+                            println!("  Registered schedule: {} ({})", skill.name, schedule_expr);
+                        }
+                    }
+                }
+            }
+        }
+```
+
+**Step 3: Run check + tests**
+
+Run: `pixi run check && pixi run test`
+
+**Step 4: Commit**
+
+```bash
+git add crates/bubbaloop/src/agent/mod.rs crates/bubbaloop/src/cli/up.rs
+git commit -m "feat: wire scheduler into agent and register skill schedules"
+```
+
+---
+
+## Task 8: Clippy, Tests, Update ROADMAP
+
+**Files:**
+- Modify: `ROADMAP.md` (check Phase 1-4 boxes)
+- All agent files (clippy fixes)
+
+**Step 1: Run full verification**
+
+```bash
+pixi run fmt
+pixi run clippy
+pixi run test
+```
+
+Fix any warnings or test failures.
+
+**Step 2: Update ROADMAP.md checkboxes**
+
+Change Phase 1 items from `[ ]` to `[x]`:
+```markdown
+- [x] `~/.bubbaloop/skills/*.yaml` loader
+- [x] Driver registry: map `driver: rtsp` → marketplace node `rtsp-camera`
+- [x] Auto-install: download precompiled binary if driver not present
+- [x] Config injection: YAML config → node env vars / config.yaml
+- [x] `bubbaloop up` command
+- [x] Built-in driver catalog (v1)
+```
+
+Change Phase 2 items from `[ ]` to `[x]`:
+```markdown
+- [x] `bubbaloop agent` CLI command
+- [x] Claude API integration via `reqwest` (tool_use for MCP tools)
+- [x] Internal MCP tool dispatch (call tools without HTTP round-trip)
+- [x] System prompt injection: sensor inventory, node status, active schedules
+- [x] Multi-turn conversation loop with tool use
+```
+
+Phase 3:
+```markdown
+- [x] SQLite via `rusqlite` (static libsqlite3) at `~/.bubbaloop/memory.db`
+- [x] `conversations` table with timestamp indexing
+- [x] `sensor_events` table: health changes, crashes, alerts
+- [x] `schedules` table: active jobs + execution history
+- [x] Context injection: recent events included in agent system prompt
+```
+
+Phase 4:
+```markdown
+- [x] Tier 1 cron executor with built-in action set (offline, no LLM)
+- [x] YAML `schedule:` + `actions:` syntax in skill files
+```
+
+Leave unchecked:
+```markdown
+- [ ] Tier 2 conversational schedules stored in SQLite
+- [ ] Rate limiting: configurable max LLM calls/day
+- [ ] `bubbaloop jobs` CLI: list, pause, resume, delete
+- [ ] Execution history logged in SQLite
+- [ ] HTTP chat endpoint for future dashboard integration
+- [ ] Daemon event hook: write sensor events as they happen (no polling)
+```
+
+**Step 3: Commit**
+
+```bash
+git add -A
+git commit -m "feat: complete Phases 2-4 — agent loop, SQLite memory, scheduler"
+```
+
+**Step 4: Push**
+
+```bash
+git push
+```

--- a/docs/plans/2026-02-28-fts5-semantic-memory-design.md
+++ b/docs/plans/2026-02-28-fts5-semantic-memory-design.md
@@ -1,0 +1,153 @@
+# FTS5 Semantic Memory Layer
+
+**Date:** 2026-02-28
+**Status:** Approved
+**Approach:** Phase 1 of 2 — FTS5 full-text search (no new deps, no unsafe)
+
+## Context
+
+The agent memory system (SQLite) currently uses recency-only retrieval — last 20 messages, last 10 events. This misses relevant past context. Adding semantic search enables the agent to retrieve conversations, events, and skills by meaning.
+
+## Design Decision
+
+After evaluating LanceDB (too heavy for Jetson: +30MB binary, Arrow/DataFusion deps) and comparing with OpenClaw (sqlite-vec) and ZeroClaw (SQLite BLOBs + FTS5), we chose a phased approach:
+
+- **Phase 1 (this PR):** FTS5 full-text search tables in the existing SQLite DB. Zero new deps, zero `unsafe`, zero binary size increase. FTS5 is built into rusqlite's `bundled` feature.
+- **Phase 2 (future):** Add `sqlite-vec` (~200KB) for vector search with embeddings. One `unsafe` block for `sqlite3_auto_extension`. Hybrid FTS5+vec0 search using Reciprocal Rank Fusion.
+
+## Architecture
+
+```
+SQLite memory.db
+├── conversations          (existing — CRUD, pruning)
+├── sensor_events          (existing — CRUD, pruning)
+├── schedules              (existing — CRUD)
+├── fts_conversations      (NEW — FTS5 over conversation content)
+├── fts_events             (NEW — FTS5 over event details)
+└── fts_skills             (NEW — FTS5 over skill name + body)
+```
+
+### Data Flow
+
+1. **Write path:** `log_message()` and `log_event()` dual-write to both the regular table and the corresponding FTS5 table. Skill indexing happens at startup.
+2. **Read path:** New `search_conversations(query, limit)`, `search_events(query, limit)`, `search_skills(query, limit)` methods query FTS5 tables with BM25 ranking.
+3. **Context injection:** `build_system_prompt()` gains a `relevant_context` parameter — results from semantic search on the current user input, injected alongside recency-based context.
+
+### FTS5 Table Schemas
+
+```sql
+-- Conversations: search over message content
+CREATE VIRTUAL TABLE IF NOT EXISTS fts_conversations USING fts5(
+    id UNINDEXED,
+    role UNINDEXED,
+    content,
+    timestamp UNINDEXED
+);
+
+-- Events: search over node_name, event_type, and details
+CREATE VIRTUAL TABLE IF NOT EXISTS fts_events USING fts5(
+    id UNINDEXED,
+    node_name,
+    event_type,
+    details,
+    timestamp UNINDEXED
+);
+
+-- Skills: search over skill name and markdown body
+CREATE VIRTUAL TABLE IF NOT EXISTS fts_skills USING fts5(
+    name,
+    driver UNINDEXED,
+    body
+);
+```
+
+### Search API
+
+```rust
+// memory.rs — new methods
+pub fn search_conversations(&self, query: &str, limit: usize) -> Result<Vec<ConversationRow>>;
+pub fn search_events(&self, query: &str, limit: usize) -> Result<Vec<SensorEvent>>;
+pub fn search_skills(&self, query: &str, limit: usize) -> Result<Vec<SkillSearchResult>>;
+
+// New struct for skill search results
+pub struct SkillSearchResult {
+    pub name: String,
+    pub driver: String,
+    pub body: String,
+    pub rank: f64,
+}
+```
+
+### Retriever Trait (future-proofing for Phase 2)
+
+```rust
+pub trait Retriever {
+    fn retrieve_conversations(&self, query: &str, limit: usize) -> Result<Vec<ConversationRow>>;
+    fn retrieve_events(&self, query: &str, limit: usize) -> Result<Vec<SensorEvent>>;
+    fn retrieve_skills(&self, query: &str, limit: usize) -> Result<Vec<SkillSearchResult>>;
+}
+```
+
+Phase 1: `FtsRetriever` (FTS5 only). Phase 2: `HybridRetriever` (FTS5 + vec0 RRF blend).
+
+### Context Injection Changes
+
+In `mod.rs` REPL loop, before sending to Claude:
+
+```rust
+// Retrieve relevant context using FTS5 search on user input
+let relevant_convos = memory.search_conversations(input, 5).unwrap_or_default();
+let relevant_events = memory.search_events(input, 5).unwrap_or_default();
+let relevant_skills = memory.search_skills(input, 3).unwrap_or_default();
+
+// Build system prompt with both recency + relevance context
+let system_prompt = build_system_prompt(
+    &inventory, &schedules, &recent_events, &skills,
+    &relevant_convos, &relevant_events, &relevant_skills,
+);
+```
+
+### Prompt Changes
+
+Add a new section to the system prompt between recent events and skills:
+
+```
+## Relevant Context (from past conversations and events)
+
+[FTS5 search results matching the current user query]
+```
+
+## Files to Modify
+
+| File | Changes |
+|------|---------|
+| `memory.rs` | Add FTS5 table creation in `open()`, dual-write in `log_message`/`log_event`, add `search_*` methods, `index_skills()`, `SkillSearchResult` struct, `Retriever` trait |
+| `mod.rs` | Call `index_skills()` at startup, add FTS5 search before each Claude call, pass results to `build_system_prompt()` |
+| `prompt.rs` | Add `relevant_context` parameters to `build_system_prompt()`, render relevant results section |
+
+## Tests
+
+- `fts_conversations_search` — insert messages, verify BM25 ranking
+- `fts_events_search` — insert events, verify search by node_name and details
+- `fts_skills_search` — index skills, verify search by name and body
+- `fts_dual_write` — verify log_message writes to both tables
+- `fts_empty_query` — verify graceful handling of empty/no-match queries
+- Existing tests remain unchanged (FTS5 tables are additive)
+
+## Verification
+
+```bash
+pixi run check          # Compilation
+pixi run clippy         # Zero warnings
+pixi run test           # All unit tests
+cargo test --lib -- memory::tests  # Targeted
+```
+
+## Phase 2 Preview (not in this PR)
+
+When ready for embeddings:
+1. Add `sqlite-vec = "0.1.7-alpha.10"` + `zerocopy` deps
+2. One `unsafe` block for `sqlite3_auto_extension(sqlite3_vec_init)`
+3. Create `vec0` tables with `distance_metric=cosine`
+4. Implement `HybridRetriever` with RRF: 70% vector / 30% FTS5
+5. Add embedding computation (candle/ort or API-based)


### PR DESCRIPTION
## Summary

- Replace dead Zenoh queryables (removed in v0.0.6) with HTTP REST API for all CLI→daemon communication
- Add `/api/v1/*` routes to the existing axum server on port 8088, alongside `/health` and `/mcp`
- New `DaemonClient` (reqwest-based) replaces all Zenoh session/query/retry code in CLI
- Input validation on all REST endpoints (node name, install source) matching MCP's validation
- Net reduction: ~300 lines removed (752 added, 1048 deleted)

### New files
| File | Purpose |
|------|---------|
| `api.rs` | REST handlers calling `PlatformOperations` with validation |
| `cli/daemon_client.rs` | HTTP client (30s timeout, `BUBBALOOP_MCP_PORT` env) |

### Migrated CLI commands
- **node**: list, add, remove, start, stop, restart, build, install, logs, clean, enable, disable
- **doctor**: HTTP health/connectivity checks (Zenoh kept for data-plane diagnostics only)
- **launch**: node resolution and instance registration via REST API

## Test plan

- [x] `pixi run check` — compiles clean
- [x] `pixi run clippy` — zero warnings
- [x] `pixi run test` — 383 tests pass
- [ ] Manual: `curl http://127.0.0.1:8088/api/v1/nodes` with daemon running
- [ ] Manual: `bubbaloop node list` works via HTTP
- [ ] Manual: `bubbaloop doctor` checks HTTP connectivity

🤖 Generated with [Claude Code](https://claude.com/claude-code)