### PR TITLE
fix: sanitize node topics to prevent namespace breakout

### DIFF
--- a/templates/rust-node/src/node.rs.template
+++ b/templates/rust-node/src/node.rs.template
@@ -176,6 +176,13 @@ impl {{node_name_pascal}}Node {
 
         log::info!("Node scoped topic prefix: {}", topic_prefix);
 
+        // Sanitize topic suffix to prevent Zenoh path injection
+        let illegal_chars = ['/', '*', '#'];
+        if self.config.publish_topic.contains(&illegal_chars[..]) || self.config.publish_topic.contains("..") {
+            return Err(anyhow!("Security: Illegal characters in publish topic '{}'", self.config.publish_topic));
+        }
+        self.config.publish_topic = self.config.publish_topic.trim_start_matches('/').to_string();
+
         // Construct full publish topic
         let full_publish_topic = format!("{}/{}", topic_prefix, self.config.publish_topic);
         log::info!("Publishing to: {}", full_publish_topic);


### PR DESCRIPTION
Hey @edgarriba  ,
I've proposed a solution for the Namespace Breakout via Zenoh Topic Injection vulnerability described in this issue through this pr.
During my investigation of the recent codebase changes (where bubbaloop-node-sdk was removed), I noticed that the vulnerability now applied directly to the standalone node templates (rust-node and python-node).
The Real Issue is that the publish_topic in the node's config.yaml was being directly appended to the node's isolated Zenoh prefix without any validation. Because the Zenoh router treats topics like Unix file paths, a user could escape their authorized namespace (bubbaloop/{scope}/{machine_id}/{node_name}) and publish to or subscribe from other nodes' private topics.

How I Reproduced It
I generated a dummy node and modified its config.yaml to include a path traversal payload using Zenoh wildcards:yaml publish_topic:"../system_monitor/critical_data"
When the node initialized, it constructed the topic by simply concatenating the strings: bubbaloop/local/robot_1/camera_node/../system_monitor/critical_data Once published, the zenoh router resolved the .. and my dummy sensor successfully bypassed its restrictions and injected data into system_monitor/critical_data.
The same injection method worked with Zenoh wildcards (*, **, #) allowing a node to subscribe to the entire mesh mesh network.
How I Fixed It
I reapplied the path sandboxing logic directly into the code generation templates (
templates/rust-node/src/node.rs.template and templates/python-node/main.py.template).

Before the node connects its publisher or generates its manifest, it now strictly validates the publish_topic string from the configuration file:
1. It scans the suffix for illegal characters: /, *, #, and directory traversal ...
2. If any of these characters are detected, the node initialization immediately halts with a Security: Illegal characters in publish topic error.
3. Leftover leading slashes are safely stripped trim_start_matches('/') so that configurations like /output don't bypass prefixing.
I've tested the changes by generating both a Rust and Python node locally, and both templates compile successfully and correctly catch the illegal topic patterns at runtime.

Let me know if there's any feedback on the PR!

