### PR TITLE
fix: remove stale CLI deprecation warnings and add InstallService command

### DIFF
--- a/crates/bubbaloop/src/cli/daemon_client.rs
+++ b/crates/bubbaloop/src/cli/daemon_client.rs
@@ -271,10 +271,8 @@ impl DaemonClient {
             "logs" | "get_logs" | "get-logs" => DaemonCommandType::GetLogs {
                 name: name.to_string(),
             },
-            "install" => DaemonCommandType::InstallNode {
-                source: name.to_string(),
-                name: None,
-                config: None,
+            "install" => DaemonCommandType::InstallService {
+                name: name.to_string(),
             },
             "build" => DaemonCommandType::BuildNode {
                 name: name.to_string(),

--- a/crates/bubbaloop/src/cli/node/mod.rs
+++ b/crates/bubbaloop/src/cli/node/mod.rs
@@ -402,7 +402,6 @@ impl NodeCommand {
                 list::list_nodes(&args.format, args.base, args.instances).await
             }
             Some(NodeAction::Add(args)) => {
-                log::warn!("Note: 'bubbaloop node add' is deprecated. Use MCP tool 'install_node' instead.");
                 manage::add_node(
                     &args.source,
                     args.output.as_deref(),
@@ -416,7 +415,6 @@ impl NodeCommand {
                 .await
             }
             Some(NodeAction::Remove(args)) => {
-                log::warn!("Note: 'bubbaloop node remove' is deprecated. Use MCP tool 'remove_node' instead.");
                 manage::remove_node(&args.name, args.delete_files).await
             }
             Some(NodeAction::Instance(args)) => {
@@ -432,20 +430,9 @@ impl NodeCommand {
             }
             Some(NodeAction::Install(args)) => install::handle_install(args).await,
             Some(NodeAction::Uninstall(args)) => send_command(&args.name, "uninstall").await,
-            Some(NodeAction::Start(args)) => {
-                log::warn!("Note: 'bubbaloop node start' is deprecated. Use MCP tool 'start_node' instead.");
-                lifecycle::start_node(&args.name).await
-            }
-            Some(NodeAction::Stop(args)) => {
-                log::warn!(
-                    "Note: 'bubbaloop node stop' is deprecated. Use MCP tool 'stop_node' instead."
-                );
-                lifecycle::stop_node(&args.name).await
-            }
-            Some(NodeAction::Restart(args)) => {
-                log::warn!("Note: 'bubbaloop node restart' is deprecated. Use MCP tool 'restart_node' instead.");
-                lifecycle::restart_node(&args.name).await
-            }
+            Some(NodeAction::Start(args)) => lifecycle::start_node(&args.name).await,
+            Some(NodeAction::Stop(args)) => lifecycle::stop_node(&args.name).await,
+            Some(NodeAction::Restart(args)) => lifecycle::restart_node(&args.name).await,
             Some(NodeAction::Logs(args)) => lifecycle::view_logs(args).await,
             Some(NodeAction::Build(args)) => build::build_node(&args.name).await,
             Some(NodeAction::Clean(args)) => send_command(&args.name, "clean").await,

--- a/crates/bubbaloop/src/daemon/gateway.rs
+++ b/crates/bubbaloop/src/daemon/gateway.rs
@@ -41,6 +41,8 @@ pub enum DaemonCommandType {
     RemoveNode { name: String },
     /// Build a node by name.
     BuildNode { name: String },
+    /// Install a registered node as a systemd service (by name).
+    InstallService { name: String },
     /// Uninstall a node by name.
     UninstallNode { name: String },
     /// Clean build artifacts for a node.
@@ -239,6 +241,9 @@ mod tests {
                 name: "cam".to_string(),
             },
             DaemonCommandType::BuildNode {
+                name: "cam".to_string(),
+            },
+            DaemonCommandType::InstallService {
                 name: "cam".to_string(),
             },
             DaemonCommandType::UninstallNode {

--- a/crates/bubbaloop/src/daemon/mod.rs
+++ b/crates/bubbaloop/src/daemon/mod.rs
@@ -321,6 +321,16 @@ async fn dispatch_daemon_command(
                 Err(e) => events.push(gateway::DaemonEvent::error(id, &e.to_string())),
             }
         }
+        gateway::DaemonCommandType::InstallService { name } => {
+            validate_name!(name);
+            match platform
+                .execute_command(name, crate::mcp::platform::NodeCommand::Install)
+                .await
+            {
+                Ok(msg) => events.push(gateway::DaemonEvent::result(id, &msg)),
+                Err(e) => events.push(gateway::DaemonEvent::error(id, &e.to_string())),
+            }
+        }
         gateway::DaemonCommandType::UninstallNode { name } => {
             validate_name!(name);
             match platform


### PR DESCRIPTION
## Summary

- Remove misleading deprecation warnings from `node add`, `remove`, `start`, `stop`, `restart` — these are valid user-facing CLI commands, not deprecated
- Add `InstallService` variant to `DaemonCommandType` for installing a registered node as a systemd service by name (distinct from `InstallNode` which takes a source URL)
- Wire `InstallService` dispatch in daemon via `NodeCommand::Install` through platform

## Test plan

- [x] 578 lib unit tests passing
- [x] Zero clippy warnings