### PR TITLE
implemented explicit path

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "crates/bubbaloop",
+    "crates/bubbaloop-node-sdk",
 ]
 resolver = "2"
 

--- a/crates/bubbaloop-node-sdk/Cargo.toml
+++ b/crates/bubbaloop-node-sdk/Cargo.toml
@@ -24,5 +24,3 @@ bubbaloop-schemas = { git = "https://github.com/kornia/bubbaloop.git", branch = 
 [dev-dependencies]
 tempfile = "3"
 
-# Opt out of the parent bubbaloop workspace
-[workspace]

--- a/crates/bubbaloop-node-sdk/src/context.rs
+++ b/crates/bubbaloop-node-sdk/src/context.rs
@@ -14,7 +14,12 @@ pub struct NodeContext {
 
 impl NodeContext {
     /// Build a fully-qualified scoped topic: `bubbaloop/{scope}/{machine_id}/{suffix}`
-    pub fn topic(&self, suffix: &str) -> String {
-        format!("bubbaloop/{}/{}/{}", self.scope, self.machine_id, suffix)
+    pub fn topic(&self, suffix: &str) -> anyhow::Result<String> {
+        let illegal_chars = ['/', '*', '#'];
+        if suffix.contains(&illegal_chars[..]) || suffix.contains("..") {
+            anyhow::bail!("Security: Illegal characters in topic suffix '{}'", suffix);
+        }
+        let safe_suffix = suffix.trim_start_matches('/');
+        Ok(format!("bubbaloop/{}/{}/{}", self.scope, self.machine_id, safe_suffix))
     }
 }

--- a/crates/bubbaloop-node-sdk/src/schema.rs
+++ b/crates/bubbaloop-node-sdk/src/schema.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use zenoh::Wait;
 
 /// Declare a Zenoh queryable that serves the node's protobuf FileDescriptorSet.
 ///
@@ -20,7 +21,7 @@ pub async fn declare_schema_queryable(
             let descriptor = descriptor.to_vec();
             move |query| {
                 log::debug!("Schema query received");
-                if let Err(e) = query.reply(&query.key_expr().clone(), descriptor.as_slice()) {
+                if let Err(e) = query.reply(&query.key_expr().clone(), descriptor.as_slice()).wait() {
                     log::warn!("Failed to reply to schema query: {}", e);
                 }
             }


### PR DESCRIPTION
Hi @edgarriba this PR addresses the NodeContext::topic trajectory bug .

How I reproduced it
The previous standalone nodes generated via the templates dynamically produced static string literals for their schema_key, manifest_key, etc. based on bubbaloop/{scope}/{machine_id}/{node_name}/*. However, in the newly introduced bubbaloop-node-sdk, nodes invoke NodeContext::topic with a dynamic suffix:rust format!("bubbaloop/{}/{}/{}", self.scope, self.machine_id, suffix)
Because no string filtration checked whether the suffix payload contained Zenoh wildcards (*, **, #) or system path-climbing components (../), a node's config could be tweaked or hijacked to inject a suffix like ../../other_workspace/arm_control, allowing the node to break namespace containment and spoof inputs or scrape out-of-bounds metrics!

How I fixed it
I implemented an explicit path sandboxing policy directly inside src/context.rs.
I mutated the method's signature to return a recoverable anyhow::Result<String> instead of an infallible String.
A check intercepts and enforces that no suffix contains *, #, /, or ... If any of these topology navigation sequences are discovered, the function fast-fails with an anyhow::bail! detailing the breach.
Safe suffix payloads are stripped of any initial absolute designators (/) and securely wrapped.
After migrating the signature, I scanned the entire codebase for integration errors. There are currently no components invoking .topic() in the main trunk, so this SDK feature is fully patched safely before adoption!