### PR TITLE
feat(agent): agent-to-agent messaging via Zenoh

### DIFF
--- a/crates/bubbaloop/src/agent/dispatch.rs
+++ b/crates/bubbaloop/src/agent/dispatch.rs
@@ -14,15 +14,22 @@ pub struct Dispatcher<P: PlatformOperations> {
     platform: Arc<P>,
     scope: String,
     machine_id: String,
+    agent_name: String,
 }
 
 impl<P: PlatformOperations> Dispatcher<P> {
     /// Create a new dispatcher.
-    pub fn new(platform: Arc<P>, scope: String, machine_id: String) -> Self {
+    pub fn new(
+        platform: Arc<P>,
+        scope: String,
+        machine_id: String,
+        agent_name: String,
+    ) -> Self {
         Self {
             platform,
             scope,
             machine_id,
+            agent_name,
         }
     }
 
@@ -269,12 +276,36 @@ impl<P: PlatformOperations> Dispatcher<P> {
                     "required": []
                 }),
             },
+            ToolDefinition {
+                name: "publish_to_topic".to_string(),
+                description: "Publish a message to a Zenoh topic. Use \
+                    bubbaloop/{scope}/agent/{name}/inbox to address a named agent. \
+                    Sender identity is injected automatically — do not include it in \
+                    the message. Example: topic=\"bubbaloop/local/agent/worker/inbox\", \
+                    message=\"process dataset X\"."
+                    .to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "topic": {
+                            "type": "string",
+                            "description": "Zenoh topic to publish to (must start with \
+                                \"bubbaloop/\", no wildcards)"
+                        },
+                        "message": {
+                            "type": "string",
+                            "description": "Text message to send"
+                        }
+                    },
+                    "required": ["topic", "message"]
+                }),
+            },
         ]
     }
 
     /// Dispatch a tool call by name, returning a `ContentBlock::ToolResult`.
     ///
-    /// Maps all 24 tool names to the corresponding `PlatformOperations` method.
+    /// Maps all 25 tool names to the corresponding `PlatformOperations` method.
     pub async fn call_tool(&self, tool_use_id: &str, name: &str, input: &Value) -> ContentBlock {
         let (text, is_error) = match name {
             // ── No-parameter tools ──────────────────────────────────
@@ -315,6 +346,7 @@ impl<P: PlatformOperations> Dispatcher<P> {
             "query_zenoh" => self.handle_query_zenoh(input).await,
             "install_node" => self.handle_install_node(input).await,
             "discover_capabilities" => self.handle_discover_capabilities(input).await,
+            "publish_to_topic" => self.handle_publish_to_topic(input).await,
 
             _ => (format!("Unknown tool: {}", name), Some(true)),
         };
@@ -733,6 +765,37 @@ impl<P: PlatformOperations> Dispatcher<P> {
             Err(e) => (format!("Error: {}", e), Some(true)),
         }
     }
+
+    async fn handle_publish_to_topic(&self, input: &Value) -> (String, Option<bool>) {
+        let topic = match input.get("topic").and_then(|v| v.as_str()) {
+            Some(t) => t.to_string(),
+            None => return ("Missing required parameter: topic".to_string(), Some(true)),
+        };
+        let message = match input.get("message").and_then(|v| v.as_str()) {
+            Some(m) => m.to_string(),
+            None => return ("Missing required parameter: message".to_string(), Some(true)),
+        };
+        if let Err(e) = validation::validate_publish_topic(&topic) {
+            return (format!("Validation error: {}", e), Some(true));
+        }
+        let envelope = json!({
+            "sender": self.agent_name,
+            "message": message,
+        });
+        log::info!(
+            "[Agent] publish_to_topic: {} -> {}",
+            self.agent_name,
+            topic
+        );
+        match self
+            .platform
+            .publish_to_topic(&topic, &envelope.to_string())
+            .await
+        {
+            Ok(()) => (format!("Published to {}", topic), None),
+            Err(e) => (format!("Error: {}", e), Some(true)),
+        }
+    }
 }
 
 // ── Tests ───────────────────────────────────────────────────────────
@@ -743,7 +806,7 @@ mod tests {
     use std::collections::HashSet;
 
     /// Expected number of tools exposed by the dispatcher.
-    const TOOL_COUNT: usize = 24;
+    const TOOL_COUNT: usize = 25;
 
     #[test]
     fn tool_definitions_count() {

--- a/crates/bubbaloop/src/agent/mod.rs
+++ b/crates/bubbaloop/src/agent/mod.rs
@@ -55,6 +55,8 @@ pub struct AgentConfig {
     pub model: Option<String>,
     /// Provider selection (claude, ollama)
     pub provider: Option<String>,
+    /// Agent name for inbox routing (CLI --name → BUBBALOOP_AGENT_NAME → "default").
+    pub name: Option<String>,
 }
 
 /// Create a lightweight Zenoh session for the agent.
@@ -145,6 +147,11 @@ pub async fn run_agent(
     // 2. Create dispatcher with DaemonPlatform
     let scope = std::env::var("BUBBALOOP_SCOPE").unwrap_or_else(|_| "local".to_string());
     let machine_id = crate::daemon::util::get_machine_id();
+    let agent_name = config
+        .name
+        .clone()
+        .or_else(|| std::env::var("BUBBALOOP_AGENT_NAME").ok())
+        .unwrap_or_else(|| "default".to_string());
     let node_manager_ref = node_manager.clone();
     let platform = Arc::new(DaemonPlatform {
         node_manager,
@@ -154,7 +161,12 @@ pub async fn run_agent(
     });
     let sched_scope = scope.clone();
     let sched_machine_id = machine_id.clone();
-    let dispatcher = Dispatcher::new(platform.clone(), scope.clone(), machine_id.clone());
+    let dispatcher = Dispatcher::new(
+        platform.clone(),
+        scope.clone(),
+        machine_id.clone(),
+        agent_name.clone(),
+    );
 
     // 3. Get tool definitions
     let tools = Dispatcher::<DaemonPlatform>::tool_definitions();
@@ -266,6 +278,52 @@ pub async fn run_agent(
         }
     });
 
+    // 5c. Subscribe to this agent's inbox topic on the Zenoh bus.
+    //
+    // Other agents publish to bubbaloop/{scope}/agent/{name}/inbox.
+    // Messages are stored via log_event() so they surface automatically
+    // in the "Recent Events" section of the next system prompt turn.
+    let inbox_topic = format!("bubbaloop/{}/agent/{}/inbox", scope, agent_name);
+    let inbox_session = session.clone();
+    match inbox_session.declare_subscriber(&inbox_topic).await {
+        Ok(inbox_subscriber) => {
+            let inbox_memory = Memory::open(&memory_path)?;
+            let mut inbox_shutdown_rx = shutdown_tx.subscribe();
+            let inbox_topic_log = inbox_topic.clone();
+            tokio::spawn(async move {
+                log::info!("[Agent] inbox listening on: {}", inbox_topic_log);
+                loop {
+                    tokio::select! {
+                        Ok(sample) = inbox_subscriber.recv_async() => {
+                            let bytes = sample.payload().to_bytes();
+                            let payload_str = String::from_utf8_lossy(&bytes).into_owned();
+                            let (sender, message) = if let Ok(v) =
+                                serde_json::from_str::<serde_json::Value>(&payload_str)
+                            {
+                                let s = v["sender"].as_str().unwrap_or("unknown").to_owned();
+                                let m = v["message"].as_str().unwrap_or(&payload_str).to_owned();
+                                (s, m)
+                            } else {
+                                ("unknown-agent".to_owned(), payload_str)
+                            };
+                            if let Err(e) = inbox_memory.log_event(
+                                &sender,
+                                "agent_message",
+                                Some(&message),
+                            ) {
+                                log::warn!("[Agent] failed to persist inbox message: {}", e);
+                            }
+                        }
+                        _ = inbox_shutdown_rx.changed() => break,
+                    }
+                }
+            });
+        }
+        Err(e) => {
+            log::warn!("[Agent] could not subscribe to inbox {}: {}", inbox_topic, e);
+        }
+    }
+
     // 6. Welcome message
     let model_name = config
         .model
@@ -286,6 +344,7 @@ pub async fn run_agent(
     println!();
     println!("  Bubbaloop Agent v{}", env!("CARGO_PKG_VERSION"));
     println!("  Model: {}", model_name);
+    println!("  Name: {} | Inbox: {}", agent_name, inbox_topic);
     println!("  Tools: {} | Nodes: {}", tools.len(), node_count);
     println!();
     println!("  Type a message to chat, 'quit' to exit.");

--- a/crates/bubbaloop/src/agent/mod.rs
+++ b/crates/bubbaloop/src/agent/mod.rs
@@ -43,6 +43,8 @@ pub enum AgentError {
     Zenoh(String),
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
+    #[error("Unknown provider: {0}")]
+    InvalidProvider(String),
 }
 
 pub type Result<T> = std::result::Result<T, AgentError>;
@@ -53,8 +55,6 @@ pub struct AgentConfig {
     pub model: Option<String>,
     /// Provider selection (claude, ollama)
     pub provider: Option<String>,
-    /// Optional camera pipeline configuration.
-    pub camera_pipeline: Option<crate::camera::pipeline::CameraPipelineConfig>,
 }
 
 /// Create a lightweight Zenoh session for the agent.
@@ -134,12 +134,12 @@ pub async fn run_agent(
     node_manager: Arc<crate::daemon::node_manager::NodeManager>,
 ) -> Result<()> {
     // 1. Initialise client based on provider
-    // If no provider is explicitly set, default to Claude for zero-regression behavior.
-    // Unrecognized string values will also safely fall back to ClaudeClient initialization.
-    let provider_name = config.provider.as_deref().unwrap_or("claude");
-    let client = match provider_name {
-        "ollama" => LlmClient::Ollama(ollama::OllamaClient::from_env(config.model.as_deref())?),
-        _ => LlmClient::Claude(ClaudeClient::from_env(config.model.as_deref())?),
+    let client = match config.provider.as_deref() {
+        Some("ollama") => {
+            LlmClient::Ollama(ollama::OllamaClient::from_env(config.model.as_deref())?)
+        }
+        Some(other) => return Err(AgentError::InvalidProvider(other.to_string())),
+        None => LlmClient::Claude(ClaudeClient::from_env(config.model.as_deref())?),
     };
 
     // 2. Create dispatcher with DaemonPlatform
@@ -244,20 +244,6 @@ pub async fn run_agent(
         shutdown_rx.clone(),
     ));
 
-    // 5a. Start camera pipeline in background if configured
-    if let Some(camera_config) = config.camera_pipeline {
-        let mem = Memory::open(&memory_path)?;
-        tokio::spawn(crate::camera::pipeline::run_camera_pipeline(
-            camera_config,
-            session.clone(),
-            platform.clone(),
-            Arc::new(std::sync::Mutex::new(mem)),
-            scope.clone(),
-            machine_id.clone(),
-            shutdown_rx.clone(),
-        ));
-    }
-
     // 5b. Bridge node events to memory
     let event_memory = Memory::open(&memory_path)?;
     let mut event_rx = node_manager_ref.subscribe();
@@ -281,10 +267,13 @@ pub async fn run_agent(
     });
 
     // 6. Welcome message
-    let model_name = config.model.as_deref().unwrap_or(match provider_name {
-        "ollama" => ollama::DEFAULT_MODEL,
-        _ => claude::DEFAULT_MODEL,
-    });
+    let model_name = config
+        .model
+        .as_deref()
+        .unwrap_or(match config.provider.as_deref() {
+            Some("ollama") => ollama::DEFAULT_MODEL,
+            _ => claude::DEFAULT_MODEL,
+        });
     let node_count = match dispatcher.get_node_inventory().await {
         ref s if s.starts_with("No nodes") => "0".to_string(),
         ref s => s

--- a/crates/bubbaloop/src/agent/mod.rs
+++ b/crates/bubbaloop/src/agent/mod.rs
@@ -1,6 +1,9 @@
 /// Raw reqwest Claude API client with tool_use support.
 pub mod claude;
 
+/// Minimal local Ollama chat backend.
+pub mod ollama;
+
 /// Internal MCP tool dispatch — calls PlatformOperations directly.
 pub mod dispatch;
 
@@ -32,6 +35,8 @@ const MAX_CONVERSATION_MESSAGES: usize = 40;
 pub enum AgentError {
     #[error("Claude API error: {0}")]
     Claude(#[from] claude::ClaudeError),
+    #[error("Ollama API error: {0}")]
+    Ollama(#[from] ollama::OllamaError),
     #[error("Memory error: {0}")]
     Memory(#[from] memory::MemoryError),
     #[error("Zenoh connection failed: {0}")]
@@ -46,6 +51,10 @@ pub type Result<T> = std::result::Result<T, AgentError>;
 pub struct AgentConfig {
     /// Claude model override (uses default if None).
     pub model: Option<String>,
+    /// Provider selection (claude, ollama)
+    pub provider: Option<String>,
+    /// Optional camera pipeline configuration.
+    pub camera_pipeline: Option<crate::camera::pipeline::CameraPipelineConfig>,
 }
 
 /// Create a lightweight Zenoh session for the agent.
@@ -87,6 +96,31 @@ pub async fn create_agent_session(endpoint: Option<&str>) -> Result<Arc<zenoh::S
     Ok(Arc::new(session))
 }
 
+enum LlmClient {
+    Claude(ClaudeClient),
+    Ollama(ollama::OllamaClient),
+}
+
+impl LlmClient {
+    async fn send(
+        &self,
+        system: Option<&str>,
+        messages: &[crate::agent::claude::Message],
+        tools: &Vec<crate::agent::claude::ToolDefinition>,
+    ) -> Result<crate::agent::claude::ApiResponse> {
+        match self {
+            LlmClient::Claude(c) => c
+                .send(system, messages, tools)
+                .await
+                .map_err(AgentError::Claude),
+            LlmClient::Ollama(c) => c
+                .send(system, messages, tools)
+                .await
+                .map_err(AgentError::Ollama),
+        }
+    }
+}
+
 /// Run the interactive agent REPL.
 ///
 /// Connects to the Claude API, initialises the tool dispatcher and memory
@@ -99,8 +133,14 @@ pub async fn run_agent(
     session: Arc<zenoh::Session>,
     node_manager: Arc<crate::daemon::node_manager::NodeManager>,
 ) -> Result<()> {
-    // 1. Initialise Claude client from ANTHROPIC_API_KEY env var
-    let client = ClaudeClient::from_env(config.model.as_deref())?;
+    // 1. Initialise client based on provider
+    // If no provider is explicitly set, default to Claude for zero-regression behavior.
+    // Unrecognized string values will also safely fall back to ClaudeClient initialization.
+    let provider_name = config.provider.as_deref().unwrap_or("claude");
+    let client = match provider_name {
+        "ollama" => LlmClient::Ollama(ollama::OllamaClient::from_env(config.model.as_deref())?),
+        _ => LlmClient::Claude(ClaudeClient::from_env(config.model.as_deref())?),
+    };
 
     // 2. Create dispatcher with DaemonPlatform
     let scope = std::env::var("BUBBALOOP_SCOPE").unwrap_or_else(|_| "local".to_string());
@@ -108,13 +148,13 @@ pub async fn run_agent(
     let node_manager_ref = node_manager.clone();
     let platform = Arc::new(DaemonPlatform {
         node_manager,
-        session,
+        session: session.clone(),
         scope: scope.clone(),
         machine_id: machine_id.clone(),
     });
     let sched_scope = scope.clone();
     let sched_machine_id = machine_id.clone();
-    let dispatcher = Dispatcher::new(platform.clone(), scope, machine_id);
+    let dispatcher = Dispatcher::new(platform.clone(), scope.clone(), machine_id.clone());
 
     // 3. Get tool definitions
     let tools = Dispatcher::<DaemonPlatform>::tool_definitions();
@@ -201,8 +241,22 @@ pub async fn run_agent(
         platform.clone(),
         sched_scope,
         sched_machine_id,
-        shutdown_rx,
+        shutdown_rx.clone(),
     ));
+
+    // 5a. Start camera pipeline in background if configured
+    if let Some(camera_config) = config.camera_pipeline {
+        let mem = Memory::open(&memory_path)?;
+        tokio::spawn(crate::camera::pipeline::run_camera_pipeline(
+            camera_config,
+            session.clone(),
+            platform.clone(),
+            Arc::new(std::sync::Mutex::new(mem)),
+            scope.clone(),
+            machine_id.clone(),
+            shutdown_rx.clone(),
+        ));
+    }
 
     // 5b. Bridge node events to memory
     let event_memory = Memory::open(&memory_path)?;
@@ -227,7 +281,10 @@ pub async fn run_agent(
     });
 
     // 6. Welcome message
-    let model_name = config.model.as_deref().unwrap_or(claude::DEFAULT_MODEL);
+    let model_name = config.model.as_deref().unwrap_or(match provider_name {
+        "ollama" => ollama::DEFAULT_MODEL,
+        _ => claude::DEFAULT_MODEL,
+    });
     let node_count = match dispatcher.get_node_inventory().await {
         ref s if s.starts_with("No nodes") => "0".to_string(),
         ref s => s
@@ -307,7 +364,7 @@ pub async fn run_agent(
                 Ok(r) => r,
                 Err(e) => {
                     println!("Error: {}", e);
-                    log::error!("Claude API error: {}", e);
+                    log::error!("Agent API error: {}", e);
                     break;
                 }
             };

--- a/crates/bubbaloop/src/agent/ollama.rs
+++ b/crates/bubbaloop/src/agent/ollama.rs
@@ -1,0 +1,125 @@
+use crate::agent::claude::{ApiResponse, ContentBlock, Message, ToolDefinition, Usage};
+use serde::{Deserialize, Serialize};
+
+pub const DEFAULT_MODEL: &str = "llama3.2";
+
+#[derive(Debug, thiserror::Error)]
+pub enum OllamaError {
+    #[error("HTTP error: {0}")]
+    Http(#[from] reqwest::Error),
+    #[error("API error (status {status}): {message}")]
+    Api { status: u16, message: String },
+}
+
+#[derive(Debug)]
+pub struct OllamaClient {
+    client: reqwest::Client,
+    model: String,
+    endpoint: String,
+}
+
+#[derive(Serialize)]
+struct OllamaMessage {
+    role: String,
+    content: String,
+}
+
+#[derive(Serialize)]
+struct OllamaRequest<'a> {
+    model: &'a str,
+    messages: Vec<OllamaMessage>,
+    stream: bool,
+}
+
+#[derive(Deserialize)]
+struct OllamaResponse {
+    message: match_message::OllamaMessageResp,
+    prompt_eval_count: Option<u32>,
+    eval_count: Option<u32>,
+}
+
+mod match_message {
+    use serde::Deserialize;
+    #[derive(Deserialize)]
+    pub struct OllamaMessageResp {
+        pub content: String,
+    }
+}
+
+impl OllamaClient {
+    pub fn from_env(model: Option<&str>) -> Result<Self, OllamaError> {
+        let endpoint =
+            std::env::var("OLLAMA_HOST").unwrap_or_else(|_| "http://localhost:11434".to_string());
+        Ok(Self {
+            client: reqwest::Client::new(),
+            model: model.unwrap_or(DEFAULT_MODEL).to_string(),
+            endpoint,
+        })
+    }
+
+    pub async fn send(
+        &self,
+        system: Option<&str>,
+        messages: &[Message],
+        // Tool-use is intentionally passed through and dropped here.
+        // Ollama handles simple chat completions while gracefully ignoring tool metadata.
+        _tools: &Vec<ToolDefinition>,
+    ) -> Result<ApiResponse, OllamaError> {
+        let mut ollama_msgs = Vec::new();
+
+        if let Some(sys) = system {
+            ollama_msgs.push(OllamaMessage {
+                role: "system".to_string(),
+                content: sys.to_string(),
+            });
+        }
+
+        for msg in messages {
+            ollama_msgs.push(OllamaMessage {
+                role: msg.role.clone(),
+                content: msg.text(),
+            });
+        }
+
+        let body = OllamaRequest {
+            model: &self.model,
+            messages: ollama_msgs,
+            stream: false,
+        };
+
+        let url = format!("{}/api/chat", self.endpoint.trim_end_matches('/'));
+        let response = self.client.post(&url).json(&body).send().await?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let message = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "unknown error".to_string());
+            return Err(OllamaError::Api {
+                status: status.as_u16(),
+                message,
+            });
+        }
+
+        let resp: OllamaResponse = response.json().await?;
+
+        // Format a unique message ID to fulfill Anthropic's type-checker requirements
+        // without introducing real coupling. Agent memory ignores this ID safely.
+        let id_str = format!("ollama-{}", uuid::Uuid::new_v4());
+
+        // Map Ollama's response fields exactly to the Claude ApiResponse schema
+        // so the core REPL loop can consume it natively without traits.
+        Ok(ApiResponse {
+            id: id_str,
+            content: vec![ContentBlock::Text {
+                text: resp.message.content,
+            }],
+            stop_reason: Some("end_turn".to_string()),
+            usage: Usage {
+                input_tokens: resp.prompt_eval_count.unwrap_or(0),
+                output_tokens: resp.eval_count.unwrap_or(0),
+            },
+        })
+    }
+}

--- a/crates/bubbaloop/src/bin/bubbaloop.rs
+++ b/crates/bubbaloop/src/bin/bubbaloop.rs
@@ -218,6 +218,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             eprintln!("  logout    Remove saved Anthropic API key");
             eprintln!("  agent     Chat with your hardware via Claude AI:");
             eprintln!("              -m, --model <model>: Claude model");
+            eprintln!("              -p, --provider <provider>: LLM provider (claude, ollama)");
             eprintln!("              -z, --zenoh-endpoint <endpoint>: Zenoh endpoint");
             eprintln!("  up        Load skills and ensure sensor nodes are running:");
             eprintln!("              -s, --skills-dir <path>: Skills directory");
@@ -294,7 +295,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 };
             let node_manager = bubbaloop::daemon::NodeManager::new().await?;
             if let Err(e) = bubbaloop::agent::run_agent(
-                bubbaloop::agent::AgentConfig { model: cmd.model },
+                bubbaloop::agent::AgentConfig {
+                    model: cmd.model,
+                    provider: cmd.provider,
+                    camera_pipeline: None,
+                },
                 session,
                 node_manager,
             )

--- a/crates/bubbaloop/src/bin/bubbaloop.rs
+++ b/crates/bubbaloop/src/bin/bubbaloop.rs
@@ -298,7 +298,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 bubbaloop::agent::AgentConfig {
                     model: cmd.model,
                     provider: cmd.provider,
-                    camera_pipeline: None,
                 },
                 session,
                 node_manager,

--- a/crates/bubbaloop/src/bin/bubbaloop.rs
+++ b/crates/bubbaloop/src/bin/bubbaloop.rs
@@ -298,6 +298,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 bubbaloop::agent::AgentConfig {
                     model: cmd.model,
                     provider: cmd.provider,
+                    name: cmd.name,
                 },
                 session,
                 node_manager,

--- a/crates/bubbaloop/src/bin/bubbaloop.rs
+++ b/crates/bubbaloop/src/bin/bubbaloop.rs
@@ -293,7 +293,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         return Ok(());
                     }
                 };
-            let node_manager = bubbaloop::daemon::NodeManager::new().await?;
+            let node_manager = bubbaloop::daemon::NodeManager::new_with_graceful_fallback().await;
             if let Err(e) = bubbaloop::agent::run_agent(
                 bubbaloop::agent::AgentConfig {
                     model: cmd.model,

--- a/crates/bubbaloop/src/cli/agent.rs
+++ b/crates/bubbaloop/src/cli/agent.rs
@@ -15,4 +15,8 @@ pub struct AgentCommand {
     /// zenoh endpoint to connect to (default: auto-discover)
     #[argh(option, short = 'z')]
     pub zenoh_endpoint: Option<String>,
+
+    /// agent name for routing messages to this agent's inbox (default: "default")
+    #[argh(option, short = 'n')]
+    pub name: Option<String>,
 }

--- a/crates/bubbaloop/src/cli/agent.rs
+++ b/crates/bubbaloop/src/cli/agent.rs
@@ -8,6 +8,10 @@ pub struct AgentCommand {
     #[argh(option, short = 'm')]
     pub model: Option<String>,
 
+    /// llm provider to use: 'claude' or 'ollama' (default: claude)
+    #[argh(option, short = 'p')]
+    pub provider: Option<String>,
+
     /// zenoh endpoint to connect to (default: auto-discover)
     #[argh(option, short = 'z')]
     pub zenoh_endpoint: Option<String>,

--- a/crates/bubbaloop/src/daemon/node_manager.rs
+++ b/crates/bubbaloop/src/daemon/node_manager.rs
@@ -165,8 +165,8 @@ impl CachedNode {
 pub struct NodeManager {
     /// Cached node states
     nodes: RwLock<HashMap<String, CachedNode>>,
-    /// Systemd client
-    systemd: SystemdClient,
+    /// Systemd client (None in stub mode on non-Linux systems)
+    systemd: Option<SystemdClient>,
     /// Channel to broadcast state changes
     event_tx: broadcast::Sender<NodeEvent>,
     /// Nodes currently being built (prevents concurrent builds)
@@ -203,7 +203,7 @@ impl NodeManager {
 
         let manager = Arc::new(Self {
             nodes: RwLock::new(HashMap::new()),
-            systemd,
+            systemd: Some(systemd),
             event_tx,
             building_nodes: Mutex::new(HashSet::new()),
             machine_id,
@@ -215,6 +215,38 @@ impl NodeManager {
         manager.refresh_all().await?;
 
         Ok(manager)
+    }
+
+    /// Create a node manager, falling back to an empty stub if systemd is unavailable.
+    ///
+    /// Used by the `agent` command so it can run on macOS (no systemd) for LLM
+    /// chat without crashing. Node-management tools will simply report 0 nodes.
+    pub async fn new_with_graceful_fallback() -> Arc<Self> {
+        match Self::new().await {
+            Ok(manager) => manager,
+            Err(e) => {
+                log::warn!(
+                    "NodeManager: systemd unavailable ({}). Running in stub mode (0 nodes).",
+                    e
+                );
+                let (event_tx, _) = broadcast::channel(100);
+                let machine_id = super::util::get_machine_id();
+                let machine_hostname = hostname::get()
+                    .map(|h| h.to_string_lossy().to_string())
+                    .unwrap_or_else(|_| "unknown".to_string());
+                let machine_ips = get_machine_ips();
+
+                Arc::new(Self {
+                    nodes: RwLock::new(HashMap::new()),
+                    systemd: None,
+                    event_tx,
+                    building_nodes: Mutex::new(HashSet::new()),
+                    machine_id,
+                    machine_hostname,
+                    machine_ips,
+                })
+            }
+        }
     }
 
     /// Subscribe to node events
@@ -232,7 +264,7 @@ impl NodeManager {
     /// Instead, we collect dirty nodes and schedule a debounced refresh on a
     /// separate task that runs after a short delay, coalescing rapid signal bursts.
     pub async fn start_signal_listener(self: Arc<Self>) -> Result<()> {
-        let mut signal_rx = self.systemd.subscribe_to_signals().await?;
+        let mut signal_rx = self.systemd.as_ref().expect("no systemd").subscribe_to_signals().await?;
 
         tokio::spawn(async move {
             log::info!("Signal listener started");
@@ -319,10 +351,10 @@ impl NodeManager {
         let service_name = systemd::get_service_name(name);
 
         // Get systemd state
-        let active_state = self.systemd.get_active_state(&service_name).await?;
+        let active_state = self.systemd.as_ref().expect("no systemd").get_active_state(&service_name).await?;
         let installed = systemd::is_service_installed(name);
         let autostart_enabled = if installed {
-            self.systemd
+            self.systemd.as_ref().expect("no systemd")
                 .is_enabled(&service_name)
                 .await
                 .unwrap_or(false)
@@ -521,10 +553,10 @@ impl NodeManager {
             let service_name = systemd::get_service_name(&eff_name);
 
             // Get systemd state
-            let active_state = self.systemd.get_active_state(&service_name).await?;
+            let active_state = self.systemd.as_ref().expect("no systemd").get_active_state(&service_name).await?;
             let installed = systemd::is_service_installed(&eff_name);
             let autostart_enabled = if installed {
-                self.systemd
+                self.systemd.as_ref().expect("no systemd")
                     .is_enabled(&service_name)
                     .await
                     .unwrap_or(false)
@@ -770,7 +802,7 @@ impl NodeManager {
     /// Start a node
     async fn start_node(self: &Arc<Self>, name: &str) -> Result<String> {
         let service_name = systemd::get_service_name(name);
-        self.systemd.start_unit(&service_name).await?;
+        self.systemd.as_ref().expect("no systemd").start_unit(&service_name).await?;
         self.spawn_refresh_and_emit("started", name);
         Ok(format!("Started {}", name))
     }
@@ -778,7 +810,7 @@ impl NodeManager {
     /// Stop a node
     async fn stop_node(self: &Arc<Self>, name: &str) -> Result<String> {
         let service_name = systemd::get_service_name(name);
-        self.systemd.stop_unit(&service_name).await?;
+        self.systemd.as_ref().expect("no systemd").stop_unit(&service_name).await?;
         self.spawn_refresh_and_emit("stopped", name);
         Ok(format!("Stopped {}", name))
     }
@@ -786,7 +818,7 @@ impl NodeManager {
     /// Restart a node
     async fn restart_node(self: &Arc<Self>, name: &str) -> Result<String> {
         let service_name = systemd::get_service_name(name);
-        self.systemd.restart_unit(&service_name).await?;
+        self.systemd.as_ref().expect("no systemd").restart_unit(&service_name).await?;
         self.spawn_refresh_and_emit("restarted", name);
         Ok(format!("Restarted {}", name))
     }
@@ -842,10 +874,10 @@ impl NodeManager {
     /// Used before build/clean operations to avoid conflicts with the running binary.
     async fn stop_if_running(&self, name: &str) {
         let service_name = systemd::get_service_name(name);
-        match self.systemd.get_active_state(&service_name).await {
+        match self.systemd.as_ref().expect("no systemd").get_active_state(&service_name).await {
             Ok(ActiveState::Active | ActiveState::Activating) => {
                 log::info!("Stopping {} before build/clean", name);
-                let _ = self.systemd.stop_unit(&service_name).await;
+                let _ = self.systemd.as_ref().expect("no systemd").stop_unit(&service_name).await;
                 tokio::time::sleep(Duration::from_millis(500)).await;
             }
             Err(e) => {
@@ -975,7 +1007,7 @@ impl NodeManager {
     /// Enable autostart for a node
     async fn enable_autostart(&self, name: &str) -> Result<String> {
         let service_name = systemd::get_service_name(name);
-        self.systemd.enable_unit(&service_name).await?;
+        self.systemd.as_ref().expect("no systemd").enable_unit(&service_name).await?;
 
         self.refresh_all().await?;
         self.emit_event("autostart_enabled", name).await;
@@ -986,7 +1018,7 @@ impl NodeManager {
     /// Disable autostart for a node
     async fn disable_autostart(&self, name: &str) -> Result<String> {
         let service_name = systemd::get_service_name(name);
-        self.systemd.disable_unit(&service_name).await?;
+        self.systemd.as_ref().expect("no systemd").disable_unit(&service_name).await?;
 
         self.refresh_all().await?;
         self.emit_event("autostart_disabled", name).await;

--- a/crates/bubbaloop/src/lib.rs
+++ b/crates/bubbaloop/src/lib.rs
@@ -35,6 +35,9 @@ pub mod skills;
 /// Agent layer: Claude API chat, SQLite memory, scheduling
 pub mod agent;
 
+/// Camera pipeline for edge local detection and LLM escalation
+pub mod camera;
+
 /// Protobuf schemas for bubbaloop
 pub mod schemas {
     pub mod header {

--- a/crates/bubbaloop/src/lib.rs
+++ b/crates/bubbaloop/src/lib.rs
@@ -35,9 +35,6 @@ pub mod skills;
 /// Agent layer: Claude API chat, SQLite memory, scheduling
 pub mod agent;
 
-/// Camera pipeline for edge local detection and LLM escalation
-pub mod camera;
-
 /// Protobuf schemas for bubbaloop
 pub mod schemas {
     pub mod header {

--- a/crates/bubbaloop/src/mcp/platform.rs
+++ b/crates/bubbaloop/src/mcp/platform.rs
@@ -120,6 +120,16 @@ pub trait PlatformOperations: Send + Sync + 'static {
         &self,
         name: &str,
     ) -> impl std::future::Future<Output = PlatformResult<String>> + Send;
+
+    /// Publish a text message to a Zenoh topic.
+    ///
+    /// Used by agents to send messages to other agents' inboxes.
+    /// Topic must start with `bubbaloop/` and contain no wildcards.
+    fn publish_to_topic(
+        &self,
+        topic: &str,
+        message: &str,
+    ) -> impl std::future::Future<Output = PlatformResult<()>> + Send;
 }
 
 // ── DaemonPlatform: real implementation backed by NodeManager + Zenoh ────
@@ -481,6 +491,13 @@ impl PlatformOperations for DaemonPlatform {
             Err(PlatformError::CommandFailed(result.message))
         }
     }
+
+    async fn publish_to_topic(&self, topic: &str, message: &str) -> PlatformResult<()> {
+        self.session
+            .put(topic, message)
+            .await
+            .map_err(|e| PlatformError::Internal(format!("Zenoh put failed: {}", e)))
+    }
 }
 
 /// Query a Zenoh key expression and return text results.
@@ -675,6 +692,11 @@ pub mod mock {
             } else {
                 Err(PlatformError::NodeNotFound(name.to_string()))
             }
+        }
+
+        async fn publish_to_topic(&self, topic: &str, _message: &str) -> PlatformResult<()> {
+            log::debug!("mock: publish_to_topic {}", topic);
+            Ok(())
         }
     }
 }


### PR DESCRIPTION
## Summary

Agents can now send messages to each other. One agent publishes, another receives — no daemon involvement, no new storage layer.

Each agent subscribes to its own inbox at startup:
```
bubbaloop/{scope}/agent/{name}/inbox
```

To send a message, the LLM calls `publish_to_topic`. The dispatcher signs it with the sender's name and puts it on the Zenoh bus. The receiving agent's background task picks it up and writes it to SQLite. It appears in the next prompt turn under "Recent Events":

```
- [2026-03-16 10:31:00] coordinator agent_message (process dataset X)
```

To reply, the worker calls `publish_to_topic("bubbaloop/local/agent/coordinator/inbox", "acknowledged")`.

## Changes

- **`--name` flag** — `bubbaloop agent --name coordinator`. Falls back to `BUBBALOOP_AGENT_NAME` env var, then `"default"`. Shown in the startup banner.
- **`publish_to_topic` MCP tool** — validates topic, injects sender, calls `session.put()`.
- **Inbox subscriber task** — mirrors the existing node-event bridge pattern in `agent/mod.rs`.
- **`PlatformOperations::publish_to_topic`** — added to trait, `DaemonPlatform`, and `MockPlatform`.

## Test plan

- [ ] `cargo test --lib` — 385/385
- [ ] Two agents start with correct name + inbox in banner
- [ ] `publish_to_topic("bubbaloop/local/agent/worker/inbox", "process dataset X")` — worker sees it on next turn
- [ ] Worker replies, coordinator sees it
- [ ] `publish_to_topic("invalid/topic", "x")` → validation error