### PR TITLE
feat(agent): add agent-to-agent messaging via Zenoh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,7 +351,7 @@ dependencies = [
 
 [[package]]
 name = "bubbaloop"
-version = "0.0.11"
+version = "0.0.12-dev"
 dependencies = [
  "anyhow",
  "argh",

--- a/crates/bubbaloop/src/agent/dispatch.rs
+++ b/crates/bubbaloop/src/agent/dispatch.rs
@@ -36,6 +36,7 @@ pub struct Dispatcher<P: PlatformOperations> {
     platform: Arc<P>,
     scope: String,
     machine_id: String,
+    agent_name: String,
     memory_backend: Option<Arc<tokio::sync::Mutex<crate::agent::memory::MemoryBackend>>>,
     job_notify: Option<Arc<tokio::sync::Notify>>,
     episodic_decay_half_life_days: u32,
@@ -49,6 +50,7 @@ impl<P: PlatformOperations> Dispatcher<P> {
             platform,
             scope,
             machine_id,
+            agent_name: String::new(),
             memory_backend: None,
             job_notify: None,
             episodic_decay_half_life_days: 7,
@@ -79,6 +81,7 @@ impl<P: PlatformOperations> Dispatcher<P> {
         platform: Arc<P>,
         scope: String,
         machine_id: String,
+        agent_name: String,
         memory_backend: Arc<tokio::sync::Mutex<crate::agent::memory::MemoryBackend>>,
         job_notify: Option<Arc<tokio::sync::Notify>>,
         episodic_decay_half_life_days: u32,
@@ -87,6 +90,7 @@ impl<P: PlatformOperations> Dispatcher<P> {
             platform,
             scope,
             machine_id,
+            agent_name,
             memory_backend: Some(memory_backend),
             job_notify,
             episodic_decay_half_life_days,
@@ -525,6 +529,27 @@ impl<P: PlatformOperations> Dispatcher<P> {
                     "required": []
                 }),
             },
+            ToolDefinition {
+                name: "publish_to_topic".to_string(),
+                description: "Publish a message to a Zenoh topic. Use topic \
+                    bubbaloop/{scope}/agent/{name}/inbox to address a named agent's inbox. \
+                    Inbox messages surface in the recipient's next prompt turn under Recent Events."
+                    .to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "topic": {
+                            "type": "string",
+                            "description": "Zenoh key expression (must start with 'bubbaloop/')"
+                        },
+                        "message": {
+                            "type": "string",
+                            "description": "Message text to deliver"
+                        }
+                    },
+                    "required": ["topic", "message"]
+                }),
+            },
         ]
     }
 
@@ -577,6 +602,7 @@ impl<P: PlatformOperations> Dispatcher<P> {
             "get_system_telemetry" => self.handle_get_system_telemetry().await,
             "get_telemetry_history" => self.handle_get_telemetry_history(input).await,
             "update_telemetry_config" => self.handle_update_telemetry_config(input).await,
+            "publish_to_topic" => self.handle_publish_to_topic(input).await,
             _ => ToolResult::error(format!(
                 "Unknown tool: {}. Use your available tools: node management \
                  (list_nodes, start_node, etc.), system (read_file, write_file, \
@@ -1437,6 +1463,37 @@ impl<P: PlatformOperations> Dispatcher<P> {
             Err(e) => ToolResult::error(format!("Error updating telemetry config: {}", e)),
         }
     }
+
+    async fn handle_publish_to_topic(&self, input: &Value) -> ToolResult {
+        let topic = match input.get("topic").and_then(|v| v.as_str()) {
+            Some(t) => t.to_string(),
+            None => return ToolResult::error("Missing required parameter: topic".to_string()),
+        };
+        let message = match input.get("message").and_then(|v| v.as_str()) {
+            Some(m) => m.to_string(),
+            None => return ToolResult::error("Missing required parameter: message".to_string()),
+        };
+        if let Err(e) = crate::validation::validate_publish_topic(&topic) {
+            return ToolResult::error(format!("Validation error: {}", e));
+        }
+        let envelope = json!({
+            "sender": self.agent_name,
+            "message": message,
+        });
+        log::info!(
+            "[Agent] publish_to_topic: {} -> {}",
+            self.agent_name,
+            topic
+        );
+        match self
+            .platform
+            .publish_to_topic(&topic, &envelope.to_string())
+            .await
+        {
+            Ok(()) => ToolResult::success(format!("Published to {}", topic)),
+            Err(e) => ToolResult::error(format!("Error: {}", e)),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -1444,7 +1501,7 @@ mod tests {
     use super::*;
     use std::collections::HashSet;
 
-    const TOOL_COUNT: usize = 37;
+    const TOOL_COUNT: usize = 38;
 
     #[test]
     fn tool_definitions_count() {

--- a/crates/bubbaloop/src/agent/dispatch.rs
+++ b/crates/bubbaloop/src/agent/dispatch.rs
@@ -1480,11 +1480,7 @@ impl<P: PlatformOperations> Dispatcher<P> {
             "sender": self.agent_name,
             "message": message,
         });
-        log::info!(
-            "[Agent] publish_to_topic: {} -> {}",
-            self.agent_name,
-            topic
-        );
+        log::info!("[Agent] publish_to_topic: {} -> {}", self.agent_name, topic);
         match self
             .platform
             .publish_to_topic(&topic, &envelope.to_string())

--- a/crates/bubbaloop/src/agent/dispatch.rs
+++ b/crates/bubbaloop/src/agent/dispatch.rs
@@ -1496,6 +1496,9 @@ impl<P: PlatformOperations> Dispatcher<P> {
 mod tests {
     use super::*;
     use std::collections::HashSet;
+    use zenoh::handlers::FifoChannelHandler;
+    use zenoh::pubsub::Subscriber;
+    use zenoh::sample::Sample;
 
     const TOOL_COUNT: usize = 38;
 
@@ -1538,16 +1541,15 @@ mod tests {
         assert_eq!(r.text, "bad");
     }
 
-    // ── E2E: agent-to-agent messaging via real Zenoh pub/sub ────────────────
+    // ── E2E: bidirectional agent-to-agent messaging via real Zenoh pub/sub ──
     //
-    // Proves the full chain without a running daemon or LLM:
+    // Proves the full chain in both directions without a daemon or LLM:
     //
-    //   Dispatcher.call_tool("publish_to_topic")
-    //     → MockPlatform (real Zenoh session) → session.put()
-    //     → Zenoh peer TCP delivery
-    //     → inbox subscriber (mirrors runtime.rs exactly)
-    //     → EpisodicLog::append()
-    //     → assert "[agent_message from coordinator] hello worker"
+    //   coordinator Dispatcher  →  session.put()  →  worker inbox subscriber
+    //     → EpisodicLog entry: "[agent_message from coordinator] hello worker"
+    //
+    //   worker Dispatcher       →  session.put()  →  coordinator inbox subscriber
+    //     → EpisodicLog entry: "[agent_message from worker] hello coordinator"
 
     /// Open a Zenoh peer session that listens on the given TCP port.
     async fn open_listen_session(port: u16) -> std::sync::Arc<zenoh::Session> {
@@ -1574,43 +1576,34 @@ mod tests {
         std::sync::Arc::new(zenoh::open(cfg).await.unwrap())
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn e2e_agent_messaging_pub_sub() {
-        // Unique port for this test — avoids conflicts with other test runs
-        const PORT: u16 = 14_789;
+    /// Assert that a tool call returned success (not an error variant).
+    fn assert_tool_ok(result: &crate::agent::provider::ContentBlock) {
+        match result {
+            crate::agent::provider::ContentBlock::ToolResult {
+                is_error, content, ..
+            } => assert!(
+                is_error.is_none(),
+                "publish_to_topic returned error: {}",
+                content
+            ),
+            other => panic!("unexpected ContentBlock variant: {:?}", other),
+        }
+    }
 
-        // ── 1. Open two Zenoh peer sessions (no router needed) ──────────────
-        // Worker session listens; coordinator session connects.
-        let worker_session = open_listen_session(PORT).await;
-        let coordinator_session = open_connect_session(PORT).await;
-
-        eprintln!("\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
-        eprintln!(" Bubbaloop — agent-to-agent messaging demo");
-        eprintln!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n");
-        eprintln!("[coordinator] Zenoh session open (peer TCP :{PORT})");
-        eprintln!("[worker]      Zenoh session open (peer TCP :{PORT})");
-
-        // ── 2. Real memory backend for the worker ────────────────────────────
-        let tmpdir = tempfile::tempdir().unwrap();
-        let worker_memory = crate::agent::memory::Memory::open(tmpdir.path()).unwrap();
-
-        // ── 3. Worker subscribes to its inbox ────────────────────────────────
-        let inbox = "bubbaloop/local/agent/worker/inbox";
-        eprintln!("[worker]      Subscribed to inbox: {}", inbox);
-
-        let sub = worker_session
-            .declare_subscriber(inbox)
-            .await
-            .expect("failed to declare subscriber");
-
-        // Spawn the inbox handler — mirrors runtime.rs:446-479 exactly
-        let backend = worker_memory.backend.clone();
-        let (done_tx, done_rx) = tokio::sync::oneshot::channel::<()>();
+    /// Spawn an inbox subscriber task that mirrors `runtime.rs` exactly.
+    ///
+    /// Returns a oneshot receiver that fires with the logged content string
+    /// once the first message arrives and is written to the episodic log.
+    fn spawn_inbox_handler(
+        sub: Subscriber<FifoChannelHandler<Sample>>,
+        backend: std::sync::Arc<tokio::sync::Mutex<crate::agent::memory::MemoryBackend>>,
+        label: &'static str,
+    ) -> tokio::sync::oneshot::Receiver<String> {
+        let (tx, rx) = tokio::sync::oneshot::channel::<String>();
         tokio::spawn(async move {
             if let Ok(sample) = sub.recv_async().await {
-                let bytes = sample.payload().to_bytes();
+                let bytes: std::borrow::Cow<[u8]> = sample.payload().to_bytes();
                 let payload = String::from_utf8_lossy(&bytes).into_owned();
-
                 let (sender, msg) =
                     if let Ok(v) = serde_json::from_str::<serde_json::Value>(&payload) {
                         let s = v["sender"].as_str().unwrap_or("unknown").to_owned();
@@ -1619,98 +1612,134 @@ mod tests {
                     } else {
                         ("unknown-agent".to_owned(), payload)
                     };
-
                 let content = format!("[agent_message from {}] {}", sender, msg);
-                eprintln!(
-                    "[worker]      Inbox received → episodic log: \"{}\"",
-                    content
-                );
-
+                eprintln!("[{}] inbox received → \"{}\"", label, content);
                 let entry = crate::agent::memory::episodic::EpisodicLog::make_entry(
                     "system", &content, None,
                 );
                 backend.lock().await.episodic.append(&entry).unwrap();
-                let _ = done_tx.send(());
+                let _ = tx.send(content);
             }
         });
+        rx
+    }
 
-        // Give the subscriber a moment to register
-        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn e2e_agent_messaging_pub_sub() {
+        const PORT: u16 = 14_789;
 
-        // ── 4. Coordinator sends via Dispatcher.call_tool ────────────────────
+        // ── Open two Zenoh peer sessions (no router needed) ──────────────────
+        // Both are Arc — cloned so each agent can both subscribe and publish.
+        let worker_session = open_listen_session(PORT).await;
+        let coordinator_session = open_connect_session(PORT).await;
+
+        eprintln!("\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+        eprintln!(" Bubbaloop agent messaging");
+        eprintln!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n");
+
+        // ── Real memory backends ─────────────────────────────────────────────
+        let worker_tmpdir = tempfile::tempdir().unwrap();
         let coordinator_tmpdir = tempfile::tempdir().unwrap();
+        let worker_memory = crate::agent::memory::Memory::open(worker_tmpdir.path()).unwrap();
         let coordinator_memory =
             crate::agent::memory::Memory::open(coordinator_tmpdir.path()).unwrap();
-        let platform = std::sync::Arc::new(
-            crate::mcp::platform::mock::MockPlatform::new().with_session(coordinator_session),
+
+        // ── Both agents subscribe to their own inbox ─────────────────────────
+        let worker_inbox = "bubbaloop/local/agent/worker/inbox";
+        let coordinator_inbox = "bubbaloop/local/agent/coordinator/inbox";
+
+        let worker_sub = worker_session
+            .declare_subscriber(worker_inbox)
+            .await
+            .unwrap();
+        let coordinator_sub = coordinator_session
+            .declare_subscriber(coordinator_inbox)
+            .await
+            .unwrap();
+
+        // Spawn inbox handlers — each fires once and signals via oneshot
+        let worker_rx = spawn_inbox_handler(worker_sub, worker_memory.backend.clone(), "worker");
+        let coordinator_rx = spawn_inbox_handler(
+            coordinator_sub,
+            coordinator_memory.backend.clone(),
+            "coordinator",
         );
-        let dispatcher = Dispatcher::new_with_memory(
-            platform,
+
+        // Give subscribers a moment to register before the first publish
+        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+
+        // ── Build dispatchers (each backed by its own real Zenoh session) ────
+        let coordinator_dispatcher = Dispatcher::new_with_memory(
+            std::sync::Arc::new(
+                crate::mcp::platform::mock::MockPlatform::new()
+                    .with_session(coordinator_session.clone()),
+            ),
             "local".to_string(),
             "test-machine".to_string(),
             "coordinator".to_string(),
-            coordinator_memory.backend,
+            coordinator_memory.backend.clone(),
+            None,
+            7,
+        );
+        let worker_dispatcher = Dispatcher::new_with_memory(
+            std::sync::Arc::new(
+                crate::mcp::platform::mock::MockPlatform::new()
+                    .with_session(worker_session.clone()),
+            ),
+            "local".to_string(),
+            "test-machine".to_string(),
+            "worker".to_string(),
+            worker_memory.backend.clone(),
             None,
             7,
         );
 
-        let input = json!({
-            "topic": "bubbaloop/local/agent/worker/inbox",
-            "message": "hello worker"
-        });
-        eprintln!(
-            "[coordinator] Calling publish_to_topic({:?}, \"hello worker\")",
-            "bubbaloop/local/agent/worker/inbox"
-        );
-
-        let result = dispatcher
-            .call_tool("demo-tool-id", "publish_to_topic", &input)
+        // ── Step 1: coordinator → worker ─────────────────────────────────────
+        eprintln!("[coordinator] publish_to_topic → worker");
+        let r = coordinator_dispatcher
+            .call_tool(
+                "msg-1",
+                "publish_to_topic",
+                &json!({"topic": worker_inbox, "message": "hello worker"}),
+            )
             .await;
+        assert_tool_ok(&r);
 
-        match &result {
-            crate::agent::provider::ContentBlock::ToolResult {
-                is_error, content, ..
-            } => {
-                eprintln!(
-                    "[coordinator] Tool result: {} (is_error={:?})",
-                    content, is_error
-                );
-                assert!(
-                    is_error.is_none(),
-                    "publish_to_topic returned error: {}",
-                    content
-                );
-            }
-            other => panic!("unexpected ContentBlock variant: {:?}", other),
-        }
-
-        // ── 5. Wait for delivery and assert the episodic log entry ───────────
-        tokio::time::timeout(std::time::Duration::from_secs(5), done_rx)
+        let worker_log = tokio::time::timeout(std::time::Duration::from_secs(5), worker_rx)
             .await
-            .expect("message never arrived within 5 s")
-            .expect("done sender dropped");
-
-        let backend = worker_memory.backend.lock().await;
-        let entries = backend.episodic.search("coordinator", 10).unwrap();
-
+            .expect("worker inbox: no message within 5 s")
+            .unwrap();
         assert!(
-            !entries.is_empty(),
-            "no entries found in worker episodic log"
-        );
-        let entry = &entries[0];
-        eprintln!("[worker]      Episodic log entry: \"{}\"", entry.content);
-        assert!(
-            entry
-                .content
-                .contains("[agent_message from coordinator] hello worker"),
-            "unexpected entry content: {}",
-            entry.content
+            worker_log.contains("[agent_message from coordinator] hello worker"),
+            "worker log: {}",
+            worker_log
         );
 
-        eprintln!("\n✓  Message delivered and logged.");
-        eprintln!("   topic   : bubbaloop/local/agent/worker/inbox");
-        eprintln!("   sender  : coordinator");
-        eprintln!("   log     : \"{}\"", entry.content);
-        eprintln!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n");
+        // ── Step 2: worker → coordinator ─────────────────────────────────────
+        eprintln!("[worker]      publish_to_topic → coordinator");
+        let r = worker_dispatcher
+            .call_tool(
+                "msg-2",
+                "publish_to_topic",
+                &json!({"topic": coordinator_inbox, "message": "hello coordinator"}),
+            )
+            .await;
+        assert_tool_ok(&r);
+
+        let coordinator_log =
+            tokio::time::timeout(std::time::Duration::from_secs(5), coordinator_rx)
+                .await
+                .expect("coordinator inbox: no message within 5 s")
+                .unwrap();
+        assert!(
+            coordinator_log.contains("[agent_message from worker] hello coordinator"),
+            "coordinator log: {}",
+            coordinator_log
+        );
+
+        eprintln!("\n✓ Bidirectional messaging verified");
+        eprintln!("  worker log      : \"{}\"", worker_log);
+        eprintln!("  coordinator log : \"{}\"", coordinator_log);
+        eprintln!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n");
     }
 }

--- a/crates/bubbaloop/src/agent/dispatch.rs
+++ b/crates/bubbaloop/src/agent/dispatch.rs
@@ -1537,4 +1537,180 @@ mod tests {
         assert!(r.is_error);
         assert_eq!(r.text, "bad");
     }
+
+    // ── E2E: agent-to-agent messaging via real Zenoh pub/sub ────────────────
+    //
+    // Proves the full chain without a running daemon or LLM:
+    //
+    //   Dispatcher.call_tool("publish_to_topic")
+    //     → MockPlatform (real Zenoh session) → session.put()
+    //     → Zenoh peer TCP delivery
+    //     → inbox subscriber (mirrors runtime.rs exactly)
+    //     → EpisodicLog::append()
+    //     → assert "[agent_message from coordinator] hello worker"
+
+    /// Open a Zenoh peer session that listens on the given TCP port.
+    async fn open_listen_session(port: u16) -> std::sync::Arc<zenoh::Session> {
+        let mut cfg = zenoh::Config::default();
+        cfg.insert_json5("mode", "\"peer\"").unwrap();
+        cfg.insert_json5("listen/endpoints", &format!("[\"tcp/127.0.0.1:{}\"]", port))
+            .unwrap();
+        cfg.insert_json5("scouting/multicast/enabled", "false")
+            .unwrap();
+        std::sync::Arc::new(zenoh::open(cfg).await.unwrap())
+    }
+
+    /// Open a Zenoh peer session that connects to the given TCP port.
+    async fn open_connect_session(port: u16) -> std::sync::Arc<zenoh::Session> {
+        let mut cfg = zenoh::Config::default();
+        cfg.insert_json5("mode", "\"peer\"").unwrap();
+        cfg.insert_json5(
+            "connect/endpoints",
+            &format!("[\"tcp/127.0.0.1:{}\"]", port),
+        )
+        .unwrap();
+        cfg.insert_json5("scouting/multicast/enabled", "false")
+            .unwrap();
+        std::sync::Arc::new(zenoh::open(cfg).await.unwrap())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn e2e_agent_messaging_pub_sub() {
+        // Unique port for this test — avoids conflicts with other test runs
+        const PORT: u16 = 14_789;
+
+        // ── 1. Open two Zenoh peer sessions (no router needed) ──────────────
+        // Worker session listens; coordinator session connects.
+        let worker_session = open_listen_session(PORT).await;
+        let coordinator_session = open_connect_session(PORT).await;
+
+        eprintln!("\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+        eprintln!(" Bubbaloop — agent-to-agent messaging demo");
+        eprintln!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n");
+        eprintln!("[coordinator] Zenoh session open (peer TCP :{PORT})");
+        eprintln!("[worker]      Zenoh session open (peer TCP :{PORT})");
+
+        // ── 2. Real memory backend for the worker ────────────────────────────
+        let tmpdir = tempfile::tempdir().unwrap();
+        let worker_memory = crate::agent::memory::Memory::open(tmpdir.path()).unwrap();
+
+        // ── 3. Worker subscribes to its inbox ────────────────────────────────
+        let inbox = "bubbaloop/local/agent/worker/inbox";
+        eprintln!("[worker]      Subscribed to inbox: {}", inbox);
+
+        let sub = worker_session
+            .declare_subscriber(inbox)
+            .await
+            .expect("failed to declare subscriber");
+
+        // Spawn the inbox handler — mirrors runtime.rs:446-479 exactly
+        let backend = worker_memory.backend.clone();
+        let (done_tx, done_rx) = tokio::sync::oneshot::channel::<()>();
+        tokio::spawn(async move {
+            if let Ok(sample) = sub.recv_async().await {
+                let bytes = sample.payload().to_bytes();
+                let payload = String::from_utf8_lossy(&bytes).into_owned();
+
+                let (sender, msg) =
+                    if let Ok(v) = serde_json::from_str::<serde_json::Value>(&payload) {
+                        let s = v["sender"].as_str().unwrap_or("unknown").to_owned();
+                        let m = v["message"].as_str().unwrap_or(&payload).to_owned();
+                        (s, m)
+                    } else {
+                        ("unknown-agent".to_owned(), payload)
+                    };
+
+                let content = format!("[agent_message from {}] {}", sender, msg);
+                eprintln!(
+                    "[worker]      Inbox received → episodic log: \"{}\"",
+                    content
+                );
+
+                let entry = crate::agent::memory::episodic::EpisodicLog::make_entry(
+                    "system", &content, None,
+                );
+                backend.lock().await.episodic.append(&entry).unwrap();
+                let _ = done_tx.send(());
+            }
+        });
+
+        // Give the subscriber a moment to register
+        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+
+        // ── 4. Coordinator sends via Dispatcher.call_tool ────────────────────
+        let coordinator_tmpdir = tempfile::tempdir().unwrap();
+        let coordinator_memory =
+            crate::agent::memory::Memory::open(coordinator_tmpdir.path()).unwrap();
+        let platform = std::sync::Arc::new(
+            crate::mcp::platform::mock::MockPlatform::new().with_session(coordinator_session),
+        );
+        let dispatcher = Dispatcher::new_with_memory(
+            platform,
+            "local".to_string(),
+            "test-machine".to_string(),
+            "coordinator".to_string(),
+            coordinator_memory.backend,
+            None,
+            7,
+        );
+
+        let input = json!({
+            "topic": "bubbaloop/local/agent/worker/inbox",
+            "message": "hello worker"
+        });
+        eprintln!(
+            "[coordinator] Calling publish_to_topic({:?}, \"hello worker\")",
+            "bubbaloop/local/agent/worker/inbox"
+        );
+
+        let result = dispatcher
+            .call_tool("demo-tool-id", "publish_to_topic", &input)
+            .await;
+
+        match &result {
+            crate::agent::provider::ContentBlock::ToolResult {
+                is_error, content, ..
+            } => {
+                eprintln!(
+                    "[coordinator] Tool result: {} (is_error={:?})",
+                    content, is_error
+                );
+                assert!(
+                    is_error.is_none(),
+                    "publish_to_topic returned error: {}",
+                    content
+                );
+            }
+            other => panic!("unexpected ContentBlock variant: {:?}", other),
+        }
+
+        // ── 5. Wait for delivery and assert the episodic log entry ───────────
+        tokio::time::timeout(std::time::Duration::from_secs(5), done_rx)
+            .await
+            .expect("message never arrived within 5 s")
+            .expect("done sender dropped");
+
+        let backend = worker_memory.backend.lock().await;
+        let entries = backend.episodic.search("coordinator", 10).unwrap();
+
+        assert!(
+            !entries.is_empty(),
+            "no entries found in worker episodic log"
+        );
+        let entry = &entries[0];
+        eprintln!("[worker]      Episodic log entry: \"{}\"", entry.content);
+        assert!(
+            entry
+                .content
+                .contains("[agent_message from coordinator] hello worker"),
+            "unexpected entry content: {}",
+            entry.content
+        );
+
+        eprintln!("\n✓  Message delivered and logged.");
+        eprintln!("   topic   : bubbaloop/local/agent/worker/inbox");
+        eprintln!("   sender  : coordinator");
+        eprintln!("   log     : \"{}\"", entry.content);
+        eprintln!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n");
+    }
 }

--- a/crates/bubbaloop/src/agent/runtime.rs
+++ b/crates/bubbaloop/src/agent/runtime.rs
@@ -383,6 +383,7 @@ impl AgentRuntime {
                     platform.clone(),
                     scope.clone(),
                     machine_id.clone(),
+                    agent_id.clone(),
                     memory.backend.clone(),
                     Some(job_notify.clone()),
                     decay,
@@ -431,6 +432,53 @@ impl AgentRuntime {
                             e
                         );
                     }
+                }
+            });
+
+            // Subscribe to this agent's inbox topic so other agents can send messages.
+            // Messages are appended to episodic memory and surface in the next prompt turn.
+            let inbox_topic = format!("bubbaloop/{}/agent/{}/inbox", scope, agent_id);
+            let inbox_session = session.clone();
+            let inbox_backend = memory.backend.clone();
+            let mut inbox_shutdown = shutdown_rx.clone();
+            let inbox_agent_id = agent_id.clone();
+            tokio::spawn(async move {
+                match inbox_session.declare_subscriber(&inbox_topic).await {
+                    Ok(sub) => {
+                        log::info!("[Runtime] Agent '{}' inbox: {}", inbox_agent_id, inbox_topic);
+                        loop {
+                            tokio::select! {
+                                Ok(sample) = sub.recv_async() => {
+                                    let bytes = sample.payload().to_bytes();
+                                    let payload = String::from_utf8_lossy(&bytes).into_owned();
+                                    let (sender, message) = if let Ok(v) =
+                                        serde_json::from_str::<serde_json::Value>(&payload)
+                                    {
+                                        let s = v["sender"].as_str().unwrap_or("unknown").to_owned();
+                                        let m = v["message"].as_str().unwrap_or(&payload).to_owned();
+                                        (s, m)
+                                    } else {
+                                        ("unknown-agent".to_owned(), payload)
+                                    };
+                                    let entry = crate::agent::memory::episodic::EpisodicLog::make_entry(
+                                        "system",
+                                        &format!("[agent_message from {}] {}", sender, message),
+                                        None,
+                                    );
+                                    let backend = inbox_backend.lock().await;
+                                    if let Err(e) = backend.episodic.append(&entry) {
+                                        log::warn!("[Runtime] Failed to persist inbox message: {}", e);
+                                    }
+                                }
+                                _ = inbox_shutdown.changed() => break,
+                            }
+                        }
+                    }
+                    Err(e) => log::warn!(
+                        "[Runtime] Agent '{}' could not subscribe to inbox: {}",
+                        inbox_agent_id,
+                        e
+                    ),
                 }
             });
 

--- a/crates/bubbaloop/src/agent/runtime.rs
+++ b/crates/bubbaloop/src/agent/runtime.rs
@@ -445,7 +445,11 @@ impl AgentRuntime {
             tokio::spawn(async move {
                 match inbox_session.declare_subscriber(&inbox_topic).await {
                     Ok(sub) => {
-                        log::info!("[Runtime] Agent '{}' inbox: {}", inbox_agent_id, inbox_topic);
+                        log::info!(
+                            "[Runtime] Agent '{}' inbox: {}",
+                            inbox_agent_id,
+                            inbox_topic
+                        );
                         loop {
                             tokio::select! {
                                 Ok(sample) = sub.recv_async() => {

--- a/crates/bubbaloop/src/mcp/daemon_platform.rs
+++ b/crates/bubbaloop/src/mcp/daemon_platform.rs
@@ -702,6 +702,13 @@ impl PlatformOperations for DaemonPlatform {
             .map_err(|e| PlatformError::Internal(e.to_string()))
     }
 
+    async fn publish_to_topic(&self, topic: &str, message: &str) -> PlatformResult<()> {
+        self.session
+            .put(topic, message)
+            .await
+            .map_err(|e| PlatformError::Internal(format!("Zenoh put failed: {}", e)))
+    }
+
     async fn clear_episodic_memory(&self, older_than_days: u32) -> PlatformResult<String> {
         let base = self
             .agent_db_path

--- a/crates/bubbaloop/src/mcp/mock_platform.rs
+++ b/crates/bubbaloop/src/mcp/mock_platform.rs
@@ -3,7 +3,7 @@
 use super::platform::{NodeCommand, NodeInfo, PlatformError, PlatformOperations, PlatformResult};
 use serde_json::Value;
 use std::collections::HashMap;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 pub struct MockPlatform {
     pub nodes: Mutex<Vec<NodeInfo>>,
@@ -14,6 +14,8 @@ pub struct MockPlatform {
     pub constraints: Mutex<Vec<(String, String, crate::daemon::constraints::Constraint)>>, // (id, mission_id, constraint)
     pub beliefs: Mutex<Vec<crate::agent::memory::semantic::Belief>>,
     pub world_state: Mutex<Vec<crate::agent::memory::WorldStateEntry>>,
+    /// Optional real Zenoh session for e2e tests that need actual pub/sub.
+    pub zenoh_session: Option<Arc<zenoh::Session>>,
 }
 
 impl Default for MockPlatform {
@@ -52,7 +54,15 @@ impl MockPlatform {
                     "commands": [],
                 }),
             )]),
+            zenoh_session: None,
         }
+    }
+
+    /// Attach a real Zenoh session so `publish_to_topic` makes actual pub/sub calls.
+    /// Used by e2e tests that verify the full Zenoh delivery path.
+    pub fn with_session(mut self, session: Arc<zenoh::Session>) -> Self {
+        self.zenoh_session = Some(session);
+        self
     }
 }
 
@@ -392,7 +402,13 @@ impl PlatformOperations for MockPlatform {
         Ok(self.world_state.lock().unwrap().clone())
     }
 
-    async fn publish_to_topic(&self, topic: &str, _message: &str) -> PlatformResult<()> {
+    async fn publish_to_topic(&self, topic: &str, message: &str) -> PlatformResult<()> {
+        if let Some(ref session) = self.zenoh_session {
+            session
+                .put(topic, message)
+                .await
+                .map_err(|e| PlatformError::Internal(format!("Zenoh put failed: {}", e)))?;
+        }
         log::debug!("[MockPlatform] publish_to_topic: {}", topic);
         Ok(())
     }
@@ -416,6 +432,7 @@ mod tests {
             constraints: Mutex::new(Vec::new()),
             beliefs: Mutex::new(Vec::new()),
             world_state: Mutex::new(Vec::new()),
+            zenoh_session: None,
         }
     }
 

--- a/crates/bubbaloop/src/mcp/mock_platform.rs
+++ b/crates/bubbaloop/src/mcp/mock_platform.rs
@@ -391,6 +391,11 @@ impl PlatformOperations for MockPlatform {
     async fn list_world_state(&self) -> PlatformResult<Vec<crate::agent::memory::WorldStateEntry>> {
         Ok(self.world_state.lock().unwrap().clone())
     }
+
+    async fn publish_to_topic(&self, topic: &str, _message: &str) -> PlatformResult<()> {
+        log::debug!("[MockPlatform] publish_to_topic: {}", topic);
+        Ok(())
+    }
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────

--- a/crates/bubbaloop/src/mcp/platform.rs
+++ b/crates/bubbaloop/src/mcp/platform.rs
@@ -246,6 +246,17 @@ pub trait PlatformOperations: Send + Sync + 'static {
         &self,
     ) -> impl std::future::Future<Output = PlatformResult<Vec<crate::agent::memory::WorldStateEntry>>>
            + Send;
+
+    // ── Agent messaging ───────────────────────────────────────────────
+
+    /// Publish a raw message to a Zenoh topic.
+    ///
+    /// Used by `publish_to_topic` tool to send agent-to-agent messages.
+    fn publish_to_topic(
+        &self,
+        topic: &str,
+        message: &str,
+    ) -> impl std::future::Future<Output = PlatformResult<()>> + Send;
 }
 
 /// Parameters for creating or updating a belief.

--- a/crates/bubbaloop/tests/integration_mcp.rs
+++ b/crates/bubbaloop/tests/integration_mcp.rs
@@ -144,6 +144,7 @@ fn mock_with_nodes(nodes: Vec<NodeInfo>) -> MockPlatform {
         constraints: Mutex::new(Vec::new()),
         beliefs: Mutex::new(Vec::new()),
         world_state: Mutex::new(Vec::new()),
+        zenoh_session: None,
     }
 }
 


### PR DESCRIPTION
## Summary

Adds a minimal agent-to-agent messaging primitive using Zenoh pub/sub. No new abstractions — just the smallest building block that enables coordination between agents.

## How it works

Each agent subscribes to `bubbaloop/{scope}/agent/{id}/inbox` at startup. When another agent calls the new `publish_to_topic` tool, the message is delivered via Zenoh and appended to the recipient's episodic memory as a `system` role entry. It surfaces automatically in the next prompt turn — no polling, no `read_inbox` tool needed.

Sending:
```
LLM calls publish_to_topic("bubbaloop/local/agent/worker/inbox", "process dataset X")
→ dispatcher wraps as {"sender": "coordinator", "message": "..."}
→ session.put() → zenohd router → worker agent subscriber
```

Receiving (automatic, next prompt turn):
```
[agent_message from coordinator] process dataset X
```

## Changes

- `mcp/platform.rs` — add `publish_to_topic` to `PlatformOperations` trait
- `mcp/daemon_platform.rs` — implement via `session.put()`
- `mcp/mock_platform.rs` — no-op mock
- `agent/dispatch.rs` — add `agent_name` to `Dispatcher`, new `publish_to_topic` tool (37 → 38 tools)
- `agent/runtime.rs` — pass `agent_id` to dispatcher, spawn inbox subscriber per agent

## What does NOT change

- Daemon: no awareness of agent messages
- Memory schema: reuses existing `EpisodicLog::append()` with role `"system"`
- Prompt builder: no changes — existing episodic memory rendering handles this