### PR TITLE
feat: node architecture overhaul with 3-tier driver system

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,15 @@ mime_guess = "2"
 # WebSocket proxy (dashboard)
 tokio-tungstenite = "0.26"
 
+# Async traits
+async-trait = "0.1"
+
+# MQTT client (built-in driver)
+rumqttc = "0.24"
+
+# Modbus TCP client (built-in driver)
+tokio-modbus = "0.14"
+
 # MCP server
 rmcp = { version = "0.15", features = ["server", "macros", "transport-streamable-http-server", "transport-io"] }
 schemars = "1.0"

--- a/crates/bubbaloop-node-sdk/Cargo.lock
+++ b/crates/bubbaloop-node-sdk/Cargo.lock
@@ -9,12 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "adler32"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
-
-[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -204,29 +198,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-broadcast"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
-dependencies = [
- "event-listener",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-recursion"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -238,71 +209,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic-waker"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
-name = "axum"
-version = "0.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
-dependencies = [
- "axum-core",
- "base64",
- "bytes",
- "form_urlencoded",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-util",
- "itoa",
- "matchit",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "serde_core",
- "serde_json",
- "serde_path_to_error",
- "serde_urlencoded",
- "sha1",
- "sync_wrapper",
- "tokio",
- "tokio-tungstenite 0.28.0",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
-dependencies = [
- "bytes",
- "futures-core",
- "http",
- "http-body",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "sync_wrapper",
- "tower-layer",
- "tower-service",
- "tracing",
-]
 
 [[package]]
 name = "base64"
@@ -315,12 +225,6 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -350,54 +254,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "bubbaloop"
-version = "0.0.11"
+name = "bubbaloop-node-sdk"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "argh",
  "async-trait",
- "axum",
- "chrono",
- "cron",
- "crossterm",
+ "bubbaloop-schemas",
  "ctrlc",
- "dirs",
  "env_logger",
- "futures",
- "hex",
  "hostname",
  "log",
- "mime_guess",
- "notify",
- "open",
  "prost",
- "prost-build",
- "prost-reflect",
- "prost-types",
- "ratatui",
- "reqwest",
- "rmcp",
- "rpassword",
- "rumqttc",
- "rusqlite",
- "rust-embed",
- "schemars 1.2.1",
  "serde",
  "serde_json",
  "serde_yaml",
- "sysinfo",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
- "tokio-modbus",
- "tokio-tungstenite 0.26.2",
- "toml",
- "tower_governor",
- "uuid",
- "walkdir",
- "whoami",
- "zbus",
  "zenoh",
+]
+
+[[package]]
+name = "bubbaloop-schemas"
+version = "0.1.0"
+source = "git+https://github.com/kornia/bubbaloop.git?branch=main#d672229dc5e5518ad73056de02ae488ef0e703b0"
+dependencies = [
+ "prost",
+ "prost-build",
+ "prost-types",
+ "serde",
 ]
 
 [[package]]
@@ -419,29 +305,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
-name = "cassowary"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
-
-[[package]]
-name = "castaway"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "cc"
 version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -470,10 +339,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
  "windows-link",
 ]
 
@@ -501,20 +368,6 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
-]
-
-[[package]]
-name = "compact_str"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
-dependencies = [
- "castaway",
- "cfg-if",
- "itoa",
- "rustversion",
- "ryu",
- "static_assertions",
 ]
 
 [[package]]
@@ -554,16 +407,6 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -577,15 +420,6 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
-name = "core2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "cpufeatures"
@@ -603,17 +437,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "cron"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5877d3fbf742507b66bc2a1945106bd30dd8504019d596901ddd012a4dd01740"
-dependencies = [
- "chrono",
- "once_cell",
- "winnow 0.6.26",
 ]
 
 [[package]]
@@ -673,32 +496,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
-name = "crossterm"
-version = "0.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
-dependencies = [
- "bitflags 2.11.0",
- "crossterm_winapi",
- "futures-core",
- "mio",
- "parking_lot",
- "rustix 0.38.44",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
-name = "crossterm_winapi"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -715,7 +512,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
 dependencies = [
  "dispatch2",
- "nix 0.31.2",
+ "nix 0.31.1",
  "windows-sys 0.61.2",
 ]
 
@@ -725,18 +522,8 @@ version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
-]
-
-[[package]]
-name = "darling"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
-dependencies = [
- "darling_core 0.23.0",
- "darling_macro 0.23.0",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -754,58 +541,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "darling_core"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
-dependencies = [
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "darling_macro"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "darling_core 0.21.3",
+ "darling_core",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
-dependencies = [
- "darling_core 0.23.0",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "dary_heap"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06d2e3287df1c007e74221c49ca10a95d557349e54b3a75dc2fb14712c751f04"
-
-[[package]]
-name = "dashmap"
-version = "6.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
 ]
 
 [[package]]
@@ -884,11 +627,11 @@ dependencies = [
 
 [[package]]
 name = "dispatch2"
-version = "0.3.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "block2",
  "libc",
  "objc2",
@@ -916,33 +659,6 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
-name = "endi"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
-
-[[package]]
-name = "enumflags2"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
-dependencies = [
- "enumflags2_derive",
- "serde",
-]
-
-[[package]]
-name = "enumflags2_derive"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
 
 [[package]]
 name = "env_filter"
@@ -995,28 +711,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "event-listener-strategy"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
-dependencies = [
- "event-listener",
- "pin-project-lite",
-]
-
-[[package]]
-name = "fallible-iterator"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
-
-[[package]]
-name = "fallible-streaming-iterator"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
-
-[[package]]
 name = "fastbloom"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1033,17 +727,6 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
-name = "filetime"
-version = "0.2.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
-dependencies = [
- "cfg-if",
- "libc",
- "libredox",
-]
 
 [[package]]
 name = "find-msvc-tools"
@@ -1107,16 +790,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "forwarded-header-value"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8835f84f38484cc86f110a805655697908257fb9a7af005234060891557198e9"
-dependencies = [
- "nonempty",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1165,19 +838,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
-name = "futures-lite"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
-dependencies = [
- "fastrand",
- "futures-core",
- "futures-io",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
 name = "futures-macro"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1199,12 +859,6 @@ name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
-
-[[package]]
-name = "futures-timer"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
@@ -1255,20 +909,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -1294,48 +948,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "governor"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9efcab3c1958580ff1f25a2a41be1668f7603d849bb63af523b208a3cc1223b8"
-dependencies = [
- "cfg-if",
- "dashmap",
- "futures-sink",
- "futures-timer",
- "futures-util",
- "getrandom 0.3.4",
- "hashbrown 0.16.1",
- "nonzero_ext",
- "parking_lot",
- "portable-atomic",
- "quanta",
- "rand 0.9.2",
- "smallvec",
- "spinning_top",
- "web-time",
-]
-
-[[package]]
-name = "h2"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http",
- "indexmap 2.13.0",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1357,8 +969,6 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
- "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -1371,15 +981,6 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
-]
-
-[[package]]
-name = "hashlink"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
-dependencies = [
- "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -1440,39 +1041,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "http-body"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
-dependencies = [
- "bytes",
- "http",
-]
-
-[[package]]
-name = "http-body-util"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
-dependencies = [
- "bytes",
- "futures-core",
- "http",
- "http-body",
- "pin-project-lite",
-]
-
-[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
-
-[[package]]
-name = "httpdate"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "humantime"
@@ -1481,86 +1053,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
-name = "hyper"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
-dependencies = [
- "atomic-waker",
- "bytes",
- "futures-channel",
- "futures-core",
- "h2",
- "http",
- "http-body",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "pin-utils",
- "smallvec",
- "tokio",
- "want",
-]
-
-[[package]]
-name = "hyper-rustls"
-version = "0.27.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
-dependencies = [
- "http",
- "hyper",
- "hyper-util",
- "rustls 0.23.37",
- "rustls-pki-types",
- "tokio",
- "tokio-rustls 0.26.4",
- "tower-service",
- "webpki-roots",
-]
-
-[[package]]
-name = "hyper-timeout"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
-dependencies = [
- "hyper",
- "hyper-util",
- "pin-project-lite",
- "tokio",
- "tower-service",
-]
-
-[[package]]
-name = "hyper-util"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
-dependencies = [
- "base64",
- "bytes",
- "futures-channel",
- "futures-util",
- "http",
- "http-body",
- "hyper",
- "ipnet",
- "libc",
- "percent-encoding",
- "pin-project-lite",
- "socket2 0.6.2",
- "tokio",
- "tower-service",
- "tracing",
-]
-
-[[package]]
 name = "iana-time-zone"
-version = "0.1.65"
+version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -1568,7 +1064,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -1695,43 +1191,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "include-flate"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e01b7cb6ca682a621e7cda1c358c9724b53a7b4409be9be1dd443b7f3a26f998"
-dependencies = [
- "include-flate-codegen",
- "include-flate-compress",
- "libflate",
- "zstd",
-]
-
-[[package]]
-name = "include-flate-codegen"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f49bf5274aebe468d6e6eba14a977eaf1efa481dc173f361020de70c1c48050"
-dependencies = [
- "include-flate-compress",
- "libflate",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "zstd",
-]
-
-[[package]]
-name = "include-flate-compress"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae6a40e716bcd5931f5dbb79cd921512a4f647e2e9413fded3171fca3824dbc"
-dependencies = [
- "libflate",
- "zstd",
-]
-
-[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1755,35 +1214,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
-name = "inotify"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd168d97690d0b8c412d6b6c10360277f4d7ee495c5d0d5d5fe0854923255cc"
-dependencies = [
- "bitflags 1.3.2",
- "inotify-sys",
- "libc",
-]
-
-[[package]]
-name = "inotify-sys"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1791,34 +1221,6 @@ checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
 ]
-
-[[package]]
-name = "instability"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357b7205c6cd18dd2c86ed312d1e70add149aea98e7ef72b9fdf0270e555c11d"
-dependencies = [
- "darling 0.23.0",
- "indoc",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "ipnet"
-version = "2.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "ipnetwork"
@@ -1830,48 +1232,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "iri-string"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
-name = "is-docker"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
-dependencies = [
- "once_cell",
-]
-
-[[package]]
-name = "is-wsl"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
-dependencies = [
- "is-docker",
- "once_cell",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -1935,16 +1299,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
-name = "jobserver"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
-dependencies = [
- "getrandom 0.3.4",
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1984,26 +1338,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kqueue"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
-dependencies = [
- "kqueue-sys",
- "libc",
-]
-
-[[package]]
-name = "kqueue-sys"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
-dependencies = [
- "bitflags 1.3.2",
- "libc",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2020,33 +1354,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
-
-[[package]]
-name = "libflate"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3248b8d211bd23a104a42d81b4fa8bb8ac4a3b75e7a43d85d2c9ccb6179cd74"
-dependencies = [
- "adler32",
- "core2",
- "crc32fast",
- "dary_heap",
- "libflate_lz77",
-]
-
-[[package]]
-name = "libflate_lz77"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a599cb10a9cd92b1300debcef28da8f70b935ec937f44fcd1b70a7c986a11c5c"
-dependencies = [
- "core2",
- "hashbrown 0.16.1",
- "rle-decode-fast",
-]
+checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "libloading"
@@ -2066,38 +1376,19 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.14"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "libc",
- "plain",
- "redox_syscall 0.7.3",
-]
-
-[[package]]
-name = "libsqlite3-sys"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad8935b44e7c13394a179a438e0cebba0fe08fe01b54f152e29a93b5cf993fd4"
-dependencies = [
- "cc",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.15"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
@@ -2119,15 +1410,6 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
-
-[[package]]
-name = "lru"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
-dependencies = [
- "hashbrown 0.15.5",
-]
 
 [[package]]
 name = "lru-slab"
@@ -2154,41 +1436,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "matchit"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
-
-[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "mime"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
-name = "mime_guess"
-version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
-dependencies = [
- "mime",
- "unicase",
-]
 
 [[package]]
 name = "minimal-lexical"
@@ -2213,7 +1464,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
- "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -2239,7 +1489,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2247,11 +1497,11 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.31.2"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+checksum = "225e7cfe711e0ba79a68baeddb2982723e4235247aefce1482f2f16c27865b66"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2274,60 +1524,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "nonempty"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9e591e719385e6ebaeb5ce5d3887f7d5676fceca6411d1925ccc95745f3d6f7"
-
-[[package]]
 name = "nonempty-collections"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e216d0e8cf9d54fa66e5780f6e1d5dc96d1c1b3c25aeba3b6758548bcbbd8b9d"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "nonzero_ext"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
-
-[[package]]
-name = "notify"
-version = "7.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c533b4c39709f9ba5005d8002048266593c1cfaf3c5f0739d5b8ab0c6c504009"
-dependencies = [
- "bitflags 2.11.0",
- "filetime",
- "inotify",
- "kqueue",
- "libc",
- "log",
- "mio",
- "notify-types",
- "walkdir",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "notify-types"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585d3cb5e12e01aed9e8a1f70d5c6b5e86fe2a6e48fc8cd0b3e0b8df6f6eb174"
-dependencies = [
- "instant",
-]
-
-[[package]]
-name = "ntapi"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
-dependencies = [
- "winapi",
 ]
 
 [[package]]
@@ -2413,9 +1615,9 @@ dependencies = [
 
 [[package]]
 name = "objc2"
-version = "0.6.4"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+checksum = "b7c2599ce0ec54857b29ce62166b0ed9b4f6f1a70ccc9a71165b6154caca8c05"
 dependencies = [
  "objc2-encode",
 ]
@@ -2448,43 +1650,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
-name = "open"
-version = "5.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43bb73a7fa3799b198970490a51174027ba0d4ec504b03cd08caf513d40024bc"
-dependencies = [
- "is-wsl",
- "libc",
- "pathdiff",
-]
-
-[[package]]
 name = "openssl-probe"
-version = "0.1.6"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
-name = "openssl-probe"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+checksum = "9f50d9b3dabb09ecd771ad0aa242ca6894994c130308ca3d7684634df8037391"
 
 [[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
-name = "ordered-stream"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
-dependencies = [
- "futures-core",
- "pin-project-lite",
-]
 
 [[package]]
 name = "parking"
@@ -2510,7 +1685,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link",
 ]
@@ -2520,18 +1695,6 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
-name = "pastey"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
-
-[[package]]
-name = "pathdiff"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "pem-rfc7468"
@@ -2647,36 +1810,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "pin-project"
-version = "1.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs1"
@@ -2698,18 +1835,6 @@ dependencies = [
  "der",
  "spki",
 ]
-
-[[package]]
-name = "pkg-config"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "pnet_base"
@@ -2751,9 +1876,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.5"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
 dependencies = [
  "portable-atomic",
 ]
@@ -2798,31 +1923,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
- "toml_edit 0.23.10+spec-1.0.0",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
+ "toml_edit",
 ]
 
 [[package]]
@@ -2851,7 +1952,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools",
  "log",
  "multimap",
  "petgraph",
@@ -2870,20 +1971,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "prost-reflect"
-version = "0.16.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b89455ef41ed200cafc47c76c552ee7792370ac420497e551f16123a9135f76e"
-dependencies = [
- "prost",
- "prost-types",
 ]
 
 [[package]]
@@ -2893,21 +1984,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
  "prost",
-]
-
-[[package]]
-name = "quanta"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
-dependencies = [
- "crossbeam-utils",
- "libc",
- "once_cell",
- "raw-cpuid",
- "wasi",
- "web-sys",
- "winapi",
 ]
 
 [[package]]
@@ -2922,7 +1998,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.37",
+ "rustls",
  "socket2 0.6.2",
  "thiserror 2.0.18",
  "tokio",
@@ -2943,7 +2019,7 @@ dependencies = [
  "rand 0.9.2",
  "ring",
  "rustc-hash",
- "rustls 0.23.37",
+ "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "slab",
@@ -2969,9 +2045,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -2981,6 +2057,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -3042,71 +2124,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "ratatui"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
-dependencies = [
- "bitflags 2.11.0",
- "cassowary",
- "compact_str",
- "crossterm",
- "indoc",
- "instability",
- "itertools 0.13.0",
- "lru",
- "paste",
- "strum",
- "unicode-segmentation",
- "unicode-truncate",
- "unicode-width 0.2.0",
-]
-
-[[package]]
-name = "raw-cpuid"
-version = "11.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
-dependencies = [
- "bitflags 2.11.0",
-]
-
-[[package]]
-name = "rayon"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
-dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -3170,47 +2193,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
-name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64",
- "bytes",
- "futures-core",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "quinn",
- "rustls 0.23.37",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-rustls 0.26.4",
- "tokio-util",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-streams",
- "web-sys",
- "webpki-roots",
-]
-
-[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3235,79 +2217,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "rle-decode-fast"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
-
-[[package]]
-name = "rmcp"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bef41ebc9ebed2c1b1d90203e9d1756091e8a00bbc3107676151f39868ca0ee"
-dependencies = [
- "async-trait",
- "axum",
- "base64",
- "bytes",
- "chrono",
- "futures",
- "http",
- "http-body",
- "http-body-util",
- "pastey",
- "pin-project-lite",
- "rand 0.9.2",
- "rmcp-macros",
- "schemars 1.2.1",
- "serde",
- "serde_json",
- "sse-stream",
- "thiserror 2.0.18",
- "tokio",
- "tokio-stream",
- "tokio-util",
- "tower-service",
- "tracing",
- "uuid",
-]
-
-[[package]]
-name = "rmcp-macros"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e88ad84b8b6237a934534a62b379a5be6388915663c0cc598ceb9b3292bbbfe"
-dependencies = [
- "darling 0.23.0",
- "proc-macro2",
- "quote",
- "serde_json",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "ron"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd490c5b18261893f14449cbd28cb9c0b637aebf161cd77900bfdedaff21ec32"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "once_cell",
  "serde",
  "serde_derive",
  "typeid",
  "unicode-ident",
-]
-
-[[package]]
-name = "rpassword"
-version = "7.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66d4c8b64f049c6721ec8ccec37ddfc3d641c4a7fca57e8f2a89de509c73df39"
-dependencies = [
- "libc",
- "rtoolbox",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3328,83 +2248,6 @@ dependencies = [
  "spki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rtoolbox"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7cc970b249fbe527d6e02e0a227762c9108b2f49d81094fe357ffc6d14d7f6f"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rumqttc"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1568e15fab2d546f940ed3a21f48bbbd1c494c90c99c4481339364a497f94a9"
-dependencies = [
- "bytes",
- "flume",
- "futures-util",
- "log",
- "rustls-native-certs 0.7.3",
- "rustls-pemfile",
- "rustls-webpki 0.102.8",
- "thiserror 1.0.69",
- "tokio",
- "tokio-rustls 0.25.0",
-]
-
-[[package]]
-name = "rusqlite"
-version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c6d5e5acb6f6129fe3f7ba0a7fc77bca1942cb568535e18e7bc40262baf3110"
-dependencies = [
- "bitflags 2.11.0",
- "fallible-iterator",
- "fallible-streaming-iterator",
- "hashlink",
- "libsqlite3-sys",
- "smallvec",
-]
-
-[[package]]
-name = "rust-embed"
-version = "8.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
-dependencies = [
- "include-flate",
- "rust-embed-impl",
- "rust-embed-utils",
- "walkdir",
-]
-
-[[package]]
-name = "rust-embed-impl"
-version = "8.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa"
-dependencies = [
- "proc-macro2",
- "quote",
- "rust-embed-utils",
- "syn 2.0.117",
- "walkdir",
-]
-
-[[package]]
-name = "rust-embed-utils"
-version = "8.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
-dependencies = [
- "sha2",
- "walkdir",
 ]
 
 [[package]]
@@ -3433,42 +2276,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "errno",
  "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
-dependencies = [
- "bitflags 2.11.0",
- "errno",
- "libc",
- "linux-raw-sys 0.12.1",
+ "linux-raw-sys",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "rustls"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
-dependencies = [
- "log",
- "ring",
- "rustls-pki-types",
- "rustls-webpki 0.102.8",
- "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -3481,22 +2297,9 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.9",
+ "rustls-webpki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
-dependencies = [
- "openssl-probe 0.1.6",
- "rustls-pemfile",
- "rustls-pki-types",
- "schannel",
- "security-framework 2.11.1",
 ]
 
 [[package]]
@@ -3505,10 +2308,10 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
- "openssl-probe 0.2.1",
+ "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.7.0",
+ "security-framework",
 ]
 
 [[package]]
@@ -3536,16 +2339,16 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
 dependencies = [
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-foundation-sys",
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.37",
- "rustls-native-certs 0.8.3",
+ "rustls",
+ "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.9",
- "security-framework 3.7.0",
+ "rustls-webpki",
+ "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
  "windows-sys 0.61.2",
@@ -3556,17 +2359,6 @@ name = "rustls-platform-verifier-android"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
-
-[[package]]
-name = "rustls-webpki"
-version = "0.102.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
-dependencies = [
- "ring",
- "rustls-pki-types",
- "untrusted",
-]
 
 [[package]]
 name = "rustls-webpki"
@@ -3627,7 +2419,6 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
- "chrono",
  "dyn-clone",
  "either",
  "ref-cast",
@@ -3666,25 +2457,12 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.11.1"
+version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
 dependencies = [
- "bitflags 2.11.0",
- "core-foundation 0.9.4",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework"
-version = "3.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
-dependencies = [
- "bitflags 2.11.0",
- "core-foundation 0.10.1",
+ "bitflags",
+ "core-foundation",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -3692,9 +2470,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.17.0"
+version = "2.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3761,49 +2539,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_path_to_error"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
-dependencies = [
- "itoa",
- "serde",
- "serde_core",
-]
-
-[[package]]
-name = "serde_repr"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "serde_spanned"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
 name = "serde_with"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3828,7 +2563,7 @@ version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6d4e30573c8cb306ed6ab1dca8423eec9a463ea0e155f45399455e0368b27e0"
 dependencies = [
- "darling 0.21.3",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -3910,27 +2645,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "signal-hook"
-version = "0.3.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
-dependencies = [
- "libc",
- "signal-hook-registry",
-]
-
-[[package]]
-name = "signal-hook-mio"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
-dependencies = [
- "libc",
- "mio",
- "signal-hook",
-]
-
-[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4010,15 +2724,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 
 [[package]]
-name = "spinning_top"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d96d2d1d716fb500937168cc09353ffdc7a012be8475ac7308e1bdf0e3923300"
-dependencies = [
- "lock_api",
-]
-
-[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4026,19 +2731,6 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
-]
-
-[[package]]
-name = "sse-stream"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb4dc4d33c68ec1f27d386b5610a351922656e1fdf5c05bbaad930cd1519479a"
-dependencies = [
- "bytes",
- "futures-util",
- "http-body",
- "http-body-util",
- "pin-project-lite",
 ]
 
 [[package]]
@@ -4083,38 +2775,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
-name = "strum"
-version = "0.26.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
-dependencies = [
- "strum_macros",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 2.0.117",
-]
 
 [[package]]
 name = "subtle"
@@ -4145,15 +2809,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sync_wrapper"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
-dependencies = [
- "futures-core",
-]
-
-[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4165,29 +2820,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "sysinfo"
-version = "0.33.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc858248ea01b66f19d8e8a6d55f41deaf91e9d495246fd01368d99935c6c01"
-dependencies = [
- "core-foundation-sys",
- "libc",
- "memchr",
- "ntapi",
- "rayon",
- "windows",
-]
-
-[[package]]
 name = "tempfile"
-version = "3.26.0"
+version = "3.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
+checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
 dependencies = [
  "fastrand",
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "once_cell",
- "rustix 1.1.4",
+ "rustix",
  "windows-sys 0.61.2",
 ]
 
@@ -4306,7 +2947,7 @@ dependencies = [
  "pin-project-lite",
  "thiserror 2.0.18",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
 ]
 
 [[package]]
@@ -4334,7 +2975,6 @@ dependencies = [
  "signal-hook-registry",
  "socket2 0.6.2",
  "tokio-macros",
- "tracing",
  "windows-sys 0.61.2",
 ]
 
@@ -4350,52 +2990,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-modbus"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "033b1b9843d693c3543e6b9c656a566ea45d2564e72ad5447e83233b9e2f3fe1"
-dependencies = [
- "async-trait",
- "byteorder",
- "bytes",
- "futures-core",
- "futures-util",
- "log",
- "smallvec",
- "thiserror 1.0.69",
- "tokio",
- "tokio-util",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
-dependencies = [
- "rustls 0.22.4",
- "rustls-pki-types",
- "tokio",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.37",
- "tokio",
-]
-
-[[package]]
-name = "tokio-stream"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
-dependencies = [
- "futures-core",
- "pin-project-lite",
+ "rustls",
  "tokio",
 ]
 
@@ -4408,31 +3008,7 @@ dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite 0.24.0",
-]
-
-[[package]]
-name = "tokio-tungstenite"
-version = "0.26.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
-dependencies = [
- "futures-util",
- "log",
- "tokio",
- "tungstenite 0.26.2",
-]
-
-[[package]]
-name = "tokio-tungstenite"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
-dependencies = [
- "futures-util",
- "log",
- "tokio",
- "tungstenite 0.28.0",
+ "tungstenite",
 ]
 
 [[package]]
@@ -4450,27 +3026,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime 0.6.11",
- "toml_edit 0.22.27",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "toml_datetime"
 version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4481,28 +3036,14 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap 2.13.0",
- "serde",
- "serde_spanned",
- "toml_datetime 0.6.11",
- "toml_write",
- "winnow 0.7.14",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
  "indexmap 2.13.0",
- "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
- "winnow 0.7.14",
+ "winnow",
 ]
 
 [[package]]
@@ -4511,108 +3052,7 @@ version = "1.0.9+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
 dependencies = [
- "winnow 0.7.14",
-]
-
-[[package]]
-name = "toml_write"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
-
-[[package]]
-name = "tonic"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
-dependencies = [
- "async-trait",
- "axum",
- "base64",
- "bytes",
- "h2",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-timeout",
- "hyper-util",
- "percent-encoding",
- "pin-project",
- "socket2 0.6.2",
- "sync_wrapper",
- "tokio",
- "tokio-stream",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
-dependencies = [
- "futures-core",
- "futures-util",
- "indexmap 2.13.0",
- "pin-project-lite",
- "slab",
- "sync_wrapper",
- "tokio",
- "tokio-util",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
-dependencies = [
- "bitflags 2.11.0",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "iri-string",
- "pin-project-lite",
- "tower",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "tower-layer"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
-
-[[package]]
-name = "tower-service"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
-
-[[package]]
-name = "tower_governor"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44de9b94d849d3c46e06a883d72d408c2de6403367b39df2b1c9d9e7b6736fe6"
-dependencies = [
- "axum",
- "forwarded-header-value",
- "governor",
- "http",
- "pin-project",
- "thiserror 2.0.18",
- "tonic",
- "tower",
- "tracing",
+ "winnow",
 ]
 
 [[package]]
@@ -4691,12 +3131,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "try-lock"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
 name = "tungstenite"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4711,40 +3145,6 @@ dependencies = [
  "rand 0.8.5",
  "sha1",
  "thiserror 1.0.69",
- "utf-8",
-]
-
-[[package]]
-name = "tungstenite"
-version = "0.26.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
-dependencies = [
- "bytes",
- "data-encoding",
- "http",
- "httparse",
- "log",
- "rand 0.9.2",
- "sha1",
- "thiserror 2.0.18",
- "utf-8",
-]
-
-[[package]]
-name = "tungstenite"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
-dependencies = [
- "bytes",
- "data-encoding",
- "http",
- "httparse",
- "log",
- "rand 0.9.2",
- "sha1",
- "thiserror 2.0.18",
  "utf-8",
 ]
 
@@ -4773,17 +3173,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
-name = "uds_windows"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89daebc3e6fd160ac4aa9fc8b3bf71e1f74fbf92367ae71fb83a037e8bf164b9"
-dependencies = [
- "memoffset",
- "tempfile",
- "winapi",
-]
-
-[[package]]
 name = "uhlc"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4798,45 +3187,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicase"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
-
-[[package]]
-name = "unicode-truncate"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
-dependencies = [
- "itertools 0.13.0",
- "unicode-segmentation",
- "unicode-width 0.1.14",
-]
-
-[[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
-
-[[package]]
-name = "unicode-width"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode-xid"
@@ -4903,9 +3257,8 @@ version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
 dependencies = [
- "getrandom 0.4.1",
+ "getrandom 0.4.2",
  "js-sys",
- "serde_core",
  "wasm-bindgen",
 ]
 
@@ -4940,12 +3293,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
 name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4965,15 +3312,6 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
-]
-
-[[package]]
-name = "want"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
-dependencies = [
- "try-lock",
 ]
 
 [[package]]
@@ -5001,12 +3339,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasite"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
-
-[[package]]
 name = "wasm-bindgen"
 version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5017,20 +3349,6 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.64"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
-dependencies = [
- "cfg-if",
- "futures-util",
- "js-sys",
- "once_cell",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
@@ -5088,38 +3406,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-streams"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
-dependencies = [
- "futures-util",
- "js-sys",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "hashbrown 0.15.5",
  "indexmap 2.13.0",
  "semver",
-]
-
-[[package]]
-name = "web-sys"
-version = "0.3.91"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -5134,9 +3429,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.6"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+checksum = "36a29fc0408b113f68cf32637857ab740edfafdf460c326cd2afaa2d84cc05dc"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -5148,17 +3443,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
-]
-
-[[package]]
-name = "whoami"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
-dependencies = [
- "libredox",
- "wasite",
- "web-sys",
 ]
 
 [[package]]
@@ -5193,49 +3477,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
-dependencies = [
- "windows-core 0.57.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
-dependencies = [
- "windows-implement 0.57.0",
- "windows-interface 0.57.0",
- "windows-result 0.1.2",
- "windows-targets 0.52.6",
-]
-
-[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
+ "windows-implement",
+ "windows-interface",
  "windows-link",
- "windows-result 0.4.1",
+ "windows-result",
  "windows-strings",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -5243,17 +3494,6 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5276,15 +3516,6 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-result"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
-dependencies = [
- "windows-targets 0.52.6",
-]
 
 [[package]]
 name = "windows-result"
@@ -5318,15 +3549,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -5537,15 +3759,6 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.6.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e90edd2ac1aa278a5c4599b1d89cf03074b610800f866d4026dc199d7929a28"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
 version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
@@ -5611,7 +3824,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
+ "bitflags",
  "indexmap 2.13.0",
  "log",
  "serde",
@@ -5688,62 +3901,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "zbus"
-version = "5.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca82f95dbd3943a40a53cfded6c2d0a2ca26192011846a1810c4256ef92c60bc"
-dependencies = [
- "async-broadcast",
- "async-recursion",
- "async-trait",
- "enumflags2",
- "event-listener",
- "futures-core",
- "futures-lite",
- "hex",
- "libc",
- "ordered-stream",
- "rustix 1.1.4",
- "serde",
- "serde_repr",
- "tokio",
- "tracing",
- "uds_windows",
- "uuid",
- "windows-sys 0.61.2",
- "winnow 0.7.14",
- "zbus_macros",
- "zbus_names",
- "zvariant",
-]
-
-[[package]]
-name = "zbus_macros"
-version = "5.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897e79616e84aac4b2c46e9132a4f63b93105d54fe8c0e8f6bffc21fa8d49222"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "zbus_names",
- "zvariant",
- "zvariant_utils",
-]
-
-[[package]]
-name = "zbus_names"
-version = "4.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffd8af6d5b78619bab301ff3c560a5bd22426150253db278f164d6cf3b72c50f"
-dependencies = [
- "serde",
- "winnow 0.7.14",
- "zvariant",
-]
-
-[[package]]
 name = "zenoh"
 version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5758,7 +3915,7 @@ dependencies = [
  "flume",
  "futures",
  "git-version",
- "itertools 0.14.0",
+ "itertools",
  "json5",
  "lazy_static",
  "nonempty-collections",
@@ -5922,10 +4079,10 @@ dependencies = [
  "flume",
  "futures",
  "quinn",
- "rustls 0.23.37",
+ "rustls",
  "rustls-pemfile",
  "rustls-pki-types",
- "rustls-webpki 0.103.9",
+ "rustls-webpki",
  "secrecy",
  "serde",
  "socket2 0.5.10",
@@ -5954,9 +4111,9 @@ dependencies = [
  "async-trait",
  "base64",
  "quinn",
- "rustls 0.23.37",
+ "rustls",
  "rustls-pemfile",
- "rustls-webpki 0.103.9",
+ "rustls-webpki",
  "secrecy",
  "time",
  "tokio",
@@ -5979,8 +4136,8 @@ checksum = "30cfb427adbc8d367505b9a62a6614c9d7802e420f03466d98644bb7bf24516f"
 dependencies = [
  "async-trait",
  "quinn",
- "rustls 0.23.37",
- "rustls-webpki 0.103.9",
+ "rustls",
+ "rustls-webpki",
  "time",
  "tokio",
  "tokio-util",
@@ -6018,16 +4175,16 @@ checksum = "17544cde682dbcd2a712114786feee14295c28a9f66fc1021637355511e32fa9"
 dependencies = [
  "async-trait",
  "base64",
- "rustls 0.23.37",
+ "rustls",
  "rustls-pemfile",
  "rustls-pki-types",
- "rustls-webpki 0.103.9",
+ "rustls-webpki",
  "secrecy",
  "socket2 0.5.10",
  "time",
  "tls-listener",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tokio-util",
  "tracing",
  "webpki-roots",
@@ -6090,7 +4247,7 @@ dependencies = [
  "async-trait",
  "futures-util",
  "tokio",
- "tokio-tungstenite 0.24.0",
+ "tokio-tungstenite",
  "tokio-util",
  "tracing",
  "url",
@@ -6346,71 +4503,3 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
-
-[[package]]
-name = "zstd"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "7.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
-dependencies = [
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.16+zstd.1.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
-dependencies = [
- "cc",
- "pkg-config",
-]
-
-[[package]]
-name = "zvariant"
-version = "5.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5708299b21903bbe348e94729f22c49c55d04720a004aa350f1f9c122fd2540b"
-dependencies = [
- "endi",
- "enumflags2",
- "serde",
- "winnow 0.7.14",
- "zvariant_derive",
- "zvariant_utils",
-]
-
-[[package]]
-name = "zvariant_derive"
-version = "5.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b59b012ebe9c46656f9cc08d8da8b4c726510aef12559da3e5f1bf72780752c"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "zvariant_utils",
-]
-
-[[package]]
-name = "zvariant_utils"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f75c23a64ef8f40f13a6989991e643554d9bef1d682a281160cf0c1bc389c5e9"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde",
- "syn 2.0.117",
- "winnow 0.7.14",
-]

--- a/crates/bubbaloop-node-sdk/Cargo.toml
+++ b/crates/bubbaloop-node-sdk/Cargo.toml
@@ -9,6 +9,7 @@ license = "Apache-2.0"
 zenoh = "1.7"
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1"
 serde_yaml = "0.9"
 log = "0.4"
 env_logger = "0.11"

--- a/crates/bubbaloop-node-sdk/src/lib.rs
+++ b/crates/bubbaloop-node-sdk/src/lib.rs
@@ -29,17 +29,25 @@
 mod config;
 mod context;
 mod health;
+pub mod prelude;
+pub mod processor;
 mod schema;
 mod shutdown;
+pub mod sink;
+pub mod source;
 mod zenoh_session;
 
 pub use context::NodeContext;
+pub use processor::{run_processor, Processor};
+pub use sink::{run_sink, Sink};
+pub use source::{run_source, Source};
 
 // Re-exports for convenience (so nodes don't need to add these deps)
 pub use anyhow;
 pub use async_trait;
 pub use log;
 pub use prost;
+pub use serde_json;
 pub use tokio;
 pub use zenoh;
 

--- a/crates/bubbaloop-node-sdk/src/prelude.rs
+++ b/crates/bubbaloop-node-sdk/src/prelude.rs
@@ -1,0 +1,20 @@
+//! Convenience re-exports for node authors.
+//!
+//! ```ignore
+//! use bubbaloop_node_sdk::prelude::*;
+//! ```
+
+pub use crate::context::NodeContext;
+pub use crate::Node;
+
+// Category traits + runners
+pub use crate::processor::{run_processor, Processor};
+pub use crate::sink::{run_sink, Sink};
+pub use crate::source::{run_source, Source};
+
+// Common dependencies (so nodes don't need extra deps)
+pub use anyhow::Result;
+pub use async_trait::async_trait;
+pub use log::{error, info, warn};
+pub use serde::Deserialize;
+pub use serde_json::{json, Value};

--- a/crates/bubbaloop-node-sdk/src/processor.rs
+++ b/crates/bubbaloop-node-sdk/src/processor.rs
@@ -1,0 +1,163 @@
+//! Processor trait — transform nodes that subscribe, process, and republish to Zenoh.
+//!
+//! Implement `Processor` for a data transformer (e.g., filter, aggregator, ML inference).
+//! The SDK handles: session setup, health heartbeat, config loading,
+//! schema registration, topic construction, and the subscribe→process→publish loop.
+
+use crate::NodeContext;
+use serde::de::DeserializeOwned;
+
+/// Trait for data-transforming nodes.
+///
+/// A Processor subscribes to an input topic, transforms each message,
+/// and publishes the result. The SDK runs the loop automatically;
+/// the node author only implements `init()` and `process()`.
+#[async_trait::async_trait]
+pub trait Processor: Send + Sync + 'static {
+    /// Node-specific configuration type (deserialized from YAML).
+    type Config: DeserializeOwned + Send + Sync + 'static;
+
+    /// Human-readable node name (must match `name` in `node.yaml`).
+    fn name() -> &'static str;
+
+    /// Protobuf FileDescriptorSet bytes for schema registration.
+    fn descriptor() -> &'static [u8];
+
+    /// Input topic suffix to subscribe to (e.g., `"raw-sensor/data"`).
+    /// Full topic: `bubbaloop/{scope}/{machine_id}/{input_topic}`.
+    fn input_topic() -> &'static str;
+
+    /// Initialize the processor after Zenoh session is established and config is loaded.
+    async fn init(ctx: &NodeContext, config: &Self::Config) -> anyhow::Result<Self>
+    where
+        Self: Sized;
+
+    /// Process an incoming message. Return `Some(json)` to publish the transformed result,
+    /// `None` to filter (drop) this message.
+    async fn process(
+        &mut self,
+        ctx: &NodeContext,
+        input: serde_json::Value,
+    ) -> anyhow::Result<Option<serde_json::Value>>;
+}
+
+/// Run a Processor node with the full SDK runtime.
+///
+/// Handles: logging, CLI args, config, Zenoh session, schema queryable,
+/// health heartbeat, and the `subscribe → process → publish` loop with graceful shutdown.
+pub async fn run_processor<P: Processor>() -> anyhow::Result<()> {
+    // 1. Init logging
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+
+    // 2. Parse CLI args
+    let args: crate::SdkArgs = argh::from_env();
+
+    // 3. Load config
+    let node_config: P::Config = crate::config::load_config(&args.config)?;
+    log::info!(
+        "{}: config loaded from {}",
+        P::name(),
+        args.config.display()
+    );
+
+    // 4. Resolve scope + machine_id
+    let scope = std::env::var("BUBBALOOP_SCOPE").unwrap_or_else(|_| "local".to_string());
+    let machine_id = std::env::var("BUBBALOOP_MACHINE_ID")
+        .unwrap_or_else(|_| {
+            hostname::get()
+                .map(|h| h.to_string_lossy().to_string())
+                .unwrap_or_else(|_| "unknown".to_string())
+        })
+        .replace('-', "_");
+
+    // 5. Setup shutdown channel
+    let (shutdown_tx, _) = crate::shutdown::setup_shutdown()?;
+
+    // 6. Open Zenoh session
+    let session = crate::zenoh_session::open_zenoh_session(&args.endpoint).await?;
+
+    // 7. Declare schema queryable
+    let _schema_queryable = crate::schema::declare_schema_queryable(
+        &session,
+        &scope,
+        &machine_id,
+        P::name(),
+        P::descriptor(),
+    )
+    .await?;
+
+    // 8. Spawn health heartbeat
+    let _health_handle = crate::health::spawn_health_heartbeat(
+        session.clone(),
+        &scope,
+        &machine_id,
+        P::name(),
+        shutdown_tx.subscribe(),
+    )
+    .await?;
+
+    // 9. Build context
+    let ctx = NodeContext {
+        session: session.clone(),
+        scope,
+        machine_id,
+        shutdown_rx: shutdown_tx.subscribe(),
+    };
+
+    // 10. Init processor
+    let mut processor = P::init(&ctx, &node_config).await?;
+    log::info!("{} processor initialized", P::name());
+
+    // 11. Subscribe → process → publish loop
+    let input_topic = ctx.topic(P::input_topic());
+    let output_topic = ctx.topic(&format!("{}/data", P::name()));
+
+    let subscriber = session
+        .declare_subscriber(&input_topic)
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to subscribe to '{}': {}", input_topic, e))?;
+
+    let mut shutdown_rx = ctx.shutdown_rx.clone();
+
+    loop {
+        tokio::select! {
+            biased;
+            _ = shutdown_rx.changed() => {
+                log::info!("{} processor shutting down", P::name());
+                break;
+            }
+            sample = subscriber.recv_async() => {
+                match sample {
+                    Ok(sample) => {
+                        let bytes = sample.payload().to_bytes();
+                        let input: serde_json::Value = match serde_json::from_slice(&bytes) {
+                            Ok(v) => v,
+                            Err(_) => {
+                                let text = String::from_utf8_lossy(&bytes);
+                                serde_json::Value::String(text.to_string())
+                            }
+                        };
+                        match processor.process(&ctx, input).await {
+                            Ok(Some(output)) => {
+                                if let Err(e) = session.put(&output_topic, output.to_string()).await {
+                                    log::warn!("{}: publish failed: {}", P::name(), e);
+                                }
+                            }
+                            Ok(None) => {} // filtered out
+                            Err(e) => {
+                                log::warn!("{}: process error: {}", P::name(), e);
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        log::warn!("{}: subscriber error: {}", P::name(), e);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    log::info!("{} processor shut down", P::name());
+    Ok(())
+}

--- a/crates/bubbaloop-node-sdk/src/sink.rs
+++ b/crates/bubbaloop-node-sdk/src/sink.rs
@@ -1,0 +1,164 @@
+//! Sink trait — data-consuming nodes that subscribe to Zenoh topics and act on data.
+//!
+//! Implement `Sink` for a data consumer (e.g., actuator, logger, alerter).
+//! The SDK handles: session setup, health heartbeat, config loading,
+//! schema registration, topic construction, and the subscribe→execute loop.
+
+use crate::NodeContext;
+use serde::de::DeserializeOwned;
+
+/// Trait for data-consuming nodes.
+///
+/// A Sink subscribes to a Zenoh topic and processes each incoming message.
+/// The SDK runs the subscriber loop automatically; the node author only
+/// implements `init()` and `execute()`.
+#[async_trait::async_trait]
+pub trait Sink: Send + Sync + 'static {
+    /// Node-specific configuration type (deserialized from YAML).
+    type Config: DeserializeOwned + Send + Sync + 'static;
+
+    /// Human-readable node name (must match `name` in `node.yaml`).
+    fn name() -> &'static str;
+
+    /// Protobuf FileDescriptorSet bytes for schema registration.
+    fn descriptor() -> &'static [u8];
+
+    /// Input topic suffix to subscribe to (e.g., `"temp-sensor/data"`).
+    /// Full topic: `bubbaloop/{scope}/{machine_id}/{input_topic}`.
+    fn input_topic() -> &'static str;
+
+    /// Initialize the sink after Zenoh session is established and config is loaded.
+    async fn init(ctx: &NodeContext, config: &Self::Config) -> anyhow::Result<Self>
+    where
+        Self: Sized;
+
+    /// Process an incoming message. Return `Some(json)` to publish a response,
+    /// `None` to consume silently.
+    async fn execute(
+        &mut self,
+        ctx: &NodeContext,
+        input: serde_json::Value,
+    ) -> anyhow::Result<Option<serde_json::Value>>;
+}
+
+/// Run a Sink node with the full SDK runtime.
+///
+/// Handles: logging, CLI args, config, Zenoh session, schema queryable,
+/// health heartbeat, and the `subscribe → execute` loop with graceful shutdown.
+pub async fn run_sink<S: Sink>() -> anyhow::Result<()> {
+    // 1. Init logging
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+
+    // 2. Parse CLI args
+    let args: crate::SdkArgs = argh::from_env();
+
+    // 3. Load config
+    let node_config: S::Config = crate::config::load_config(&args.config)?;
+    log::info!(
+        "{}: config loaded from {}",
+        S::name(),
+        args.config.display()
+    );
+
+    // 4. Resolve scope + machine_id
+    let scope = std::env::var("BUBBALOOP_SCOPE").unwrap_or_else(|_| "local".to_string());
+    let machine_id = std::env::var("BUBBALOOP_MACHINE_ID")
+        .unwrap_or_else(|_| {
+            hostname::get()
+                .map(|h| h.to_string_lossy().to_string())
+                .unwrap_or_else(|_| "unknown".to_string())
+        })
+        .replace('-', "_");
+
+    // 5. Setup shutdown channel
+    let (shutdown_tx, _) = crate::shutdown::setup_shutdown()?;
+
+    // 6. Open Zenoh session
+    let session = crate::zenoh_session::open_zenoh_session(&args.endpoint).await?;
+
+    // 7. Declare schema queryable
+    let _schema_queryable = crate::schema::declare_schema_queryable(
+        &session,
+        &scope,
+        &machine_id,
+        S::name(),
+        S::descriptor(),
+    )
+    .await?;
+
+    // 8. Spawn health heartbeat
+    let _health_handle = crate::health::spawn_health_heartbeat(
+        session.clone(),
+        &scope,
+        &machine_id,
+        S::name(),
+        shutdown_tx.subscribe(),
+    )
+    .await?;
+
+    // 9. Build context
+    let ctx = NodeContext {
+        session: session.clone(),
+        scope,
+        machine_id,
+        shutdown_rx: shutdown_tx.subscribe(),
+    };
+
+    // 10. Init sink
+    let mut sink = S::init(&ctx, &node_config).await?;
+    log::info!("{} sink initialized", S::name());
+
+    // 11. Subscribe loop
+    let input_topic = ctx.topic(S::input_topic());
+    let output_topic = ctx.topic(&format!("{}/data", S::name()));
+
+    let subscriber = session
+        .declare_subscriber(&input_topic)
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to subscribe to '{}': {}", input_topic, e))?;
+
+    let mut shutdown_rx = ctx.shutdown_rx.clone();
+
+    loop {
+        tokio::select! {
+            biased;
+            _ = shutdown_rx.changed() => {
+                log::info!("{} sink shutting down", S::name());
+                break;
+            }
+            sample = subscriber.recv_async() => {
+                match sample {
+                    Ok(sample) => {
+                        let bytes = sample.payload().to_bytes();
+                        let input: serde_json::Value = match serde_json::from_slice(&bytes) {
+                            Ok(v) => v,
+                            Err(_) => {
+                                // Fallback: treat as string
+                                let text = String::from_utf8_lossy(&bytes);
+                                serde_json::Value::String(text.to_string())
+                            }
+                        };
+                        match sink.execute(&ctx, input).await {
+                            Ok(Some(output)) => {
+                                if let Err(e) = session.put(&output_topic, output.to_string()).await {
+                                    log::warn!("{}: publish failed: {}", S::name(), e);
+                                }
+                            }
+                            Ok(None) => {}
+                            Err(e) => {
+                                log::warn!("{}: execute error: {}", S::name(), e);
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        log::warn!("{}: subscriber error: {}", S::name(), e);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    log::info!("{} sink shut down", S::name());
+    Ok(())
+}

--- a/crates/bubbaloop-node-sdk/src/source.rs
+++ b/crates/bubbaloop-node-sdk/src/source.rs
@@ -1,0 +1,138 @@
+//! Source trait — data-producing nodes that read on an interval and publish to Zenoh.
+//!
+//! Implement `Source` for a polling data producer (e.g., REST API, sensor).
+//! The SDK handles: session setup, health heartbeat, config loading,
+//! schema registration, topic construction, and the read→publish loop.
+
+use crate::NodeContext;
+use serde::de::DeserializeOwned;
+use std::time::Duration;
+
+/// Trait for data-producing nodes.
+///
+/// A Source reads data on a fixed interval and publishes JSON to Zenoh.
+/// The SDK runs the read loop automatically; the node author only implements
+/// `init()`, `read()`, and optionally `interval()`.
+#[async_trait::async_trait]
+pub trait Source: Send + Sync + 'static {
+    /// Node-specific configuration type (deserialized from YAML).
+    type Config: DeserializeOwned + Send + Sync + 'static;
+
+    /// Human-readable node name (must match `name` in `node.yaml`).
+    fn name() -> &'static str;
+
+    /// Protobuf FileDescriptorSet bytes for schema registration.
+    fn descriptor() -> &'static [u8];
+
+    /// Initialize the source after Zenoh session is established and config is loaded.
+    async fn init(ctx: &NodeContext, config: &Self::Config) -> anyhow::Result<Self>
+    where
+        Self: Sized;
+
+    /// Read a single value. Return `Some(json)` to publish, `None` to skip this tick.
+    async fn read(&mut self, ctx: &NodeContext) -> anyhow::Result<Option<serde_json::Value>>;
+
+    /// Interval between reads. Override to customize (default: 1 second).
+    fn interval(&self) -> Duration {
+        Duration::from_secs(1)
+    }
+}
+
+/// Run a Source node with the full SDK runtime.
+///
+/// Handles: logging, CLI args, config, Zenoh session, schema queryable,
+/// health heartbeat, and the `read → publish` loop with graceful shutdown.
+pub async fn run_source<S: Source>() -> anyhow::Result<()> {
+    // 1. Init logging
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+
+    // 2. Parse CLI args
+    let args: crate::SdkArgs = argh::from_env();
+
+    // 3. Load config
+    let node_config: S::Config = crate::config::load_config(&args.config)?;
+    log::info!(
+        "{}: config loaded from {}",
+        S::name(),
+        args.config.display()
+    );
+
+    // 4. Resolve scope + machine_id
+    let scope = std::env::var("BUBBALOOP_SCOPE").unwrap_or_else(|_| "local".to_string());
+    let machine_id = std::env::var("BUBBALOOP_MACHINE_ID")
+        .unwrap_or_else(|_| {
+            hostname::get()
+                .map(|h| h.to_string_lossy().to_string())
+                .unwrap_or_else(|_| "unknown".to_string())
+        })
+        .replace('-', "_");
+
+    // 5. Setup shutdown channel
+    let (shutdown_tx, _) = crate::shutdown::setup_shutdown()?;
+
+    // 6. Open Zenoh session
+    let session = crate::zenoh_session::open_zenoh_session(&args.endpoint).await?;
+
+    // 7. Declare schema queryable
+    let _schema_queryable = crate::schema::declare_schema_queryable(
+        &session,
+        &scope,
+        &machine_id,
+        S::name(),
+        S::descriptor(),
+    )
+    .await?;
+
+    // 8. Spawn health heartbeat
+    let _health_handle = crate::health::spawn_health_heartbeat(
+        session.clone(),
+        &scope,
+        &machine_id,
+        S::name(),
+        shutdown_tx.subscribe(),
+    )
+    .await?;
+
+    // 9. Build context
+    let ctx = NodeContext {
+        session: session.clone(),
+        scope,
+        machine_id,
+        shutdown_rx: shutdown_tx.subscribe(),
+    };
+
+    // 10. Init source
+    let mut source = S::init(&ctx, &node_config).await?;
+    log::info!("{} source initialized", S::name());
+
+    // 11. Read loop
+    let data_topic = ctx.topic(&format!("{}/data", S::name()));
+    let mut interval = tokio::time::interval(source.interval());
+    let mut shutdown_rx = ctx.shutdown_rx.clone();
+
+    loop {
+        tokio::select! {
+            biased;
+            _ = shutdown_rx.changed() => {
+                log::info!("{} source shutting down", S::name());
+                break;
+            }
+            _ = interval.tick() => {
+                match source.read(&ctx).await {
+                    Ok(Some(value)) => {
+                        if let Err(e) = session.put(&data_topic, value.to_string()).await {
+                            log::warn!("{}: publish failed: {}", S::name(), e);
+                        }
+                    }
+                    Ok(None) => {} // skip
+                    Err(e) => {
+                        log::warn!("{}: read error: {}", S::name(), e);
+                    }
+                }
+            }
+        }
+    }
+
+    log::info!("{} source shut down", S::name());
+    Ok(())
+}

--- a/crates/bubbaloop/Cargo.toml
+++ b/crates/bubbaloop/Cargo.toml
@@ -87,6 +87,11 @@ toml = "0.8"
 ratatui = { version = "0.29", default-features = false, features = ["crossterm"] }
 crossterm = { version = "0.28", features = ["event-stream"] }
 
+# Built-in driver framework
+async-trait.workspace = true
+rumqttc.workspace = true
+tokio-modbus.workspace = true
+
 # MCP server (core)
 rmcp.workspace = true
 schemars.workspace = true

--- a/crates/bubbaloop/src/agent/dispatch.rs
+++ b/crates/bubbaloop/src/agent/dispatch.rs
@@ -276,7 +276,7 @@ impl<P: PlatformOperations> Dispatcher<P> {
                 input_schema: json!({
                     "type": "object",
                     "properties": {
-                        "capability": { "type": "string", "description": "Filter by type: sensor, actuator, processor, gateway" }
+                        "capability": { "type": "string", "description": "Filter by type: source, sink, processor, gateway" }
                     },
                     "required": []
                 }),
@@ -525,6 +525,40 @@ impl<P: PlatformOperations> Dispatcher<P> {
                     "required": []
                 }),
             },
+            // ── Built-in driver tools ─────────────────────────────────
+            ToolDefinition {
+                name: "start_builtin_driver".to_string(),
+                description: "Start a built-in driver for a skill. Built-in drivers run as async \
+                    tasks inside the daemon (no binary download needed). Available: http-poll, \
+                    webhook, exec, cron-task, system, tcp-listen, udp-listen, file-watch, mqtt, modbus."
+                    .to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "skill_name": { "type": "string", "description": "Skill name" },
+                        "driver_name": { "type": "string", "description": "Built-in driver name" },
+                        "config": { "type": "object", "description": "Driver config key-value pairs" }
+                    },
+                    "required": ["skill_name", "driver_name"]
+                }),
+            },
+            ToolDefinition {
+                name: "stop_builtin_driver".to_string(),
+                description: "Stop a running built-in driver by skill name.".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "skill_name": { "type": "string", "description": "Skill name to stop" }
+                    },
+                    "required": ["skill_name"]
+                }),
+            },
+            ToolDefinition {
+                name: "list_builtin_drivers".to_string(),
+                description: "List all running built-in drivers with their skill and driver names."
+                    .to_string(),
+                input_schema: empty_object,
+            },
         ]
     }
 
@@ -577,12 +611,16 @@ impl<P: PlatformOperations> Dispatcher<P> {
             "get_system_telemetry" => self.handle_get_system_telemetry().await,
             "get_telemetry_history" => self.handle_get_telemetry_history(input).await,
             "update_telemetry_config" => self.handle_update_telemetry_config(input).await,
+            "start_builtin_driver" => self.handle_start_builtin_driver(input).await,
+            "stop_builtin_driver" => self.handle_stop_builtin_driver(input).await,
+            "list_builtin_drivers" => self.handle_list_builtin_drivers().await,
             _ => ToolResult::error(format!(
                 "Unknown tool: {}. Use your available tools: node management \
                  (list_nodes, start_node, etc.), system (read_file, write_file, \
                  run_command), memory (memory_search, memory_forget), jobs/proposals \
                  (schedule_task, list_jobs, delete_job, create_proposal, list_proposals), \
-                 or telemetry (get_system_telemetry, get_telemetry_history, update_telemetry_config).",
+                 telemetry (get_system_telemetry, get_telemetry_history, update_telemetry_config), \
+                 or drivers (start_builtin_driver, stop_builtin_driver, list_builtin_drivers).",
                 name
             )),
         };
@@ -1437,6 +1475,65 @@ impl<P: PlatformOperations> Dispatcher<P> {
             Err(e) => ToolResult::error(format!("Error updating telemetry config: {}", e)),
         }
     }
+
+    // ── Built-in driver tool handlers ──────────────────────────────
+
+    async fn handle_start_builtin_driver(&self, input: &Value) -> ToolResult {
+        let skill_name = match input.get("skill_name").and_then(|v| v.as_str()) {
+            Some(s) => s.to_string(),
+            None => return ToolResult::error("Missing required parameter: skill_name".to_string()),
+        };
+        let driver_name = match input.get("driver_name").and_then(|v| v.as_str()) {
+            Some(s) => s.to_string(),
+            None => {
+                return ToolResult::error("Missing required parameter: driver_name".to_string())
+            }
+        };
+        let config: std::collections::HashMap<String, serde_yaml::Value> = input
+            .get("config")
+            .and_then(|v| serde_json::from_value(v.clone()).ok())
+            .unwrap_or_default();
+
+        match self
+            .platform
+            .start_builtin_driver(&skill_name, &driver_name, &config)
+            .await
+        {
+            Ok(msg) => ToolResult::success(msg),
+            Err(e) => ToolResult::error(format!("Error: {}", e)),
+        }
+    }
+
+    async fn handle_stop_builtin_driver(&self, input: &Value) -> ToolResult {
+        let skill_name = match input.get("skill_name").and_then(|v| v.as_str()) {
+            Some(s) => s.to_string(),
+            None => return ToolResult::error("Missing required parameter: skill_name".to_string()),
+        };
+        match self.platform.stop_builtin_driver(&skill_name).await {
+            Ok(msg) => ToolResult::success(msg),
+            Err(e) => ToolResult::error(format!("Error: {}", e)),
+        }
+    }
+
+    async fn handle_list_builtin_drivers(&self) -> ToolResult {
+        match self.platform.list_builtin_drivers().await {
+            Ok(drivers) => {
+                let json_drivers: Vec<Value> = drivers
+                    .iter()
+                    .map(|(skill, driver)| {
+                        json!({
+                            "skill_name": skill,
+                            "driver_name": driver,
+                        })
+                    })
+                    .collect();
+                let text = serde_json::to_string_pretty(&json_drivers)
+                    .unwrap_or_else(|_| "[]".to_string());
+                ToolResult::success(text)
+            }
+            Err(e) => ToolResult::error(format!("Error: {}", e)),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -1444,7 +1541,7 @@ mod tests {
     use super::*;
     use std::collections::HashSet;
 
-    const TOOL_COUNT: usize = 37;
+    const TOOL_COUNT: usize = 40;
 
     #[test]
     fn tool_definitions_count() {

--- a/crates/bubbaloop/src/agent/prompt.rs
+++ b/crates/bubbaloop/src/agent/prompt.rs
@@ -210,9 +210,9 @@ pub fn build_system_prompt_with_soul_path(
 
     // Current node inventory
     parts.push(format!(
-        "\n## Current Sensor Inventory\n\n{}",
+        "\n## Current Node Inventory\n\n{}",
         if node_inventory.is_empty() {
-            "No sensors installed."
+            "No nodes installed."
         } else {
             node_inventory
         }
@@ -265,7 +265,7 @@ mod tests {
         let soul = Soul::default();
         let prompt = build_system_prompt(&soul, "", &[], &[], None, None, None);
         assert!(prompt.contains("Bubbaloop"));
-        assert!(prompt.contains("No sensors installed."));
+        assert!(prompt.contains("No nodes installed."));
         assert!(prompt.contains("claude-sonnet-4-20250514"));
     }
 
@@ -293,7 +293,7 @@ mod tests {
         assert!(prompt.contains("test-model"));
         assert!(prompt.contains("Operating Mode: Propose"));
         assert!(prompt.contains("cam"));
-        assert!(!prompt.contains("No sensors installed."));
+        assert!(!prompt.contains("No nodes installed."));
     }
 
     #[test]

--- a/crates/bubbaloop/src/agent/soul.rs
+++ b/crates/bubbaloop/src/agent/soul.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 
 /// Default identity prompt, embedded at compile time.
-const DEFAULT_IDENTITY: &str = r#"You are Bubbaloop, an AI agent that manages physical sensors and hardware
+const DEFAULT_IDENTITY: &str = r#"You are Bubbaloop, an AI agent that manages physical sources and devices
 through the Bubbaloop skill runtime.
 
 Your job is to keep the fleet healthy and do what the user asks.
@@ -195,7 +195,7 @@ impl Soul {
 
         let focus = prompt_with_default(
             "  Describe your agent's focus (e.g., \"home security cameras\",\n  \"weather monitoring station\", \"robot fleet\")",
-            "general-purpose sensor management",
+            "general-purpose node management",
         )?;
 
         let approval = prompt_with_default(
@@ -210,7 +210,7 @@ impl Soul {
 
         // Generate personalized identity
         let identity = format!(
-            "You are {name}, an AI agent that manages physical sensors and hardware\n\
+            "You are {name}, an AI agent that manages physical sources and devices\n\
              through the Bubbaloop skill runtime.\n\
              \n\
              Your focus: {focus}\n\

--- a/crates/bubbaloop/src/bin/bubbaloop.rs
+++ b/crates/bubbaloop/src/bin/bubbaloop.rs
@@ -240,7 +240,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             eprintln!("              setup [-a <id>]: Configure provider, model, and identity (no daemon needed)");
             eprintln!("              chat [-a agent[@machine]] [message]: Send messages to agents");
             eprintln!("              list [--all]: Show running agents and capabilities");
-            eprintln!("  up        Load skills and ensure sensor nodes are running:");
+            eprintln!("  up        Load skills and ensure source nodes are running:");
             eprintln!("              -s, --skills-dir <path>: Skills directory");
             eprintln!("              --dry-run: Show what would be done");
             eprintln!("  debug     Debug Zenoh connectivity:");

--- a/crates/bubbaloop/src/cli/daemon_client.rs
+++ b/crates/bubbaloop/src/cli/daemon_client.rs
@@ -326,6 +326,34 @@ impl DaemonClient {
         })
         .await
     }
+
+    /// Start a built-in driver for a skill.
+    pub async fn start_builtin_driver(
+        &self,
+        skill_name: &str,
+        driver_name: &str,
+        config: &std::collections::HashMap<String, serde_yaml::Value>,
+    ) -> Result<String> {
+        self.send(DaemonCommandType::StartBuiltinDriver {
+            skill_name: skill_name.to_string(),
+            driver_name: driver_name.to_string(),
+            config: config.clone(),
+        })
+        .await
+    }
+
+    /// Stop a built-in driver by skill name.
+    pub async fn stop_builtin_driver(&self, skill_name: &str) -> Result<String> {
+        self.send(DaemonCommandType::StopBuiltinDriver {
+            skill_name: skill_name.to_string(),
+        })
+        .await
+    }
+
+    /// List running built-in drivers.
+    pub async fn list_builtin_drivers(&self) -> Result<String> {
+        self.send(DaemonCommandType::ListBuiltinDrivers).await
+    }
 }
 
 /// Run the daemon status command: query manifest and print a summary.

--- a/crates/bubbaloop/src/cli/node/install.rs
+++ b/crates/bubbaloop/src/cli/node/install.rs
@@ -494,6 +494,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn test_set_executable() {
         use std::os::unix::fs::PermissionsExt;
         let dir = tempfile::tempdir().unwrap();

--- a/crates/bubbaloop/src/cli/node/mod.rs
+++ b/crates/bubbaloop/src/cli/node/mod.rs
@@ -83,6 +83,10 @@ struct InitArgs {
     #[argh(option, short = 't', default = "String::from(\"rust\")")]
     node_type: String,
 
+    /// node category: source, sink, or processor (default: source)
+    #[argh(option, short = 'k', default = "String::from(\"source\")")]
+    category: String,
+
     /// output directory (default: ./<name> in current directory)
     #[argh(option, short = 'o')]
     output: Option<String>,
@@ -518,6 +522,15 @@ fn init_node(args: InitArgs) -> Result<()> {
         )));
     }
 
+    // Validate category
+    let category = args.category.to_lowercase();
+    if !matches!(category.as_str(), "source" | "sink" | "processor") {
+        return Err(NodeError::CommandFailed(format!(
+            "Invalid category '{}'. Use: source, sink, or processor",
+            args.category
+        )));
+    }
+
     // Determine output directory (default: ./<name> in current directory)
     let output_dir = args
         .output
@@ -530,6 +543,7 @@ fn init_node(args: InitArgs) -> Result<()> {
         &args.node_type,
         &args.author,
         &args.description,
+        &category,
         &output_dir,
     )
     .map_err(|e| NodeError::CommandFailed(e.to_string()))?;

--- a/crates/bubbaloop/src/cli/up.rs
+++ b/crates/bubbaloop/src/cli/up.rs
@@ -1,4 +1,4 @@
-//! `bubbaloop up` — Load all skills and ensure sensor nodes are running.
+//! `bubbaloop up` — Load all skills and ensure source nodes are running.
 //!
 //! Reads all YAML skill files from `~/.bubbaloop/skills/`, resolves the
 //! corresponding marketplace nodes, installs missing nodes, injects
@@ -113,97 +113,134 @@ impl UpCommand {
                 }
             };
 
-            let marketplace_node = driver_entry.marketplace_node;
-            println!("  node:   {}", marketplace_node);
+            match driver_entry.tier {
+                skills::DriverTier::BuiltIn => {
+                    // ── Built-in: start as async task inside the daemon ──
+                    println!("  tier:   built-in");
 
-            let registry_node = match registry::find_by_name(&registry_nodes, marketplace_node) {
-                Some(n) => n,
-                None => {
-                    println!("  [skip] Node '{}' not in registry", marketplace_node);
-                    skipped_count += 1;
-                    continue;
-                }
-            };
-
-            // Step 1: Download if not installed locally
-            let node_dir = if is_node_installed(marketplace_node) {
-                resolve_node_dir(&registry_node)
-            } else if self.dry_run {
-                println!("  [dry-run] Would install {}", marketplace_node);
-                skipped_count += 1;
-                continue;
-            } else {
-                println!("  Installing {}...", marketplace_node);
-                let dir = marketplace::download_precompiled(&registry_node)?;
-                println!("  Downloaded to {}", dir);
-                PathBuf::from(&dir)
-            };
-
-            // Step 2: Write per-skill config (each skill gets its own file)
-            let config_path = if !skill.config.is_empty() && !self.dry_run {
-                let cfg_dir = get_bubbaloop_home().join("skills-config").join(&skill.name);
-                match write_node_config(&cfg_dir, &skill.config) {
-                    Ok(()) => {
-                        let p = cfg_dir.join("config.yaml");
-                        println!("  Config written to {}", p.display());
-                        Some(p.display().to_string())
+                    if self.dry_run {
+                        println!("  [dry-run] Would start built-in driver '{}'", skill.driver);
+                        continue;
                     }
-                    Err(e) => {
-                        println!("  [warn] Config write failed: {}", e);
-                        None
+
+                    match client
+                        .start_builtin_driver(&skill.name, &skill.driver, &skill.config)
+                        .await
+                    {
+                        Ok(msg) => {
+                            if msg.contains("already") || msg.contains("Already") {
+                                println!("  [ok] Already running");
+                                already_running += 1;
+                            } else {
+                                println!("  [ok] Started (built-in)");
+                                started_count += 1;
+                            }
+                        }
+                        Err(e) => {
+                            println!("  [err] Failed to start built-in driver: {}", e);
+                            skipped_count += 1;
+                        }
                     }
                 }
-            } else {
-                None
-            };
+                skills::DriverTier::Marketplace => {
+                    // ── Marketplace: download binary + register + systemd ──
+                    let marketplace_node = driver_entry.marketplace_node;
+                    println!("  tier:   marketplace");
+                    println!("  node:   {}", marketplace_node);
 
-            if self.dry_run {
-                println!("  [dry-run] Would register + start {}", skill.name);
-                continue;
-            }
+                    let registry_node =
+                        match registry::find_by_name(&registry_nodes, marketplace_node) {
+                            Some(n) => n,
+                            None => {
+                                println!("  [skip] Node '{}' not in registry", marketplace_node);
+                                skipped_count += 1;
+                                continue;
+                            }
+                        };
 
-            // Step 3: Register with daemon as a named instance
-            // Each skill becomes its own node instance (e.g. "entrance-cam" backed by rtsp-camera binary)
-            let node_path = node_dir.display().to_string();
-            let instance_name = &skill.name;
-            match client
-                .add_node(&node_path, Some(instance_name), config_path.as_deref())
-                .await
-            {
-                Ok(msg) => {
-                    log::debug!("Registered {}: {}", instance_name, msg);
-                }
-                Err(e) => {
-                    println!("  [warn] Could not register with daemon: {}", e);
-                    skipped_count += 1;
-                    continue;
-                }
-            }
-
-            // Step 4: Install systemd service
-            match client.send_node_command(instance_name, "install").await {
-                Ok(msg) => {
-                    log::debug!("Installed service for {}: {}", instance_name, msg);
-                }
-                Err(_) => {
-                    log::debug!("Service install for {} (may already exist)", instance_name);
-                }
-            }
-
-            // Step 5: Start the node
-            match client.send_node_command(instance_name, "start").await {
-                Ok(msg) => {
-                    if msg.contains("already") || msg.contains("Running") {
-                        println!("  [ok] Already running");
-                        already_running += 1;
+                    // Step 1: Download if not installed locally
+                    let node_dir = if is_node_installed(marketplace_node) {
+                        resolve_node_dir(&registry_node)
+                    } else if self.dry_run {
+                        println!("  [dry-run] Would install {}", marketplace_node);
+                        skipped_count += 1;
+                        continue;
                     } else {
-                        println!("  [ok] Started");
-                        started_count += 1;
+                        println!("  Installing {}...", marketplace_node);
+                        let dir = marketplace::download_precompiled(&registry_node)?;
+                        println!("  Downloaded to {}", dir);
+                        PathBuf::from(&dir)
+                    };
+
+                    // Step 2: Write per-skill config (each skill gets its own file)
+                    let config_path = if !skill.config.is_empty() && !self.dry_run {
+                        let cfg_dir = get_bubbaloop_home().join("skills-config").join(&skill.name);
+                        match write_node_config(&cfg_dir, &skill.config) {
+                            Ok(()) => {
+                                let p = cfg_dir.join("config.yaml");
+                                println!("  Config written to {}", p.display());
+                                Some(p.display().to_string())
+                            }
+                            Err(e) => {
+                                println!("  [warn] Config write failed: {}", e);
+                                None
+                            }
+                        }
+                    } else {
+                        None
+                    };
+
+                    if self.dry_run {
+                        println!("  [dry-run] Would register + start {}", skill.name);
+                        continue;
                     }
-                }
-                Err(e) => {
-                    println!("  [err] Failed to start: {}", e);
-                    skipped_count += 1;
+
+                    // Step 3: Register with daemon as a named instance
+                    let node_path = node_dir.display().to_string();
+                    let instance_name = &skill.name;
+                    match client
+                        .add_node(&node_path, Some(instance_name), config_path.as_deref())
+                        .await
+                    {
+                        Ok(msg) => {
+                            log::debug!("Registered {}: {}", instance_name, msg);
+                        }
+                        Err(e) => {
+                            println!("  [warn] Could not register with daemon: {}", e);
+                            skipped_count += 1;
+                            continue;
+                        }
+                    }
+
+                    // Step 4: Install systemd service
+                    match client.send_node_command(instance_name, "install").await {
+                        Ok(msg) => {
+                            log::debug!("Installed service for {}: {}", instance_name, msg);
+                        }
+                        Err(_) => {
+                            log::debug!(
+                                "Service install for {} (may already exist)",
+                                instance_name
+                            );
+                        }
+                    }
+
+                    // Step 5: Start the node
+                    match client.send_node_command(instance_name, "start").await {
+                        Ok(msg) => {
+                            if msg.contains("already") || msg.contains("Running") {
+                                println!("  [ok] Already running");
+                                already_running += 1;
+                            } else {
+                                println!("  [ok] Started");
+                                started_count += 1;
+                            }
+                        }
+                        Err(e) => {
+                            println!("  [err] Failed to start: {}", e);
+                            skipped_count += 1;
+                        }
+                    }
                 }
             }
         }

--- a/crates/bubbaloop/src/daemon/builtin_drivers/cron_task.rs
+++ b/crates/bubbaloop/src/daemon/builtin_drivers/cron_task.rs
@@ -1,0 +1,120 @@
+//! Cron task driver — run a command on a cron schedule, publish output to Zenoh.
+
+use super::{spawn_health_loop, BuiltinDriver, DriverConfig, DriverError, Result};
+use cron::Schedule;
+use std::str::FromStr;
+use std::time::Duration;
+
+pub struct CronTaskDriver;
+
+#[async_trait::async_trait]
+impl BuiltinDriver for CronTaskDriver {
+    fn name(&self) -> &'static str {
+        "cron-task"
+    }
+
+    async fn run(&self, config: DriverConfig) -> Result<()> {
+        let command = config.require_str("command")?;
+        let schedule_str = config.require_str("schedule")?;
+
+        // Validate command (same rules as exec driver)
+        let forbidden = ['|', ';', '&', '$', '`', '(', ')', '{', '}', '<', '>'];
+        for c in &forbidden {
+            if command.contains(*c) {
+                return Err(DriverError::ConfigError(format!(
+                    "Command contains forbidden shell metacharacter '{}'",
+                    c
+                )));
+            }
+        }
+
+        // cron crate expects 7-field or 6-field expressions; prepend "sec" if 5-field
+        let cron_expr = if schedule_str.split_whitespace().count() == 5 {
+            format!("0 {}", schedule_str)
+        } else {
+            schedule_str.clone()
+        };
+
+        let schedule = Schedule::from_str(&cron_expr)
+            .map_err(|e| DriverError::ConfigError(format!("Invalid cron: {}", e)))?;
+
+        let data_topic = config.data_topic();
+        let health_topic = config.health_topic();
+        let session = config.session.clone();
+        let mut shutdown_rx = config.shutdown_rx.clone();
+
+        // Spawn health heartbeat
+        let health_session = session.clone();
+        let health_shutdown = config.shutdown_rx.clone();
+        tokio::spawn(spawn_health_loop(
+            health_session,
+            health_topic,
+            health_shutdown,
+        ));
+
+        log::info!(
+            "[cron-task] skill='{}' command='{}' schedule='{}'",
+            config.skill_name,
+            command,
+            schedule_str
+        );
+
+        let parts: Vec<&str> = command.split_whitespace().collect();
+        if parts.is_empty() {
+            return Err(DriverError::ConfigError("Empty command".to_string()));
+        }
+
+        loop {
+            // Find next scheduled time
+            let next = match schedule.upcoming(chrono::Utc).next() {
+                Some(t) => t,
+                None => {
+                    log::warn!("[cron-task] No upcoming schedule times");
+                    break;
+                }
+            };
+
+            let now = chrono::Utc::now();
+            let delay = (next - now).to_std().unwrap_or(Duration::from_secs(1));
+
+            tokio::select! {
+                biased;
+                _ = shutdown_rx.changed() => {
+                    log::info!("[cron-task] '{}' shutting down", config.skill_name);
+                    break;
+                }
+                _ = tokio::time::sleep(delay) => {
+                    match tokio::process::Command::new(parts[0])
+                        .args(&parts[1..])
+                        .output()
+                        .await
+                    {
+                        Ok(output) => {
+                            let stdout = String::from_utf8_lossy(&output.stdout);
+                            let payload = serde_json::json!({
+                                "stdout": stdout.trim(),
+                                "exit_code": output.status.code(),
+                                "schedule": schedule_str,
+                            });
+                            if let Err(e) = session.put(&data_topic, payload.to_string()).await {
+                                log::warn!("[cron-task] publish failed: {}", e);
+                            }
+                        }
+                        Err(e) => log::warn!("[cron-task] command failed: {}", e),
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn driver_name() {
+        assert_eq!(CronTaskDriver.name(), "cron-task");
+    }
+}

--- a/crates/bubbaloop/src/daemon/builtin_drivers/exec.rs
+++ b/crates/bubbaloop/src/daemon/builtin_drivers/exec.rs
@@ -1,0 +1,110 @@
+//! Exec driver — run a shell command on a fixed interval, publish stdout to Zenoh.
+
+use super::{spawn_health_loop, BuiltinDriver, DriverConfig, DriverError, Result};
+use std::time::Duration;
+
+pub struct ExecDriver;
+
+/// Validate that a command does not contain shell metacharacters.
+fn validate_command(cmd: &str) -> Result<()> {
+    let forbidden = ['|', ';', '&', '$', '`', '(', ')', '{', '}', '<', '>'];
+    for c in forbidden {
+        if cmd.contains(c) {
+            return Err(DriverError::ConfigError(format!(
+                "Command contains forbidden shell metacharacter '{}'",
+                c
+            )));
+        }
+    }
+    Ok(())
+}
+
+#[async_trait::async_trait]
+impl BuiltinDriver for ExecDriver {
+    fn name(&self) -> &'static str {
+        "exec"
+    }
+
+    async fn run(&self, config: DriverConfig) -> Result<()> {
+        let command = config.require_str("command")?;
+        validate_command(&command)?;
+        let interval_secs = config.u64_or("interval_secs", 60);
+
+        let data_topic = config.data_topic();
+        let health_topic = config.health_topic();
+        let session = config.session.clone();
+        let mut shutdown_rx = config.shutdown_rx.clone();
+
+        // Spawn health heartbeat
+        let health_session = session.clone();
+        let health_shutdown = config.shutdown_rx.clone();
+        tokio::spawn(spawn_health_loop(
+            health_session,
+            health_topic,
+            health_shutdown,
+        ));
+
+        let mut interval = tokio::time::interval(Duration::from_secs(interval_secs));
+        log::info!(
+            "[exec] skill='{}' command='{}' interval={}s",
+            config.skill_name,
+            command,
+            interval_secs
+        );
+
+        let parts: Vec<&str> = command.split_whitespace().collect();
+        if parts.is_empty() {
+            return Err(DriverError::ConfigError("Empty command".to_string()));
+        }
+
+        loop {
+            tokio::select! {
+                biased;
+                _ = shutdown_rx.changed() => {
+                    log::info!("[exec] '{}' shutting down", config.skill_name);
+                    break;
+                }
+                _ = interval.tick() => {
+                    match tokio::process::Command::new(parts[0])
+                        .args(&parts[1..])
+                        .output()
+                        .await
+                    {
+                        Ok(output) => {
+                            let stdout = String::from_utf8_lossy(&output.stdout);
+                            let payload = serde_json::json!({
+                                "stdout": stdout.trim(),
+                                "exit_code": output.status.code(),
+                            });
+                            if let Err(e) = session.put(&data_topic, payload.to_string()).await {
+                                log::warn!("[exec] publish failed: {}", e);
+                            }
+                        }
+                        Err(e) => log::warn!("[exec] command failed: {}", e),
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn driver_name() {
+        assert_eq!(ExecDriver.name(), "exec");
+    }
+
+    #[test]
+    fn rejects_shell_metacharacters() {
+        assert!(validate_command("ls -la").is_ok());
+        assert!(validate_command("echo hello | grep h").is_err());
+        assert!(validate_command("rm -rf /; echo done").is_err());
+        assert!(validate_command("cmd && cmd2").is_err());
+        assert!(validate_command("$(whoami)").is_err());
+        assert!(validate_command("`whoami`").is_err());
+    }
+}

--- a/crates/bubbaloop/src/daemon/builtin_drivers/file_watch.rs
+++ b/crates/bubbaloop/src/daemon/builtin_drivers/file_watch.rs
@@ -1,0 +1,104 @@
+//! File watch driver — watch file/directory for changes and publish events to Zenoh.
+
+use super::{spawn_health_loop, BuiltinDriver, DriverConfig, DriverError, Result};
+use notify::{Event, RecursiveMode, Watcher};
+use std::path::PathBuf;
+
+pub struct FileWatchDriver;
+
+#[async_trait::async_trait]
+impl BuiltinDriver for FileWatchDriver {
+    fn name(&self) -> &'static str {
+        "file-watch"
+    }
+
+    async fn run(&self, config: DriverConfig) -> Result<()> {
+        let path_str = config.require_str("path")?;
+        let recursive = config.bool_or("recursive", false);
+
+        let watch_path = PathBuf::from(&path_str);
+        if !watch_path.exists() {
+            return Err(DriverError::ConfigError(format!(
+                "Watch path does not exist: {}",
+                path_str
+            )));
+        }
+
+        let data_topic = config.data_topic();
+        let health_topic = config.health_topic();
+        let session = config.session.clone();
+        let mut shutdown_rx = config.shutdown_rx.clone();
+
+        // Spawn health heartbeat
+        let health_session = session.clone();
+        let health_shutdown = config.shutdown_rx.clone();
+        tokio::spawn(spawn_health_loop(
+            health_session,
+            health_topic,
+            health_shutdown,
+        ));
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<Event>(256);
+
+        let mode = if recursive {
+            RecursiveMode::Recursive
+        } else {
+            RecursiveMode::NonRecursive
+        };
+
+        let mut watcher =
+            notify::recommended_watcher(move |res: std::result::Result<Event, notify::Error>| {
+                if let Ok(event) = res {
+                    let _ = tx.blocking_send(event);
+                }
+            })
+            .map_err(|e| DriverError::StartFailed(format!("watcher init: {}", e)))?;
+
+        watcher
+            .watch(&watch_path, mode)
+            .map_err(|e| DriverError::StartFailed(format!("watch '{}': {}", path_str, e)))?;
+
+        log::info!(
+            "[file-watch] skill='{}' watching '{}' recursive={}",
+            config.skill_name,
+            path_str,
+            recursive
+        );
+
+        loop {
+            tokio::select! {
+                biased;
+                _ = shutdown_rx.changed() => {
+                    log::info!("[file-watch] '{}' shutting down", config.skill_name);
+                    break;
+                }
+                event = rx.recv() => {
+                    match event {
+                        Some(evt) => {
+                            let paths: Vec<String> = evt.paths.iter().map(|p| p.display().to_string()).collect();
+                            let payload = serde_json::json!({
+                                "kind": format!("{:?}", evt.kind),
+                                "paths": paths,
+                            });
+                            if let Err(e) = session.put(&data_topic, payload.to_string()).await {
+                                log::warn!("[file-watch] publish failed: {}", e);
+                            }
+                        }
+                        None => break,
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn driver_name() {
+        assert_eq!(FileWatchDriver.name(), "file-watch");
+    }
+}

--- a/crates/bubbaloop/src/daemon/builtin_drivers/http_poll.rs
+++ b/crates/bubbaloop/src/daemon/builtin_drivers/http_poll.rs
@@ -1,0 +1,89 @@
+//! HTTP poll driver — GET/POST a URL on a fixed interval, publish response to Zenoh.
+
+use super::{spawn_health_loop, BuiltinDriver, DriverConfig, Result};
+use std::time::Duration;
+
+pub struct HttpPollDriver;
+
+#[async_trait::async_trait]
+impl BuiltinDriver for HttpPollDriver {
+    fn name(&self) -> &'static str {
+        "http-poll"
+    }
+
+    async fn run(&self, config: DriverConfig) -> Result<()> {
+        let url = config.require_str("url")?;
+        let method = config.str_or("method", "GET").to_uppercase();
+        let interval_secs = config.u64_or("interval_secs", 60);
+        let body = config.str_or("body", "");
+
+        let data_topic = config.data_topic();
+        let health_topic = config.health_topic();
+        let session = config.session.clone();
+        let mut shutdown_rx = config.shutdown_rx.clone();
+
+        // Spawn health heartbeat
+        let health_session = session.clone();
+        let health_shutdown = config.shutdown_rx.clone();
+        tokio::spawn(spawn_health_loop(
+            health_session,
+            health_topic,
+            health_shutdown,
+        ));
+
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(30))
+            .build()
+            .map_err(|e| super::DriverError::StartFailed(e.to_string()))?;
+
+        let mut interval = tokio::time::interval(Duration::from_secs(interval_secs));
+        log::info!(
+            "[http-poll] skill='{}' url='{}' method={} interval={}s",
+            config.skill_name,
+            url,
+            method,
+            interval_secs
+        );
+
+        loop {
+            tokio::select! {
+                biased;
+                _ = shutdown_rx.changed() => {
+                    log::info!("[http-poll] '{}' shutting down", config.skill_name);
+                    break;
+                }
+                _ = interval.tick() => {
+                    let request = match method.as_str() {
+                        "POST" => client.post(&url).body(body.clone()),
+                        _ => client.get(&url),
+                    };
+
+                    match request.send().await {
+                        Ok(resp) => {
+                            match resp.text().await {
+                                Ok(text) => {
+                                    if let Err(e) = session.put(&data_topic, text).await {
+                                        log::warn!("[http-poll] publish failed: {}", e);
+                                    }
+                                }
+                                Err(e) => log::warn!("[http-poll] body read failed: {}", e),
+                            }
+                        }
+                        Err(e) => log::warn!("[http-poll] request to '{}' failed: {}", url, e),
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn driver_name() {
+        assert_eq!(HttpPollDriver.name(), "http-poll");
+    }
+}

--- a/crates/bubbaloop/src/daemon/builtin_drivers/mod.rs
+++ b/crates/bubbaloop/src/daemon/builtin_drivers/mod.rs
@@ -1,0 +1,358 @@
+//! Built-in driver framework — lightweight drivers that run as async tasks inside the daemon.
+//!
+//! Built-in drivers handle common protocols (HTTP, TCP, UDP, MQTT, Modbus, cron, sysinfo, file-watch)
+//! without needing a separate binary or systemd service. They publish to the same Zenoh topic
+//! hierarchy as external nodes, so consumers see a uniform interface.
+
+pub mod cron_task;
+pub mod exec;
+pub mod file_watch;
+pub mod http_poll;
+pub mod modbus;
+pub mod mqtt;
+pub mod system;
+pub mod tcp_listen;
+pub mod udp_listen;
+pub mod webhook;
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+use thiserror::Error;
+use tokio::sync::watch;
+
+#[derive(Error, Debug)]
+pub enum DriverError {
+    #[error("Driver start failed: {0}")]
+    StartFailed(String),
+    #[error("Configuration error: missing required param '{0}'")]
+    MissingParam(String),
+    #[error("Configuration error: {0}")]
+    ConfigError(String),
+    #[error("Already running: {0}")]
+    AlreadyRunning(String),
+    #[error("Not running: {0}")]
+    NotRunning(String),
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+pub type Result<T> = std::result::Result<T, DriverError>;
+
+/// Configuration passed to a built-in driver at startup.
+pub struct DriverConfig {
+    pub session: Arc<zenoh::Session>,
+    pub scope: String,
+    pub machine_id: String,
+    pub skill_name: String,
+    pub params: HashMap<String, serde_yaml::Value>,
+    pub shutdown_rx: watch::Receiver<()>,
+}
+
+impl DriverConfig {
+    /// Standard data topic: `bubbaloop/{scope}/{machine_id}/{skill_name}/data`
+    pub fn data_topic(&self) -> String {
+        format!(
+            "bubbaloop/{}/{}/{}/data",
+            self.scope, self.machine_id, self.skill_name
+        )
+    }
+
+    /// Standard health topic: `bubbaloop/{scope}/{machine_id}/health/{skill_name}`
+    pub fn health_topic(&self) -> String {
+        format!(
+            "bubbaloop/{}/{}/health/{}",
+            self.scope, self.machine_id, self.skill_name
+        )
+    }
+
+    /// Extract a required string param from the config map.
+    pub fn require_str(&self, key: &str) -> Result<String> {
+        self.params
+            .get(key)
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+            .ok_or_else(|| DriverError::MissingParam(key.to_string()))
+    }
+
+    /// Extract an optional string param with a default.
+    pub fn str_or(&self, key: &str, default: &str) -> String {
+        self.params
+            .get(key)
+            .and_then(|v| v.as_str())
+            .unwrap_or(default)
+            .to_string()
+    }
+
+    /// Extract an optional u64 param with a default.
+    pub fn u64_or(&self, key: &str, default: u64) -> u64 {
+        self.params
+            .get(key)
+            .and_then(|v| v.as_u64())
+            .unwrap_or(default)
+    }
+
+    /// Extract an optional u16 param with a default.
+    pub fn u16_or(&self, key: &str, default: u16) -> u16 {
+        self.params
+            .get(key)
+            .and_then(|v| v.as_u64())
+            .map(|v| v as u16)
+            .unwrap_or(default)
+    }
+
+    /// Extract an optional bool param with a default.
+    pub fn bool_or(&self, key: &str, default: bool) -> bool {
+        self.params
+            .get(key)
+            .and_then(|v| v.as_bool())
+            .unwrap_or(default)
+    }
+}
+
+/// Trait that all built-in drivers implement.
+#[async_trait::async_trait]
+pub trait BuiltinDriver: Send + Sync + 'static {
+    /// Human-readable driver name (e.g., "http-poll").
+    fn name(&self) -> &'static str;
+
+    /// Start the driver. Runs until shutdown_rx fires or an unrecoverable error occurs.
+    async fn run(&self, config: DriverConfig) -> Result<()>;
+}
+
+/// Handle to a running built-in driver task.
+pub struct DriverHandle {
+    pub skill_name: String,
+    pub driver_name: String,
+    task: tokio::task::JoinHandle<()>,
+    shutdown_tx: watch::Sender<()>,
+}
+
+impl DriverHandle {
+    /// Stop the driver gracefully.
+    pub async fn stop(self) {
+        let _ = self.shutdown_tx.send(());
+        let _ = self.task.await;
+    }
+}
+
+/// Registry of running built-in driver instances.
+pub struct DriverRegistry {
+    handles: tokio::sync::Mutex<HashMap<String, DriverHandle>>,
+}
+
+impl Default for DriverRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DriverRegistry {
+    pub fn new() -> Self {
+        Self {
+            handles: tokio::sync::Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Start a built-in driver for a skill.
+    pub async fn start_driver(
+        &self,
+        driver: Box<dyn BuiltinDriver>,
+        session: Arc<zenoh::Session>,
+        scope: String,
+        machine_id: String,
+        skill_name: String,
+        params: HashMap<String, serde_yaml::Value>,
+    ) -> Result<()> {
+        let mut handles = self.handles.lock().await;
+        if handles.contains_key(&skill_name) {
+            return Err(DriverError::AlreadyRunning(skill_name));
+        }
+
+        let (shutdown_tx, shutdown_rx) = watch::channel(());
+        let driver_name = driver.name().to_string();
+        let driver_name_clone = driver_name.clone();
+        let skill = skill_name.clone();
+
+        let config = DriverConfig {
+            session,
+            scope,
+            machine_id,
+            skill_name: skill.clone(),
+            params,
+            shutdown_rx,
+        };
+
+        let task = tokio::spawn(async move {
+            if let Err(e) = driver.run(config).await {
+                log::error!(
+                    "Built-in driver '{}' for skill '{}' failed: {}",
+                    driver_name_clone,
+                    skill,
+                    e
+                );
+            }
+        });
+
+        handles.insert(
+            skill_name.clone(),
+            DriverHandle {
+                skill_name,
+                driver_name,
+                task,
+                shutdown_tx,
+            },
+        );
+
+        Ok(())
+    }
+
+    /// Stop a running driver by skill name.
+    pub async fn stop_driver(&self, skill_name: &str) -> Result<()> {
+        let handle = {
+            let mut handles = self.handles.lock().await;
+            handles
+                .remove(skill_name)
+                .ok_or_else(|| DriverError::NotRunning(skill_name.to_string()))?
+        };
+        handle.stop().await;
+        Ok(())
+    }
+
+    /// Check if a driver is running.
+    pub async fn is_running(&self, skill_name: &str) -> bool {
+        self.handles.lock().await.contains_key(skill_name)
+    }
+
+    /// List all running drivers as (skill_name, driver_name) pairs.
+    pub async fn list_running(&self) -> Vec<(String, String)> {
+        self.handles
+            .lock()
+            .await
+            .values()
+            .map(|h| (h.skill_name.clone(), h.driver_name.clone()))
+            .collect()
+    }
+
+    /// Stop all drivers (for daemon shutdown).
+    pub async fn stop_all(&self) {
+        let handles: Vec<DriverHandle> = {
+            let mut map = self.handles.lock().await;
+            map.drain().map(|(_, h)| h).collect()
+        };
+        for handle in handles {
+            handle.stop().await;
+        }
+    }
+}
+
+/// Factory function: create a driver instance by name.
+pub fn create_driver(driver_name: &str) -> Option<Box<dyn BuiltinDriver>> {
+    match driver_name {
+        "http-poll" => Some(Box::new(http_poll::HttpPollDriver)),
+        "webhook" => Some(Box::new(webhook::WebhookDriver)),
+        "exec" => Some(Box::new(exec::ExecDriver)),
+        "cron-task" => Some(Box::new(cron_task::CronTaskDriver)),
+        "system" => Some(Box::new(system::SystemDriver)),
+        "tcp-listen" => Some(Box::new(tcp_listen::TcpListenDriver)),
+        "udp-listen" => Some(Box::new(udp_listen::UdpListenDriver)),
+        "file-watch" => Some(Box::new(file_watch::FileWatchDriver)),
+        "mqtt" => Some(Box::new(mqtt::MqttDriver)),
+        "modbus" => Some(Box::new(modbus::ModbusDriver)),
+        _ => None,
+    }
+}
+
+/// Spawn a health heartbeat loop that publishes "ok" every 5 seconds.
+pub async fn spawn_health_loop(
+    session: Arc<zenoh::Session>,
+    topic: String,
+    mut shutdown_rx: watch::Receiver<()>,
+) {
+    let mut interval = tokio::time::interval(Duration::from_secs(5));
+    loop {
+        tokio::select! {
+            biased;
+            _ = shutdown_rx.changed() => break,
+            _ = interval.tick() => {
+                if let Err(e) = session.put(&topic, "ok").await {
+                    log::warn!("Health publish to '{}' failed: {}", topic, e);
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_driver_known_names() {
+        let names = [
+            "http-poll",
+            "webhook",
+            "exec",
+            "cron-task",
+            "system",
+            "tcp-listen",
+            "udp-listen",
+            "file-watch",
+            "mqtt",
+            "modbus",
+        ];
+        for name in names {
+            assert!(
+                create_driver(name).is_some(),
+                "create_driver('{}') returned None",
+                name
+            );
+        }
+    }
+
+    #[test]
+    fn create_driver_unknown_returns_none() {
+        assert!(create_driver("not-a-driver").is_none());
+        assert!(create_driver("").is_none());
+    }
+
+    #[test]
+    fn driver_config_param_helpers() {
+        let mut params = HashMap::new();
+        params.insert(
+            "url".to_string(),
+            serde_yaml::Value::String("http://example.com".to_string()),
+        );
+        params.insert(
+            "interval_secs".to_string(),
+            serde_yaml::Value::Number(serde_yaml::Number::from(30u64)),
+        );
+        params.insert("recursive".to_string(), serde_yaml::Value::Bool(true));
+
+        // require_str
+        assert_eq!(
+            params.get("url").and_then(|v| v.as_str()).unwrap(),
+            "http://example.com"
+        );
+        assert!(params.get("missing").and_then(|v| v.as_str()).is_none());
+
+        // u64_or equivalent
+        assert_eq!(
+            params
+                .get("interval_secs")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(60),
+            30
+        );
+        assert_eq!(
+            params.get("missing").and_then(|v| v.as_u64()).unwrap_or(60),
+            60
+        );
+
+        // bool_or equivalent
+        assert!(params
+            .get("recursive")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false));
+    }
+}

--- a/crates/bubbaloop/src/daemon/builtin_drivers/modbus.rs
+++ b/crates/bubbaloop/src/daemon/builtin_drivers/modbus.rs
@@ -1,0 +1,149 @@
+//! Modbus TCP driver — read registers on a fixed interval and publish to Zenoh.
+
+use super::{spawn_health_loop, BuiltinDriver, DriverConfig, DriverError, Result};
+use std::net::SocketAddr;
+use std::time::Duration;
+use tokio_modbus::prelude::*;
+
+pub struct ModbusDriver;
+
+#[async_trait::async_trait]
+impl BuiltinDriver for ModbusDriver {
+    fn name(&self) -> &'static str {
+        "modbus"
+    }
+
+    async fn run(&self, config: DriverConfig) -> Result<()> {
+        let host = config.require_str("host")?;
+        let port = config.u16_or("port", 502);
+        let register = config.u64_or("register", 0) as u16;
+        let register_type = config.str_or("type", "u16");
+        let interval_secs = config.u64_or("interval_secs", 2);
+        let count = match register_type.as_str() {
+            "float32" | "f32" => 2u16,
+            "u32" | "i32" => 2,
+            _ => 1, // u16, i16
+        };
+
+        let data_topic = config.data_topic();
+        let health_topic = config.health_topic();
+        let session = config.session.clone();
+        let mut shutdown_rx = config.shutdown_rx.clone();
+
+        // Spawn health heartbeat
+        let health_session = session.clone();
+        let health_shutdown = config.shutdown_rx.clone();
+        tokio::spawn(spawn_health_loop(
+            health_session,
+            health_topic,
+            health_shutdown,
+        ));
+
+        let addr: SocketAddr = format!("{}:{}", host, port)
+            .parse()
+            .map_err(|e| DriverError::ConfigError(format!("Invalid address: {}", e)))?;
+
+        let mut ctx = tcp::connect(addr)
+            .await
+            .map_err(|e| DriverError::StartFailed(format!("Modbus connect to {}: {}", addr, e)))?;
+
+        let mut interval = tokio::time::interval(Duration::from_secs(interval_secs));
+
+        log::info!(
+            "[modbus] skill='{}' host='{}:{}' register={} type={} interval={}s",
+            config.skill_name,
+            host,
+            port,
+            register,
+            register_type,
+            interval_secs
+        );
+
+        loop {
+            tokio::select! {
+                biased;
+                _ = shutdown_rx.changed() => {
+                    log::info!("[modbus] '{}' shutting down", config.skill_name);
+                    break;
+                }
+                _ = interval.tick() => {
+                    match ctx.read_holding_registers(register, count).await {
+                        Ok(Ok(registers)) => {
+                            let value = decode_registers(&registers, &register_type);
+                            let payload = serde_json::json!({
+                                "register": register,
+                                "type": register_type,
+                                "value": value,
+                                "raw": registers,
+                            });
+                            if let Err(e) = session.put(&data_topic, payload.to_string()).await {
+                                log::warn!("[modbus] publish failed: {}", e);
+                            }
+                        }
+                        Ok(Err(exception)) => log::warn!("[modbus] register {} exception: {:?}", register, exception),
+                        Err(e) => log::warn!("[modbus] read register {} failed: {}", register, e),
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+fn decode_registers(regs: &[u16], register_type: &str) -> serde_json::Value {
+    match register_type {
+        "u16" => serde_json::json!(regs.first().copied().unwrap_or(0)),
+        "i16" => serde_json::json!(regs.first().copied().unwrap_or(0) as i16),
+        "u32" if regs.len() >= 2 => {
+            let val = ((regs[0] as u32) << 16) | (regs[1] as u32);
+            serde_json::json!(val)
+        }
+        "i32" if regs.len() >= 2 => {
+            let val = (((regs[0] as u32) << 16) | (regs[1] as u32)) as i32;
+            serde_json::json!(val)
+        }
+        "float32" | "f32" if regs.len() >= 2 => {
+            let bits = ((regs[0] as u32) << 16) | (regs[1] as u32);
+            let val = f32::from_bits(bits);
+            serde_json::json!(val)
+        }
+        _ => serde_json::json!(regs),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn driver_name() {
+        assert_eq!(ModbusDriver.name(), "modbus");
+    }
+
+    #[test]
+    fn decode_u16() {
+        assert_eq!(decode_registers(&[42], "u16"), serde_json::json!(42));
+    }
+
+    #[test]
+    fn decode_i16() {
+        // 0xFFFF = 65535 unsigned, -1 as i16
+        assert_eq!(decode_registers(&[0xFFFF], "i16"), serde_json::json!(-1));
+    }
+
+    #[test]
+    fn decode_u32() {
+        // 0x0001_0000 = 65536
+        assert_eq!(decode_registers(&[1, 0], "u32"), serde_json::json!(65536));
+    }
+
+    #[test]
+    fn decode_float32() {
+        // IEEE 754: 42.0 = 0x42280000
+        let bits: u32 = 42.0f32.to_bits();
+        let hi = (bits >> 16) as u16;
+        let lo = (bits & 0xFFFF) as u16;
+        let result = decode_registers(&[hi, lo], "float32");
+        assert_eq!(result, serde_json::json!(42.0));
+    }
+}

--- a/crates/bubbaloop/src/daemon/builtin_drivers/mqtt.rs
+++ b/crates/bubbaloop/src/daemon/builtin_drivers/mqtt.rs
@@ -1,0 +1,112 @@
+//! MQTT driver — subscribe to MQTT topics and publish messages to Zenoh.
+
+use super::{spawn_health_loop, BuiltinDriver, DriverConfig, DriverError, Result};
+use rumqttc::{AsyncClient, Event, MqttOptions, Packet, QoS};
+use std::time::Duration;
+
+pub struct MqttDriver;
+
+#[async_trait::async_trait]
+impl BuiltinDriver for MqttDriver {
+    fn name(&self) -> &'static str {
+        "mqtt"
+    }
+
+    async fn run(&self, config: DriverConfig) -> Result<()> {
+        let broker = config.require_str("broker")?;
+        let mqtt_topic = config.require_str("topic")?;
+        let qos_val = config.u64_or("qos", 1);
+        let qos = match qos_val {
+            0 => QoS::AtMostOnce,
+            1 => QoS::AtLeastOnce,
+            _ => QoS::ExactlyOnce,
+        };
+
+        // Parse broker URL: mqtt://host:port
+        let broker_clean = broker
+            .trim_start_matches("mqtt://")
+            .trim_start_matches("tcp://");
+        let (host, port) = if let Some((h, p)) = broker_clean.rsplit_once(':') {
+            (h.to_string(), p.parse::<u16>().unwrap_or(1883))
+        } else {
+            (broker_clean.to_string(), 1883)
+        };
+
+        let data_topic = config.data_topic();
+        let health_topic = config.health_topic();
+        let session = config.session.clone();
+        let mut shutdown_rx = config.shutdown_rx.clone();
+
+        // Spawn health heartbeat
+        let health_session = session.clone();
+        let health_shutdown = config.shutdown_rx.clone();
+        tokio::spawn(spawn_health_loop(
+            health_session,
+            health_topic,
+            health_shutdown,
+        ));
+
+        let client_id = format!("bubbaloop-{}", config.skill_name);
+        let mut mqttoptions = MqttOptions::new(&client_id, &host, port);
+        mqttoptions.set_keep_alive(Duration::from_secs(30));
+
+        let (client, mut eventloop) = AsyncClient::new(mqttoptions, 100);
+
+        client
+            .subscribe(&mqtt_topic, qos)
+            .await
+            .map_err(|e| DriverError::StartFailed(format!("MQTT subscribe: {}", e)))?;
+
+        log::info!(
+            "[mqtt] skill='{}' broker='{}:{}' topic='{}' qos={}",
+            config.skill_name,
+            host,
+            port,
+            mqtt_topic,
+            qos_val
+        );
+
+        loop {
+            tokio::select! {
+                biased;
+                _ = shutdown_rx.changed() => {
+                    log::info!("[mqtt] '{}' shutting down", config.skill_name);
+                    client.disconnect().await.ok();
+                    break;
+                }
+                notification = eventloop.poll() => {
+                    match notification {
+                        Ok(Event::Incoming(Packet::Publish(publish))) => {
+                            let payload_str = String::from_utf8_lossy(&publish.payload);
+                            let payload = serde_json::json!({
+                                "topic": publish.topic,
+                                "payload": payload_str.as_ref(),
+                                "qos": publish.qos as u8,
+                            });
+                            if let Err(e) = session.put(&data_topic, payload.to_string()).await {
+                                log::warn!("[mqtt] publish to Zenoh failed: {}", e);
+                            }
+                        }
+                        Ok(_) => {} // Ignore non-publish events (ConnAck, SubAck, etc.)
+                        Err(e) => {
+                            log::warn!("[mqtt] eventloop error: {}", e);
+                            // Brief backoff before reconnect attempt
+                            tokio::time::sleep(Duration::from_secs(5)).await;
+                        }
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn driver_name() {
+        assert_eq!(MqttDriver.name(), "mqtt");
+    }
+}

--- a/crates/bubbaloop/src/daemon/builtin_drivers/system.rs
+++ b/crates/bubbaloop/src/daemon/builtin_drivers/system.rs
@@ -1,0 +1,87 @@
+//! System driver — publish CPU, RAM, disk metrics via sysinfo.
+
+use super::{spawn_health_loop, BuiltinDriver, DriverConfig, Result};
+use std::time::Duration;
+use sysinfo::System;
+
+pub struct SystemDriver;
+
+#[async_trait::async_trait]
+impl BuiltinDriver for SystemDriver {
+    fn name(&self) -> &'static str {
+        "system"
+    }
+
+    async fn run(&self, config: DriverConfig) -> Result<()> {
+        let interval_secs = config.u64_or("interval_secs", 30);
+
+        let data_topic = config.data_topic();
+        let health_topic = config.health_topic();
+        let session = config.session.clone();
+        let mut shutdown_rx = config.shutdown_rx.clone();
+
+        // Spawn health heartbeat
+        let health_session = session.clone();
+        let health_shutdown = config.shutdown_rx.clone();
+        tokio::spawn(spawn_health_loop(
+            health_session,
+            health_topic,
+            health_shutdown,
+        ));
+
+        let mut interval = tokio::time::interval(Duration::from_secs(interval_secs));
+        let mut sys = System::new_all();
+
+        log::info!(
+            "[system] skill='{}' interval={}s",
+            config.skill_name,
+            interval_secs
+        );
+
+        loop {
+            tokio::select! {
+                biased;
+                _ = shutdown_rx.changed() => {
+                    log::info!("[system] '{}' shutting down", config.skill_name);
+                    break;
+                }
+                _ = interval.tick() => {
+                    sys.refresh_all();
+
+                    let payload = serde_json::json!({
+                        "cpu_usage_percent": sys.global_cpu_usage(),
+                        "memory_total_bytes": sys.total_memory(),
+                        "memory_used_bytes": sys.used_memory(),
+                        "memory_available_bytes": sys.available_memory(),
+                        "swap_total_bytes": sys.total_swap(),
+                        "swap_used_bytes": sys.used_swap(),
+                    });
+
+                    if let Err(e) = session.put(&data_topic, payload.to_string()).await {
+                        log::warn!("[system] publish failed: {}", e);
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn driver_name() {
+        assert_eq!(SystemDriver.name(), "system");
+    }
+
+    #[test]
+    fn sysinfo_produces_valid_data() {
+        let mut sys = System::new_all();
+        sys.refresh_all();
+        // Just verify these don't panic and return reasonable values
+        let _ = sys.global_cpu_usage();
+        assert!(sys.total_memory() > 0);
+    }
+}

--- a/crates/bubbaloop/src/daemon/builtin_drivers/tcp_listen.rs
+++ b/crates/bubbaloop/src/daemon/builtin_drivers/tcp_listen.rs
@@ -1,0 +1,95 @@
+//! TCP listen driver — accept raw TCP connections and publish incoming data to Zenoh.
+
+use super::{spawn_health_loop, BuiltinDriver, DriverConfig, Result};
+use tokio::io::AsyncReadExt;
+
+pub struct TcpListenDriver;
+
+#[async_trait::async_trait]
+impl BuiltinDriver for TcpListenDriver {
+    fn name(&self) -> &'static str {
+        "tcp-listen"
+    }
+
+    async fn run(&self, config: DriverConfig) -> Result<()> {
+        let port = config.u16_or("port", 5000);
+
+        let data_topic = config.data_topic();
+        let health_topic = config.health_topic();
+        let session = config.session.clone();
+        let mut shutdown_rx = config.shutdown_rx.clone();
+
+        // Spawn health heartbeat
+        let health_session = session.clone();
+        let health_shutdown = config.shutdown_rx.clone();
+        tokio::spawn(spawn_health_loop(
+            health_session,
+            health_topic,
+            health_shutdown,
+        ));
+
+        // Security: bind localhost only
+        let addr = format!("127.0.0.1:{}", port);
+        let listener = tokio::net::TcpListener::bind(&addr)
+            .await
+            .map_err(|e| super::DriverError::StartFailed(format!("bind {}: {}", addr, e)))?;
+
+        log::info!(
+            "[tcp-listen] skill='{}' listening on {}",
+            config.skill_name,
+            addr
+        );
+
+        loop {
+            tokio::select! {
+                biased;
+                _ = shutdown_rx.changed() => {
+                    log::info!("[tcp-listen] '{}' shutting down", config.skill_name);
+                    break;
+                }
+                accept = listener.accept() => {
+                    match accept {
+                        Ok((mut stream, peer)) => {
+                            let session = session.clone();
+                            let topic = data_topic.clone();
+                            tokio::spawn(async move {
+                                let mut buf = vec![0u8; 65536];
+                                loop {
+                                    match stream.read(&mut buf).await {
+                                        Ok(0) => break, // connection closed
+                                        Ok(n) => {
+                                            let data = String::from_utf8_lossy(&buf[..n]);
+                                            let payload = serde_json::json!({
+                                                "peer": peer.to_string(),
+                                                "data": data.trim(),
+                                            });
+                                            if let Err(e) = session.put(&topic, payload.to_string()).await {
+                                                log::warn!("[tcp-listen] publish failed: {}", e);
+                                            }
+                                        }
+                                        Err(e) => {
+                                            log::warn!("[tcp-listen] read error from {}: {}", peer, e);
+                                            break;
+                                        }
+                                    }
+                                }
+                            });
+                        }
+                        Err(e) => log::warn!("[tcp-listen] accept failed: {}", e),
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn driver_name() {
+        assert_eq!(TcpListenDriver.name(), "tcp-listen");
+    }
+}

--- a/crates/bubbaloop/src/daemon/builtin_drivers/udp_listen.rs
+++ b/crates/bubbaloop/src/daemon/builtin_drivers/udp_listen.rs
@@ -1,0 +1,79 @@
+//! UDP listen driver — receive UDP packets and publish to Zenoh.
+
+use super::{spawn_health_loop, BuiltinDriver, DriverConfig, Result};
+
+pub struct UdpListenDriver;
+
+#[async_trait::async_trait]
+impl BuiltinDriver for UdpListenDriver {
+    fn name(&self) -> &'static str {
+        "udp-listen"
+    }
+
+    async fn run(&self, config: DriverConfig) -> Result<()> {
+        let port = config.u16_or("port", 5001);
+
+        let data_topic = config.data_topic();
+        let health_topic = config.health_topic();
+        let session = config.session.clone();
+        let mut shutdown_rx = config.shutdown_rx.clone();
+
+        // Spawn health heartbeat
+        let health_session = session.clone();
+        let health_shutdown = config.shutdown_rx.clone();
+        tokio::spawn(spawn_health_loop(
+            health_session,
+            health_topic,
+            health_shutdown,
+        ));
+
+        // Security: bind localhost only
+        let addr = format!("127.0.0.1:{}", port);
+        let socket = tokio::net::UdpSocket::bind(&addr)
+            .await
+            .map_err(|e| super::DriverError::StartFailed(format!("bind {}: {}", addr, e)))?;
+
+        log::info!(
+            "[udp-listen] skill='{}' listening on {}",
+            config.skill_name,
+            addr
+        );
+
+        let mut buf = vec![0u8; 65536];
+        loop {
+            tokio::select! {
+                biased;
+                _ = shutdown_rx.changed() => {
+                    log::info!("[udp-listen] '{}' shutting down", config.skill_name);
+                    break;
+                }
+                result = socket.recv_from(&mut buf) => {
+                    match result {
+                        Ok((n, peer)) => {
+                            let data = String::from_utf8_lossy(&buf[..n]);
+                            let payload = serde_json::json!({
+                                "peer": peer.to_string(),
+                                "data": data.trim(),
+                            });
+                            if let Err(e) = session.put(&data_topic, payload.to_string()).await {
+                                log::warn!("[udp-listen] publish failed: {}", e);
+                            }
+                        }
+                        Err(e) => log::warn!("[udp-listen] recv failed: {}", e),
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn driver_name() {
+        assert_eq!(UdpListenDriver.name(), "udp-listen");
+    }
+}

--- a/crates/bubbaloop/src/daemon/builtin_drivers/webhook.rs
+++ b/crates/bubbaloop/src/daemon/builtin_drivers/webhook.rs
@@ -1,0 +1,88 @@
+//! Webhook driver — listen for inbound HTTP POSTs and publish payloads to Zenoh.
+
+use super::{spawn_health_loop, BuiltinDriver, DriverConfig, Result};
+use axum::{extract::State, routing::post, Router};
+use std::sync::Arc;
+
+struct WebhookState {
+    session: Arc<zenoh::Session>,
+    data_topic: String,
+}
+
+pub struct WebhookDriver;
+
+#[async_trait::async_trait]
+impl BuiltinDriver for WebhookDriver {
+    fn name(&self) -> &'static str {
+        "webhook"
+    }
+
+    async fn run(&self, config: DriverConfig) -> Result<()> {
+        let port = config.u16_or("port", 9090);
+        let path = config.str_or("path", "/");
+
+        let data_topic = config.data_topic();
+        let health_topic = config.health_topic();
+        let session = config.session.clone();
+        let mut shutdown_rx = config.shutdown_rx.clone();
+
+        // Spawn health heartbeat
+        let health_session = session.clone();
+        let health_shutdown = config.shutdown_rx.clone();
+        tokio::spawn(spawn_health_loop(
+            health_session,
+            health_topic,
+            health_shutdown,
+        ));
+
+        let state = Arc::new(WebhookState {
+            session,
+            data_topic,
+        });
+
+        let app = Router::new()
+            .route(&path, post(handle_webhook))
+            .with_state(state);
+
+        // Security: bind localhost only
+        let addr = format!("127.0.0.1:{}", port);
+        let listener = tokio::net::TcpListener::bind(&addr)
+            .await
+            .map_err(|e| super::DriverError::StartFailed(format!("bind {}: {}", addr, e)))?;
+
+        log::info!(
+            "[webhook] skill='{}' listening on {} path='{}'",
+            config.skill_name,
+            addr,
+            path
+        );
+
+        axum::serve(listener, app)
+            .with_graceful_shutdown(async move {
+                let _ = shutdown_rx.changed().await;
+                log::info!("[webhook] '{}' shutting down", config.skill_name);
+            })
+            .await
+            .map_err(|e| super::DriverError::StartFailed(e.to_string()))?;
+
+        Ok(())
+    }
+}
+
+async fn handle_webhook(State(state): State<Arc<WebhookState>>, body: String) -> &'static str {
+    if let Err(e) = state.session.put(&state.data_topic, body).await {
+        log::warn!("[webhook] publish failed: {}", e);
+        return "error";
+    }
+    "ok"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn driver_name() {
+        assert_eq!(WebhookDriver.name(), "webhook");
+    }
+}

--- a/crates/bubbaloop/src/daemon/gateway.rs
+++ b/crates/bubbaloop/src/daemon/gateway.rs
@@ -51,6 +51,16 @@ pub enum DaemonCommandType {
     EnableAutostart { name: String },
     /// Disable autostart for a node.
     DisableAutostart { name: String },
+    /// Start a built-in driver for a skill.
+    StartBuiltinDriver {
+        skill_name: String,
+        driver_name: String,
+        config: std::collections::HashMap<String, serde_yaml::Value>,
+    },
+    /// Stop a built-in driver by skill name.
+    StopBuiltinDriver { skill_name: String },
+    /// List running built-in drivers.
+    ListBuiltinDrivers,
     /// Query daemon health.
     Health,
     /// Graceful daemon shutdown.
@@ -258,6 +268,15 @@ mod tests {
             DaemonCommandType::DisableAutostart {
                 name: "cam".to_string(),
             },
+            DaemonCommandType::StartBuiltinDriver {
+                skill_name: "my-sensor".to_string(),
+                driver_name: "system".to_string(),
+                config: std::collections::HashMap::new(),
+            },
+            DaemonCommandType::StopBuiltinDriver {
+                skill_name: "my-sensor".to_string(),
+            },
+            DaemonCommandType::ListBuiltinDrivers,
             DaemonCommandType::Health,
             DaemonCommandType::Shutdown,
         ];

--- a/crates/bubbaloop/src/daemon/mod.rs
+++ b/crates/bubbaloop/src/daemon/mod.rs
@@ -1,6 +1,6 @@
 //! Bubbaloop Skill Runtime
 //!
-//! Lightweight daemon for managing sensor/actuator nodes as discoverable skills.
+//! Lightweight daemon for managing source/sink nodes as discoverable skills.
 //!
 //! # Architecture
 //!
@@ -13,6 +13,7 @@
 //! The daemon never makes autonomous decisions — it's a passive skill runtime.
 
 pub mod belief_updater;
+pub mod builtin_drivers;
 pub mod constraints;
 pub mod context_provider;
 pub mod federated;
@@ -120,17 +121,19 @@ async fn run_daemon_gateway(
     mcp_port: u16,
     shutdown_tx: tokio::sync::watch::Sender<()>,
     mut shutdown_rx: tokio::sync::watch::Receiver<()>,
+    driver_registry: std::sync::Arc<builtin_drivers::DriverRegistry>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let scope = std::env::var("BUBBALOOP_SCOPE").unwrap_or_else(|_| "local".to_string());
     let machine_id = util::get_machine_id();
     let start_time = std::time::Instant::now();
 
     // Create platform for dispatching commands
-    let platform = std::sync::Arc::new(crate::mcp::platform::DaemonPlatform::new(
+    let platform = std::sync::Arc::new(crate::mcp::platform::DaemonPlatform::with_driver_registry(
         node_manager.clone(),
         session.clone(),
         scope.clone(),
         machine_id.clone(),
+        driver_registry,
     ));
 
     // 1. Register manifest queryable
@@ -410,6 +413,34 @@ async fn dispatch_daemon_command(
             let text = serde_json::to_string(&manifest).unwrap_or_default();
             events.push(gateway::DaemonEvent::result(id, &text));
         }
+        gateway::DaemonCommandType::StartBuiltinDriver {
+            skill_name,
+            driver_name,
+            config,
+        } => {
+            match platform
+                .start_builtin_driver(skill_name, driver_name, config)
+                .await
+            {
+                Ok(msg) => events.push(gateway::DaemonEvent::result(id, &msg)),
+                Err(e) => events.push(gateway::DaemonEvent::error(id, &e.to_string())),
+            }
+        }
+        gateway::DaemonCommandType::StopBuiltinDriver { skill_name } => {
+            match platform.stop_builtin_driver(skill_name).await {
+                Ok(msg) => events.push(gateway::DaemonEvent::result(id, &msg)),
+                Err(e) => events.push(gateway::DaemonEvent::error(id, &e.to_string())),
+            }
+        }
+        gateway::DaemonCommandType::ListBuiltinDrivers => {
+            match platform.list_builtin_drivers().await {
+                Ok(drivers) => {
+                    let text = serde_json::to_string(&drivers).unwrap_or_default();
+                    events.push(gateway::DaemonEvent::result(id, &text));
+                }
+                Err(e) => events.push(gateway::DaemonEvent::error(id, &e.to_string())),
+            }
+        }
         gateway::DaemonCommandType::Shutdown => {
             log::info!("[Gateway] Received shutdown command");
             events.push(gateway::DaemonEvent::result(id, "shutting down"));
@@ -496,6 +527,9 @@ pub async fn run(zenoh_endpoint: Option<String>) -> Result<(), Box<dyn std::erro
         telemetry::TelemetryService::start(node_manager.clone(), shutdown_rx.clone()).await,
     );
 
+    // Create shared driver registry for built-in drivers
+    let driver_registry = std::sync::Arc::new(builtin_drivers::DriverRegistry::new());
+
     // Start MCP server (HTTP on port 8088)
     let mcp_port: u16 = std::env::var("BUBBALOOP_MCP_PORT")
         .ok()
@@ -541,6 +575,7 @@ pub async fn run(zenoh_endpoint: Option<String>) -> Result<(), Box<dyn std::erro
         let gw_manager = node_manager.clone();
         let gw_shutdown_tx = shutdown_tx.clone();
         let gw_shutdown_rx = shutdown_rx.clone();
+        let gw_driver_registry = driver_registry.clone();
         tokio::spawn(async move {
             if let Err(e) = run_daemon_gateway(
                 gw_session,
@@ -548,6 +583,7 @@ pub async fn run(zenoh_endpoint: Option<String>) -> Result<(), Box<dyn std::erro
                 mcp_port,
                 gw_shutdown_tx,
                 gw_shutdown_rx,
+                gw_driver_registry,
             )
             .await
             {
@@ -569,6 +605,9 @@ pub async fn run(zenoh_endpoint: Option<String>) -> Result<(), Box<dyn std::erro
     shutdown_wait.changed().await.ok();
 
     log::info!("Shutdown signal received, waiting for tasks to gracefully finish...");
+
+    // Stop all built-in drivers
+    driver_registry.stop_all().await;
 
     // Wait for all tasks to complete gracefully (they all listen to shutdown_rx)
     let _ = tokio::join!(mcp_task, agent_task, gateway_task);

--- a/crates/bubbaloop/src/daemon/registry.rs
+++ b/crates/bubbaloop/src/daemon/registry.rs
@@ -34,8 +34,10 @@ pub type Result<T> = std::result::Result<T, RegistryError>;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum Capability {
-    Sensor,
-    Actuator,
+    #[serde(alias = "sensor")]
+    Source,
+    #[serde(alias = "actuator")]
+    Sink,
     Processor,
     Gateway,
 }

--- a/crates/bubbaloop/src/marketplace.rs
+++ b/crates/bubbaloop/src/marketplace.rs
@@ -118,10 +118,17 @@ pub fn verify_sha256(path: &Path, expected: &str) -> Result<()> {
 }
 
 /// Set a file as executable (chmod 755).
+#[cfg(unix)]
 pub fn set_executable(path: &Path) -> Result<()> {
     use std::os::unix::fs::PermissionsExt;
     let perms = std::fs::Permissions::from_mode(0o755);
     std::fs::set_permissions(path, perms)?;
+    Ok(())
+}
+
+/// Set a file as executable (no-op on Windows — executability is determined by extension).
+#[cfg(not(unix))]
+pub fn set_executable(_path: &Path) -> Result<()> {
     Ok(())
 }
 

--- a/crates/bubbaloop/src/mcp/daemon_platform.rs
+++ b/crates/bubbaloop/src/mcp/daemon_platform.rs
@@ -18,6 +18,8 @@ pub struct DaemonPlatform {
     pub machine_id: String,
     /// Cached path to the default agent's memory.db.
     agent_db_path: PathBuf,
+    /// Registry of running built-in drivers.
+    driver_registry: Arc<crate::daemon::builtin_drivers::DriverRegistry>,
 }
 
 impl DaemonPlatform {
@@ -29,12 +31,33 @@ impl DaemonPlatform {
         machine_id: String,
     ) -> Self {
         let agent_db_path = Self::compute_agent_db_path();
+        let driver_registry = Arc::new(crate::daemon::builtin_drivers::DriverRegistry::new());
         Self {
             node_manager,
             session,
             scope,
             machine_id,
             agent_db_path,
+            driver_registry,
+        }
+    }
+
+    /// Create a new DaemonPlatform with an existing DriverRegistry (for shared shutdown).
+    pub fn with_driver_registry(
+        node_manager: Arc<NodeManager>,
+        session: Arc<Session>,
+        scope: String,
+        machine_id: String,
+        driver_registry: Arc<crate::daemon::builtin_drivers::DriverRegistry>,
+    ) -> Self {
+        let agent_db_path = Self::compute_agent_db_path();
+        Self {
+            node_manager,
+            session,
+            scope,
+            machine_id,
+            agent_db_path,
+            driver_registry,
         }
     }
 
@@ -700,6 +723,57 @@ impl PlatformOperations for DaemonPlatform {
         store
             .world_state_snapshot()
             .map_err(|e| PlatformError::Internal(e.to_string()))
+    }
+
+    async fn start_builtin_driver(
+        &self,
+        skill_name: &str,
+        driver_name: &str,
+        config: &std::collections::HashMap<String, serde_yaml::Value>,
+    ) -> PlatformResult<String> {
+        let driver =
+            crate::daemon::builtin_drivers::create_driver(driver_name).ok_or_else(|| {
+                PlatformError::InvalidInput(format!("Unknown built-in driver: {}", driver_name))
+            })?;
+
+        self.driver_registry
+            .start_driver(
+                driver,
+                self.session.clone(),
+                self.scope.clone(),
+                self.machine_id.clone(),
+                skill_name.to_string(),
+                config.clone(),
+            )
+            .await
+            .map_err(|e| PlatformError::CommandFailed(e.to_string()))?;
+
+        log::info!(
+            "[MCP] tool=start_builtin_driver skill={} driver={}",
+            skill_name,
+            driver_name
+        );
+        Ok(format!(
+            "Started built-in driver '{}' for skill '{}'",
+            driver_name, skill_name
+        ))
+    }
+
+    async fn stop_builtin_driver(&self, skill_name: &str) -> PlatformResult<String> {
+        self.driver_registry
+            .stop_driver(skill_name)
+            .await
+            .map_err(|e| PlatformError::CommandFailed(e.to_string()))?;
+
+        log::info!("[MCP] tool=stop_builtin_driver skill={}", skill_name);
+        Ok(format!(
+            "Stopped built-in driver for skill '{}'",
+            skill_name
+        ))
+    }
+
+    async fn list_builtin_drivers(&self) -> PlatformResult<Vec<(String, String)>> {
+        Ok(self.driver_registry.list_running().await)
     }
 
     async fn clear_episodic_memory(&self, older_than_days: u32) -> PlatformResult<String> {

--- a/crates/bubbaloop/src/mcp/mock_platform.rs
+++ b/crates/bubbaloop/src/mcp/mock_platform.rs
@@ -46,7 +46,7 @@ impl MockPlatform {
                     "version": "1.0.0",
                     "type": "rust",
                     "description": "A test node",
-                    "capabilities": ["sensor"],
+                    "capabilities": ["source"],
                     "publishes": [],
                     "subscribes": [],
                     "commands": [],
@@ -193,6 +193,29 @@ impl PlatformOperations for MockPlatform {
 
     async fn delete_job(&self, id: &str) -> PlatformResult<String> {
         Ok(format!("mock: job '{}' deleted", id))
+    }
+
+    async fn start_builtin_driver(
+        &self,
+        skill_name: &str,
+        driver_name: &str,
+        _config: &std::collections::HashMap<String, serde_yaml::Value>,
+    ) -> PlatformResult<String> {
+        Ok(format!(
+            "mock: started built-in driver '{}' for skill '{}'",
+            driver_name, skill_name
+        ))
+    }
+
+    async fn stop_builtin_driver(&self, skill_name: &str) -> PlatformResult<String> {
+        Ok(format!(
+            "mock: stopped built-in driver for skill '{}'",
+            skill_name
+        ))
+    }
+
+    async fn list_builtin_drivers(&self) -> PlatformResult<Vec<(String, String)>> {
+        Ok(vec![])
     }
 
     async fn clear_episodic_memory(&self, older_than_days: u32) -> PlatformResult<String> {

--- a/crates/bubbaloop/src/mcp/mod.rs
+++ b/crates/bubbaloop/src/mcp/mod.rs
@@ -58,7 +58,7 @@ impl<P: PlatformOperations> ServerHandler for BubbaLoopMcpServer<P> {
             capabilities: ServerCapabilities::builder().enable_tools().build(),
             server_info: Implementation::from_build_env(),
             instructions: Some(
-                "Bubbaloop skill runtime for AI agents. Controls physical sensor nodes via MCP.\n\n\
+                "Bubbaloop skill runtime for AI agents. Controls physical source/sink nodes via MCP.\n\n\
                  **Discovery:** list_nodes, get_node_health, get_node_schema, get_stream_info, discover_capabilities\n\
                  **Lifecycle:** start_node, stop_node, restart_node, build_node, install_node, remove_node, uninstall_node, clean_node\n\
                  **Autostart:** enable_autostart, disable_autostart\n\
@@ -74,7 +74,7 @@ impl<P: PlatformOperations> ServerHandler for BubbaLoopMcpServer<P> {
                  **Alerts:** register_alert, unregister_alert — reactive rules that spike arousal when world state matches\n\
                  **System:** get_system_status, get_machine_info, query_zenoh, discover_nodes\n\n\
                  install_node accepts marketplace names (e.g., 'rtsp-camera'), local paths, or GitHub 'user/repo' format.\n\
-                 Use discover_capabilities to find nodes by capability (sensor, actuator, processor, gateway).\n\
+                 Use discover_capabilities to find nodes by capability (source, sink, processor, gateway).\n\
                  Use get_node_manifest for full node details including topics, commands, and requirements.\n\
                  Streaming data flows through Zenoh (not MCP). Use get_stream_info to get Zenoh connection params.\n\
                  Missions are created by dropping a YAML file into ~/.bubbaloop/agents/{id}/missions/ — the daemon picks them up automatically.\n\

--- a/crates/bubbaloop/src/mcp/platform.rs
+++ b/crates/bubbaloop/src/mcp/platform.rs
@@ -151,6 +151,27 @@ pub trait PlatformOperations: Send + Sync + 'static {
         recurrence: bool,
     ) -> impl std::future::Future<Output = PlatformResult<String>> + Send;
 
+    // ── Built-in drivers ──────────────────────────────────────────
+
+    /// Start a built-in driver for a skill.
+    fn start_builtin_driver(
+        &self,
+        skill_name: &str,
+        driver_name: &str,
+        config: &std::collections::HashMap<String, serde_yaml::Value>,
+    ) -> impl std::future::Future<Output = PlatformResult<String>> + Send;
+
+    /// Stop a built-in driver by skill name.
+    fn stop_builtin_driver(
+        &self,
+        skill_name: &str,
+    ) -> impl std::future::Future<Output = PlatformResult<String>> + Send;
+
+    /// List running built-in drivers.
+    fn list_builtin_drivers(
+        &self,
+    ) -> impl std::future::Future<Output = PlatformResult<Vec<(String, String)>>> + Send;
+
     // ── Memory admin ────────────────────────────────────────────────
 
     /// List jobs, optionally filtered by status. Returns JSON string.

--- a/crates/bubbaloop/src/mcp/tools.rs
+++ b/crates/bubbaloop/src/mcp/tools.rs
@@ -45,7 +45,7 @@ pub(crate) struct InstallNodeRequest {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub(crate) struct DiscoverCapabilitiesParams {
-    /// Filter by capability type: "sensor", "actuator", "processor", "gateway". Omit for all.
+    /// Filter by capability type: "source", "sink", "processor", "gateway". Omit for all.
     #[serde(default)]
     capability: Option<String>,
 }
@@ -184,6 +184,23 @@ pub(crate) struct UpdateBeliefRequest {
     /// Free-form notes.
     #[serde(default)]
     notes: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub(crate) struct StartBuiltinDriverRequest {
+    /// Skill name (from ~/.bubbaloop/skills/*.yaml)
+    skill_name: String,
+    /// Built-in driver name (e.g., "http-poll", "system", "webhook")
+    driver_name: String,
+    /// Driver configuration as key-value pairs (e.g., {"url": "https://example.com", "interval_secs": 60})
+    #[serde(default)]
+    config: std::collections::HashMap<String, serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub(crate) struct StopBuiltinDriverRequest {
+    /// Skill name to stop the driver for
+    skill_name: String,
 }
 
 // ── Tool implementations ──────────────────────────────────────────
@@ -543,7 +560,7 @@ impl<P: PlatformOperations> BubbaLoopMcpServer<P> {
     }
 
     #[tool(
-        description = "Discover available node capabilities. Returns nodes grouped by capability type (sensor, actuator, processor, gateway). Optionally filter by a single capability type."
+        description = "Discover available node capabilities. Returns nodes grouped by capability type (source, sink, processor, gateway). Optionally filter by a single capability type."
     )]
     async fn discover_capabilities(
         &self,
@@ -1302,6 +1319,86 @@ impl<P: PlatformOperations> BubbaLoopMcpServer<P> {
             Ok(entries) => Ok(CallToolResult::success(vec![Content::text(
                 serde_json::to_string_pretty(&entries).unwrap_or_else(|_| "[]".to_string()),
             )])),
+            Err(e) => Ok(CallToolResult::success(vec![Content::text(format!(
+                "Error: {}",
+                e
+            ))])),
+        }
+    }
+
+    // ── Built-in driver tools ──────────────────────────────────────
+
+    #[tool(
+        description = "Start a built-in driver for a skill. Built-in drivers run as async tasks inside the daemon (no binary download needed). Available drivers: http-poll, webhook, exec, cron-task, system, tcp-listen, udp-listen, file-watch, mqtt, modbus. Admin only."
+    )]
+    async fn start_builtin_driver(
+        &self,
+        Parameters(req): Parameters<StartBuiltinDriverRequest>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        log::info!(
+            "[MCP] tool=start_builtin_driver skill={} driver={}",
+            req.skill_name,
+            req.driver_name
+        );
+        // Convert serde_json::Value config to serde_yaml::Value for the platform layer
+        let yaml_config: std::collections::HashMap<String, serde_yaml::Value> = req
+            .config
+            .into_iter()
+            .map(|(k, v)| {
+                let yaml_val: serde_yaml::Value =
+                    serde_yaml::from_str(&v.to_string()).unwrap_or(serde_yaml::Value::Null);
+                (k, yaml_val)
+            })
+            .collect();
+        match self
+            .platform
+            .start_builtin_driver(&req.skill_name, &req.driver_name, &yaml_config)
+            .await
+        {
+            Ok(msg) => Ok(CallToolResult::success(vec![Content::text(msg)])),
+            Err(e) => Ok(CallToolResult::success(vec![Content::text(format!(
+                "Error: {}",
+                e
+            ))])),
+        }
+    }
+
+    #[tool(description = "Stop a running built-in driver by skill name. Admin only.")]
+    async fn stop_builtin_driver(
+        &self,
+        Parameters(req): Parameters<StopBuiltinDriverRequest>,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        log::info!("[MCP] tool=stop_builtin_driver skill={}", req.skill_name);
+        match self.platform.stop_builtin_driver(&req.skill_name).await {
+            Ok(msg) => Ok(CallToolResult::success(vec![Content::text(msg)])),
+            Err(e) => Ok(CallToolResult::success(vec![Content::text(format!(
+                "Error: {}",
+                e
+            ))])),
+        }
+    }
+
+    #[tool(
+        description = "List all running built-in drivers. Returns skill name and driver name for each active driver."
+    )]
+    async fn list_builtin_drivers(&self) -> Result<CallToolResult, rmcp::ErrorData> {
+        log::info!("[MCP] tool=list_builtin_drivers");
+        match self.platform.list_builtin_drivers().await {
+            Ok(drivers) => {
+                let json_drivers: Vec<serde_json::Value> = drivers
+                    .iter()
+                    .map(|(skill, driver)| {
+                        serde_json::json!({
+                            "skill_name": skill,
+                            "driver_name": driver,
+                        })
+                    })
+                    .collect();
+                Ok(CallToolResult::success(vec![Content::text(
+                    serde_json::to_string_pretty(&json_drivers)
+                        .unwrap_or_else(|_| "[]".to_string()),
+                )]))
+            }
             Err(e) => Ok(CallToolResult::success(vec![Content::text(format!(
                 "Error: {}",
                 e

--- a/crates/bubbaloop/src/skills/mod.rs
+++ b/crates/bubbaloop/src/skills/mod.rs
@@ -1,7 +1,7 @@
-//! YAML Skill Loader — configure sensors with 5-line YAML files.
+//! YAML Skill Loader — configure sources with 5-line YAML files.
 //!
 //! Skills map a human-readable driver name to a marketplace node,
-//! letting users express sensor configuration without writing Rust.
+//! letting users express source configuration without writing Rust.
 //!
 //! Example skill file (`~/.bubbaloop/skills/my-camera.yaml`):
 //! ```yaml
@@ -61,55 +61,111 @@ fn default_enabled() -> bool {
     true
 }
 
-/// Maps a driver name to the corresponding marketplace node.
+/// How a driver is executed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DriverTier {
+    /// Runs as a tokio task inside the daemon process.
+    BuiltIn,
+    /// Downloaded as a precompiled binary, runs as a systemd service.
+    Marketplace,
+}
+
+/// Maps a driver name to execution tier and marketplace node fallback.
 #[derive(Debug, Clone, Copy)]
 pub struct DriverEntry {
     pub driver_name: &'static str,
     pub marketplace_node: &'static str,
     pub description: &'static str,
+    pub tier: DriverTier,
 }
 
-/// Built-in driver catalog.
+/// Driver catalog — built-in drivers first, then marketplace drivers.
 pub static DRIVER_CATALOG: &[DriverEntry] = &[
-    DriverEntry {
-        driver_name: "rtsp",
-        marketplace_node: "rtsp-camera",
-        description: "IP cameras, NVRs",
-    },
-    DriverEntry {
-        driver_name: "v4l2",
-        marketplace_node: "v4l2-camera",
-        description: "USB webcams, CSI cameras",
-    },
-    DriverEntry {
-        driver_name: "serial",
-        marketplace_node: "serial-bridge",
-        description: "Arduino, UART, RS-485",
-    },
-    DriverEntry {
-        driver_name: "gpio",
-        marketplace_node: "gpio-controller",
-        description: "Buttons, LEDs, relays",
-    },
+    // ── Built-in drivers (run inside daemon as async tasks) ──
     DriverEntry {
         driver_name: "http-poll",
         marketplace_node: "http-sensor",
         description: "REST APIs, weather services",
+        tier: DriverTier::BuiltIn,
     },
     DriverEntry {
-        driver_name: "mqtt",
-        marketplace_node: "mqtt-bridge",
-        description: "Home automation, industrial",
+        driver_name: "webhook",
+        marketplace_node: "webhook-listener",
+        description: "Incoming HTTP hooks",
+        tier: DriverTier::BuiltIn,
     },
     DriverEntry {
-        driver_name: "modbus",
-        marketplace_node: "modbus-bridge",
-        description: "Industrial IoT, PLCs",
+        driver_name: "exec",
+        marketplace_node: "exec-runner",
+        description: "Shell command on interval",
+        tier: DriverTier::BuiltIn,
+    },
+    DriverEntry {
+        driver_name: "cron-task",
+        marketplace_node: "cron-runner",
+        description: "Shell command on cron schedule",
+        tier: DriverTier::BuiltIn,
     },
     DriverEntry {
         driver_name: "system",
         marketplace_node: "system-telemetry",
         description: "CPU, RAM, disk, temperature",
+        tier: DriverTier::BuiltIn,
+    },
+    DriverEntry {
+        driver_name: "tcp-listen",
+        marketplace_node: "tcp-listener",
+        description: "Raw TCP socket listener",
+        tier: DriverTier::BuiltIn,
+    },
+    DriverEntry {
+        driver_name: "udp-listen",
+        marketplace_node: "udp-listener",
+        description: "Raw UDP socket listener",
+        tier: DriverTier::BuiltIn,
+    },
+    DriverEntry {
+        driver_name: "file-watch",
+        marketplace_node: "file-watcher",
+        description: "File/dir change watcher",
+        tier: DriverTier::BuiltIn,
+    },
+    DriverEntry {
+        driver_name: "mqtt",
+        marketplace_node: "mqtt-bridge",
+        description: "Home automation, industrial",
+        tier: DriverTier::BuiltIn,
+    },
+    DriverEntry {
+        driver_name: "modbus",
+        marketplace_node: "modbus-bridge",
+        description: "Industrial IoT, PLCs",
+        tier: DriverTier::BuiltIn,
+    },
+    // ── Marketplace drivers (external binary, systemd) ──
+    DriverEntry {
+        driver_name: "rtsp",
+        marketplace_node: "rtsp-camera",
+        description: "IP cameras, NVRs",
+        tier: DriverTier::Marketplace,
+    },
+    DriverEntry {
+        driver_name: "v4l2",
+        marketplace_node: "v4l2-camera",
+        description: "USB webcams, CSI cameras",
+        tier: DriverTier::Marketplace,
+    },
+    DriverEntry {
+        driver_name: "serial",
+        marketplace_node: "serial-bridge",
+        description: "Arduino, UART, RS-485",
+        tier: DriverTier::Marketplace,
+    },
+    DriverEntry {
+        driver_name: "gpio",
+        marketplace_node: "gpio-controller",
+        description: "Buttons, LEDs, relays",
+        tier: DriverTier::Marketplace,
     },
 ];
 
@@ -253,21 +309,30 @@ actions:
     // ── resolve_driver ───────────────────────────────────────────────────────
 
     #[test]
-    fn resolve_all_builtin_drivers() {
+    fn resolve_all_catalog_drivers() {
         let cases = [
-            ("rtsp", "rtsp-camera"),
-            ("v4l2", "v4l2-camera"),
-            ("serial", "serial-bridge"),
-            ("gpio", "gpio-controller"),
-            ("http-poll", "http-sensor"),
-            ("mqtt", "mqtt-bridge"),
-            ("modbus", "modbus-bridge"),
-            ("system", "system-telemetry"),
+            // Built-in drivers
+            ("http-poll", "http-sensor", DriverTier::BuiltIn),
+            ("webhook", "webhook-listener", DriverTier::BuiltIn),
+            ("exec", "exec-runner", DriverTier::BuiltIn),
+            ("cron-task", "cron-runner", DriverTier::BuiltIn),
+            ("system", "system-telemetry", DriverTier::BuiltIn),
+            ("tcp-listen", "tcp-listener", DriverTier::BuiltIn),
+            ("udp-listen", "udp-listener", DriverTier::BuiltIn),
+            ("file-watch", "file-watcher", DriverTier::BuiltIn),
+            ("mqtt", "mqtt-bridge", DriverTier::BuiltIn),
+            ("modbus", "modbus-bridge", DriverTier::BuiltIn),
+            // Marketplace drivers
+            ("rtsp", "rtsp-camera", DriverTier::Marketplace),
+            ("v4l2", "v4l2-camera", DriverTier::Marketplace),
+            ("serial", "serial-bridge", DriverTier::Marketplace),
+            ("gpio", "gpio-controller", DriverTier::Marketplace),
         ];
-        for (driver, node) in cases {
+        for (driver, node, tier) in cases {
             let entry = resolve_driver(driver)
                 .unwrap_or_else(|| panic!("driver '{}' not found in catalog", driver));
             assert_eq!(entry.marketplace_node, node);
+            assert_eq!(entry.tier, tier, "wrong tier for driver '{}'", driver);
         }
     }
 

--- a/crates/bubbaloop/src/templates.rs
+++ b/crates/bubbaloop/src/templates.rs
@@ -32,16 +32,18 @@ pub struct TemplateVars {
     pub node_name_snake: String,  // snake_case: my_sensor
     pub author: String,
     pub description: String,
+    pub category: String, // source, sink, or processor
 }
 
 impl TemplateVars {
-    pub fn new(name: &str, author: &str, description: &str) -> Self {
+    pub fn new(name: &str, author: &str, description: &str, category: &str) -> Self {
         Self {
             node_name: to_kebab_case(name),
             node_name_pascal: to_pascal_case(name),
             node_name_snake: to_snake_case(name),
             author: author.to_string(),
             description: description.to_string(),
+            category: category.to_string(),
         }
     }
 }
@@ -154,6 +156,8 @@ pub fn process_template(content: &str, vars: &TemplateVars) -> String {
         .replace("{{node_name}}", &vars.node_name)
         .replace("{{node_name_pascal}}", &vars.node_name_pascal)
         .replace("{{node_name_snake}}", &vars.node_name_snake)
+        // Category variable (source, sink, processor)
+        .replace("{{category}}", &vars.category)
         // Legacy plugin-style variables (for backwards compatibility with *-plugin templates)
         .replace("{{plugin_name}}", &vars.node_name)
         .replace("{{plugin_name_pascal}}", &vars.node_name_pascal)
@@ -168,6 +172,7 @@ pub fn create_node_at(
     node_type: &str,
     author: &str,
     description: &str,
+    category: &str,
     output_dir: &Path,
 ) -> Result<PathBuf> {
     // Validate node type
@@ -196,7 +201,7 @@ pub fn create_node_at(
     log::info!("Creating node at: {}", output_dir.display());
 
     // Template variables
-    let vars = TemplateVars::new(name, author, description);
+    let vars = TemplateVars::new(name, author, description, category);
 
     // Copy and process template files
     copy_template(&template_dir, output_dir, &vars)?;
@@ -243,7 +248,7 @@ mod tests {
 
     #[test]
     fn test_process_template_substitution() {
-        let vars = TemplateVars::new("my-sensor", "Test Author", "A test node");
+        let vars = TemplateVars::new("my-sensor", "Test Author", "A test node", "source");
         let input = "name = \"{{node_name}}\"\nclass {{node_name_pascal}}Node\nmod {{node_name_snake}}\nauthor: {{author}}\ndesc: {{description}}";
         let result = process_template(input, &vars);
         assert!(result.contains("name = \"my-sensor\""));
@@ -254,8 +259,16 @@ mod tests {
     }
 
     #[test]
+    fn test_process_template_category_substitution() {
+        let vars = TemplateVars::new("my-node", "Author", "desc", "sink");
+        let input = "capabilities: [{{category}}]";
+        let result = process_template(input, &vars);
+        assert_eq!(result, "capabilities: [sink]");
+    }
+
+    #[test]
     fn test_process_template_legacy_plugin_vars() {
-        let vars = TemplateVars::new("my-sensor", "Author", "desc");
+        let vars = TemplateVars::new("my-sensor", "Author", "desc", "source");
         let input = "{{plugin_name}} / {{plugin_name_pascal}}";
         let result = process_template(input, &vars);
         assert_eq!(result, "my-sensor / MySensor");
@@ -263,16 +276,17 @@ mod tests {
 
     #[test]
     fn test_template_vars_new() {
-        let vars = TemplateVars::new("rtsp-camera", "Team", "Camera node");
+        let vars = TemplateVars::new("rtsp-camera", "Team", "Camera node", "processor");
         assert_eq!(vars.node_name, "rtsp-camera");
         assert_eq!(vars.node_name_pascal, "RtspCamera");
         assert_eq!(vars.node_name_snake, "rtsp_camera");
+        assert_eq!(vars.category, "processor");
     }
 
     #[test]
     fn test_create_node_at_invalid_type() {
         let tmp = std::env::temp_dir().join("bubbaloop_test_invalid_type");
-        let result = create_node_at("test", "java", "author", "desc", &tmp);
+        let result = create_node_at("test", "java", "author", "desc", "source", &tmp);
         assert!(matches!(result, Err(TemplateError::InvalidType(_))));
     }
 
@@ -314,7 +328,7 @@ mod tests {
         let tmp = std::env::temp_dir().join("bubbaloop_test_nonempty");
         let _ = fs::create_dir_all(&tmp);
         let _ = fs::write(tmp.join("existing.txt"), "data");
-        let result = create_node_at("test", "rust", "author", "desc", &tmp);
+        let result = create_node_at("test", "rust", "author", "desc", "source", &tmp);
         assert!(matches!(result, Err(TemplateError::DirectoryExists(_))));
         let _ = fs::remove_dir_all(&tmp);
     }


### PR DESCRIPTION
Implements a comprehensive node architecture redesign:

- Rename capabilities: sensor→source, actuator→sink (with serde aliases)
- Add DriverTier enum (BuiltIn/Marketplace) and expand DRIVER_CATALOG to 14 entries
- Built-in driver framework: BuiltinDriver trait, DriverRegistry, DriverConfig
- 10 built-in drivers: http-poll, webhook, exec, cron-task, system, tcp-listen, udp-listen, file-watch, mqtt (rumqttc), modbus (tokio-modbus)
- 3-tier dispatch in CLI `up` command (BuiltIn vs Marketplace paths)
- PlatformOperations: start/stop/list_builtin_drivers methods
- DaemonPlatform: shared DriverRegistry with graceful shutdown
- 3 new MCP tools + 3 new agent dispatch tools (40 total)
- Node SDK: Source, Sink, Processor traits with serde_json::Value
- `node init --category source|sink|processor` flag with template variable
- Fix pre-existing Windows compilation: cfg(unix) gate on set_executable