### PR TITLE
fix(dashboard): node discovery, start/stop commands, and is_built detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,7 +351,7 @@ dependencies = [
 
 [[package]]
 name = "bubbaloop"
-version = "0.0.11"
+version = "0.0.12-dev"
 dependencies = [
  "anyhow",
  "argh",

--- a/crates/bubbaloop/src/daemon/gateway.rs
+++ b/crates/bubbaloop/src/daemon/gateway.rs
@@ -173,6 +173,13 @@ pub fn manifest_wildcard(scope: &str) -> String {
     format!("bubbaloop/{}/*/daemon/manifest", scope)
 }
 
+/// Build the daemon nodes topic (queryable — returns protobuf NodeList).
+///
+/// Format: `bubbaloop/{scope}/{machine}/daemon/nodes`
+pub fn nodes_topic(scope: &str, machine_id: &str) -> String {
+    format!("bubbaloop/{}/{}/daemon/nodes", scope, machine_id)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/bubbaloop/src/daemon/mod.rs
+++ b/crates/bubbaloop/src/daemon/mod.rs
@@ -297,6 +297,11 @@ async fn run_daemon_gateway(
                                         .execute_command(&cmd.node_name, platform_cmd)
                                         .await;
 
+                                    let now_ms = std::time::SystemTime::now()
+                                        .duration_since(std::time::UNIX_EPOCH)
+                                        .map(|d| d.as_millis() as i64)
+                                        .unwrap_or(0);
+
                                     let cmd_result = match result {
                                         Ok(msg) => CommandResult {
                                             request_id: cmd.request_id.clone(),
@@ -304,6 +309,7 @@ async fn run_daemon_gateway(
                                             message: msg.clone(),
                                             output: msg,
                                             responding_machine: cmd_queryable_machine_id.clone(),
+                                            timestamp_ms: now_ms,
                                             ..Default::default()
                                         },
                                         Err(e) => CommandResult {
@@ -311,6 +317,7 @@ async fn run_daemon_gateway(
                                             success: false,
                                             message: e.to_string(),
                                             responding_machine: cmd_queryable_machine_id.clone(),
+                                            timestamp_ms: now_ms,
                                             ..Default::default()
                                         },
                                     };

--- a/crates/bubbaloop/src/daemon/mod.rs
+++ b/crates/bubbaloop/src/daemon/mod.rs
@@ -242,6 +242,7 @@ async fn run_daemon_gateway(
                                                 success: false,
                                                 message: format!("Invalid command payload: {}", e),
                                                 responding_machine: cmd_queryable_machine_id.clone(),
+                                                timestamp_ms: util::now_ms(),
                                                 ..Default::default()
                                             };
                                             let mut buf = Vec::new();
@@ -265,24 +266,43 @@ async fn run_daemon_gateway(
                                     log::info!("[Gateway] Command query: {:?} for {}", cmd.command, cmd.node_name);
 
                                     use crate::mcp::platform::{NodeCommand as PlatformCmd, PlatformOperations};
-                                    let platform_cmd = match cmd.command {
-                                        0 => PlatformCmd::Start,
-                                        1 => PlatformCmd::Stop,
-                                        2 => PlatformCmd::Restart,
-                                        3 => PlatformCmd::Install,
-                                        4 => PlatformCmd::Uninstall,
-                                        5 => PlatformCmd::Build,
-                                        6 => PlatformCmd::Clean,
-                                        7 => PlatformCmd::EnableAutostart,
-                                        8 => PlatformCmd::DisableAutostart,
-                                        12 => PlatformCmd::GetLogs,
-                                        _ => {
+                                    use crate::schemas::daemon::v1::CommandType;
+
+                                    let platform_cmd = match CommandType::try_from(cmd.command) {
+                                        Ok(CommandType::Start) => PlatformCmd::Start,
+                                        Ok(CommandType::Stop) => PlatformCmd::Stop,
+                                        Ok(CommandType::Restart) => PlatformCmd::Restart,
+                                        Ok(CommandType::Install) => PlatformCmd::Install,
+                                        Ok(CommandType::Uninstall) => PlatformCmd::Uninstall,
+                                        Ok(CommandType::Build) => PlatformCmd::Build,
+                                        Ok(CommandType::Clean) => PlatformCmd::Clean,
+                                        Ok(CommandType::EnableAutostart) => PlatformCmd::EnableAutostart,
+                                        Ok(CommandType::DisableAutostart) => PlatformCmd::DisableAutostart,
+                                        Ok(CommandType::GetLogs) => PlatformCmd::GetLogs,
+                                        Ok(CommandType::AddNode) | Ok(CommandType::RemoveNode) | Ok(CommandType::Refresh) => {
+                                            log::warn!("[Gateway] Unsupported command type in queryable: {}", cmd.command);
+                                            let err = CommandResult {
+                                                request_id: cmd.request_id.clone(),
+                                                success: false,
+                                                message: format!("Command type {} not supported by queryable interface", cmd.command),
+                                                responding_machine: cmd_queryable_machine_id.clone(),
+                                                timestamp_ms: util::now_ms(),
+                                                ..Default::default()
+                                            };
+                                            let mut buf = Vec::new();
+                                            if err.encode(&mut buf).is_ok() {
+                                                let _ = query.reply(&cmd_queryable_key, buf).await;
+                                            }
+                                            continue;
+                                        }
+                                        Err(_) => {
                                             log::warn!("[Gateway] Unknown command type: {}", cmd.command);
                                             let err = CommandResult {
                                                 request_id: cmd.request_id.clone(),
                                                 success: false,
                                                 message: format!("Unknown command type: {}", cmd.command),
                                                 responding_machine: cmd_queryable_machine_id.clone(),
+                                                timestamp_ms: util::now_ms(),
                                                 ..Default::default()
                                             };
                                             let mut buf = Vec::new();
@@ -297,10 +317,7 @@ async fn run_daemon_gateway(
                                         .execute_command(&cmd.node_name, platform_cmd)
                                         .await;
 
-                                    let now_ms = std::time::SystemTime::now()
-                                        .duration_since(std::time::UNIX_EPOCH)
-                                        .map(|d| d.as_millis() as i64)
-                                        .unwrap_or(0);
+                                    let now_ms = util::now_ms();
 
                                     let cmd_result = match result {
                                         Ok(msg) => CommandResult {

--- a/crates/bubbaloop/src/daemon/mod.rs
+++ b/crates/bubbaloop/src/daemon/mod.rs
@@ -199,7 +199,7 @@ async fn run_daemon_gateway(
                         _ = nodes_shutdown.changed() => break,
                     }
                 }
-            },
+            }
             Err(e) => {
                 log::warn!("[Gateway] Failed to register nodes queryable: {}", e);
             }
@@ -217,9 +217,15 @@ async fn run_daemon_gateway(
         use crate::schemas::daemon::v1::{CommandResult, NodeCommand};
         use prost::Message as _;
 
-        match cmd_queryable_session.declare_queryable(&cmd_queryable_key).await {
+        match cmd_queryable_session
+            .declare_queryable(&cmd_queryable_key)
+            .await
+        {
             Ok(queryable) => {
-                log::info!("[Gateway] Command queryable registered: {}", cmd_queryable_key);
+                log::info!(
+                    "[Gateway] Command queryable registered: {}",
+                    cmd_queryable_key
+                );
                 loop {
                     tokio::select! {
                         result = queryable.recv_async() => {

--- a/crates/bubbaloop/src/daemon/mod.rs
+++ b/crates/bubbaloop/src/daemon/mod.rs
@@ -43,9 +43,9 @@ pub async fn create_session(endpoint: Option<&str>) -> Result<Arc<Session>, zeno
     // Configure Zenoh session
     let mut config = zenoh::Config::default();
 
-    // Peer mode — allows direct connections from co-located nodes
+    // Client mode — routes through zenohd so queryables are reachable
     config
-        .insert_json5("mode", "\"peer\"")
+        .insert_json5("mode", "\"client\"")
         .expect("Failed to set Zenoh mode");
 
     // Resolve endpoint: parameter > env var > default
@@ -179,22 +179,25 @@ async fn run_daemon_gateway(
     let mut nodes_shutdown = shutdown_rx.clone();
     tokio::spawn(async move {
         match nodes_session.declare_queryable(&nodes_key).await {
-            Ok(queryable) => loop {
-                tokio::select! {
-                    result = queryable.recv_async() => {
-                        match result {
-                            Ok(query) => {
-                                let node_list = nodes_nm.get_node_list().await;
-                                let mut buf = Vec::new();
-                                use prost::Message as _;
-                                if node_list.encode(&mut buf).is_ok() {
-                                    let _ = query.reply(&nodes_key, buf).await;
+            Ok(queryable) => {
+                log::info!("[Gateway] Nodes queryable registered: {}", nodes_key);
+                loop {
+                    tokio::select! {
+                        result = queryable.recv_async() => {
+                            match result {
+                                Ok(query) => {
+                                    let node_list = nodes_nm.get_node_list().await;
+                                    let mut buf = Vec::new();
+                                    use prost::Message as _;
+                                    if node_list.encode(&mut buf).is_ok() {
+                                        let _ = query.reply(&nodes_key, buf).await;
+                                    }
                                 }
+                                Err(_) => break,
                             }
-                            Err(_) => break,
                         }
+                        _ = nodes_shutdown.changed() => break,
                     }
-                    _ = nodes_shutdown.changed() => break,
                 }
             },
             Err(e) => {
@@ -203,7 +206,95 @@ async fn run_daemon_gateway(
         }
     });
 
-    // 3. Subscribe to command topic and dispatch
+    // 3. Register command queryable (for dashboard / Zenoh GET clients)
+    //    Accepts protobuf NodeCommand, returns protobuf CommandResult.
+    let cmd_queryable_key = gateway::command_topic(&scope, &machine_id);
+    let cmd_queryable_session = session.clone();
+    let cmd_queryable_platform = platform.clone();
+    let cmd_queryable_machine_id = machine_id.clone();
+    let mut cmd_queryable_shutdown = shutdown_rx.clone();
+    tokio::spawn(async move {
+        use crate::schemas::daemon::v1::{CommandResult, NodeCommand};
+        use prost::Message as _;
+
+        match cmd_queryable_session.declare_queryable(&cmd_queryable_key).await {
+            Ok(queryable) => {
+                log::info!("[Gateway] Command queryable registered: {}", cmd_queryable_key);
+                loop {
+                    tokio::select! {
+                        result = queryable.recv_async() => {
+                            match result {
+                                Ok(query) => {
+                                    let payload = query.payload()
+                                        .map(|p| p.to_bytes().to_vec())
+                                        .unwrap_or_default();
+                                    let cmd = match NodeCommand::decode(payload.as_slice()) {
+                                        Ok(c) => c,
+                                        Err(e) => {
+                                            log::warn!("[Gateway] Invalid NodeCommand: {}", e);
+                                            continue;
+                                        }
+                                    };
+                                    log::info!("[Gateway] Command query: {:?} for {}", cmd.command, cmd.node_name);
+
+                                    use crate::mcp::platform::{NodeCommand as PlatformCmd, PlatformOperations};
+                                    let platform_cmd = match cmd.command {
+                                        0 => PlatformCmd::Start,
+                                        1 => PlatformCmd::Stop,
+                                        2 => PlatformCmd::Restart,
+                                        3 => PlatformCmd::Install,
+                                        4 => PlatformCmd::Uninstall,
+                                        5 => PlatformCmd::Build,
+                                        6 => PlatformCmd::Clean,
+                                        7 => PlatformCmd::EnableAutostart,
+                                        8 => PlatformCmd::DisableAutostart,
+                                        12 => PlatformCmd::GetLogs,
+                                        _ => {
+                                            log::warn!("[Gateway] Unknown command type: {}", cmd.command);
+                                            continue;
+                                        }
+                                    };
+
+                                    let result = cmd_queryable_platform
+                                        .execute_command(&cmd.node_name, platform_cmd)
+                                        .await;
+
+                                    let cmd_result = match result {
+                                        Ok(msg) => CommandResult {
+                                            request_id: cmd.request_id.clone(),
+                                            success: true,
+                                            message: msg,
+                                            responding_machine: cmd_queryable_machine_id.clone(),
+                                            ..Default::default()
+                                        },
+                                        Err(e) => CommandResult {
+                                            request_id: cmd.request_id.clone(),
+                                            success: false,
+                                            message: e.to_string(),
+                                            responding_machine: cmd_queryable_machine_id.clone(),
+                                            ..Default::default()
+                                        },
+                                    };
+
+                                    let mut buf = Vec::new();
+                                    if cmd_result.encode(&mut buf).is_ok() {
+                                        let _ = query.reply(&cmd_queryable_key, buf).await;
+                                    }
+                                }
+                                Err(_) => break,
+                            }
+                        }
+                        _ = cmd_queryable_shutdown.changed() => break,
+                    }
+                }
+            }
+            Err(e) => {
+                log::warn!("[Gateway] Failed to register command queryable: {}", e);
+            }
+        }
+    });
+
+    // 4. Subscribe to command topic and dispatch
     let cmd_topic = gateway::command_topic(&scope, &machine_id);
     let evt_topic = gateway::events_topic(&scope, &machine_id);
 

--- a/crates/bubbaloop/src/daemon/mod.rs
+++ b/crates/bubbaloop/src/daemon/mod.rs
@@ -232,9 +232,30 @@ async fn run_daemon_gateway(
                                         Ok(c) => c,
                                         Err(e) => {
                                             log::warn!("[Gateway] Invalid NodeCommand: {}", e);
+                                            let err = CommandResult {
+                                                success: false,
+                                                message: format!("Invalid command payload: {}", e),
+                                                responding_machine: cmd_queryable_machine_id.clone(),
+                                                ..Default::default()
+                                            };
+                                            let mut buf = Vec::new();
+                                            if err.encode(&mut buf).is_ok() {
+                                                let _ = query.reply(&cmd_queryable_key, buf).await;
+                                            }
                                             continue;
                                         }
                                     };
+                                    // If target_machine is set, only respond if it matches our
+                                    // machine_id. This prevents fan-out on the wildcard query path.
+                                    if !cmd.target_machine.is_empty()
+                                        && cmd.target_machine != cmd_queryable_machine_id
+                                    {
+                                        log::debug!(
+                                            "[Gateway] Command for '{}', skipping (local='{}')",
+                                            cmd.target_machine, cmd_queryable_machine_id
+                                        );
+                                        continue;
+                                    }
                                     log::info!("[Gateway] Command query: {:?} for {}", cmd.command, cmd.node_name);
 
                                     use crate::mcp::platform::{NodeCommand as PlatformCmd, PlatformOperations};
@@ -251,6 +272,17 @@ async fn run_daemon_gateway(
                                         12 => PlatformCmd::GetLogs,
                                         _ => {
                                             log::warn!("[Gateway] Unknown command type: {}", cmd.command);
+                                            let err = CommandResult {
+                                                request_id: cmd.request_id.clone(),
+                                                success: false,
+                                                message: format!("Unknown command type: {}", cmd.command),
+                                                responding_machine: cmd_queryable_machine_id.clone(),
+                                                ..Default::default()
+                                            };
+                                            let mut buf = Vec::new();
+                                            if err.encode(&mut buf).is_ok() {
+                                                let _ = query.reply(&cmd_queryable_key, buf).await;
+                                            }
                                             continue;
                                         }
                                     };
@@ -294,7 +326,9 @@ async fn run_daemon_gateway(
         }
     });
 
-    // 4. Subscribe to command topic and dispatch
+    // 4. Subscribe to command topic and dispatch (legacy JSON pub/sub for CLI clients).
+    //    The protobuf queryable above handles the dashboard's request/reply API.
+    //    Both coexist on the same topic; their payload formats are distinct.
     let cmd_topic = gateway::command_topic(&scope, &machine_id);
     let evt_topic = gateway::events_topic(&scope, &machine_id);
 

--- a/crates/bubbaloop/src/daemon/mod.rs
+++ b/crates/bubbaloop/src/daemon/mod.rs
@@ -172,7 +172,38 @@ async fn run_daemon_gateway(
         }
     });
 
-    // 2. Subscribe to command topic and dispatch
+    // 2. Register nodes queryable (returns protobuf NodeList for dashboard)
+    let nodes_key = gateway::nodes_topic(&scope, &machine_id);
+    let nodes_session = session.clone();
+    let nodes_nm = node_manager.clone();
+    let mut nodes_shutdown = shutdown_rx.clone();
+    tokio::spawn(async move {
+        match nodes_session.declare_queryable(&nodes_key).await {
+            Ok(queryable) => loop {
+                tokio::select! {
+                    result = queryable.recv_async() => {
+                        match result {
+                            Ok(query) => {
+                                let node_list = nodes_nm.get_node_list().await;
+                                let mut buf = Vec::new();
+                                use prost::Message as _;
+                                if node_list.encode(&mut buf).is_ok() {
+                                    let _ = query.reply(&nodes_key, buf).await;
+                                }
+                            }
+                            Err(_) => break,
+                        }
+                    }
+                    _ = nodes_shutdown.changed() => break,
+                }
+            },
+            Err(e) => {
+                log::warn!("[Gateway] Failed to register nodes queryable: {}", e);
+            }
+        }
+    });
+
+    // 3. Subscribe to command topic and dispatch
     let cmd_topic = gateway::command_topic(&scope, &machine_id);
     let evt_topic = gateway::events_topic(&scope, &machine_id);
 

--- a/crates/bubbaloop/src/daemon/mod.rs
+++ b/crates/bubbaloop/src/daemon/mod.rs
@@ -301,7 +301,8 @@ async fn run_daemon_gateway(
                                         Ok(msg) => CommandResult {
                                             request_id: cmd.request_id.clone(),
                                             success: true,
-                                            message: msg,
+                                            message: msg.clone(),
+                                            output: msg,
                                             responding_machine: cmd_queryable_machine_id.clone(),
                                             ..Default::default()
                                         },

--- a/crates/bubbaloop/src/daemon/registry.rs
+++ b/crates/bubbaloop/src/daemon/registry.rs
@@ -468,12 +468,19 @@ pub fn check_is_built(node_path: &str, manifest: &NodeManifest) -> bool {
 
     let tokens: Vec<&str> = command.split_whitespace().collect();
 
+    // Empty or whitespace-only command cannot be resolved — not built
+    if tokens.is_empty() {
+        return false;
+    }
+
     // Check `-m module.path` → module/path.py
     if let Some(pos) = tokens.iter().position(|t| *t == "-m") {
-        if let Some(module) = tokens.get(pos + 1) {
-            let module_file = module.replace('.', "/") + ".py";
-            return path.join(&module_file).exists();
-        }
+        let Some(module) = tokens.get(pos + 1) else {
+            // `-m` with no following token is malformed — not built
+            return false;
+        };
+        let module_file = module.replace('.', "/") + ".py";
+        return path.join(&module_file).exists();
     }
 
     // Find first *.py token and check it exists in node dir
@@ -759,6 +766,20 @@ mod tests {
             command: command.map(String::from),
             ..Default::default()
         }
+    }
+
+    #[test]
+    fn test_is_built_empty_command_returns_false() {
+        let dir = tempfile::tempdir().unwrap();
+        let m = manifest_with("python", Some(""));
+        assert!(!check_is_built(dir.path().to_str().unwrap(), &m));
+    }
+
+    #[test]
+    fn test_is_built_m_without_module_returns_false() {
+        let dir = tempfile::tempdir().unwrap();
+        let m = manifest_with("python", Some("pixi run python -m"));
+        assert!(!check_is_built(dir.path().to_str().unwrap(), &m));
     }
 
     #[test]

--- a/crates/bubbaloop/src/daemon/registry.rs
+++ b/crates/bubbaloop/src/daemon/registry.rs
@@ -811,24 +811,6 @@ mod tests {
     }
 
     #[test]
-    fn test_is_built_config_only_no_false_positive() {
-        let dir = tempfile::tempdir().unwrap();
-        // Only config.yaml exists — must NOT match
-        std::fs::write(dir.path().join("config.yaml"), b"").unwrap();
-        let m = manifest_with("python", Some("pixi run python main.py config.yaml"));
-        assert!(!check_is_built(dir.path().to_str().unwrap(), &m));
-    }
-
-    #[test]
-    fn test_is_built_script_found_despite_config() {
-        let dir = tempfile::tempdir().unwrap();
-        std::fs::write(dir.path().join("main.py"), b"").unwrap();
-        std::fs::write(dir.path().join("config.yaml"), b"").unwrap();
-        let m = manifest_with("python", Some("pixi run python main.py config.yaml"));
-        assert!(check_is_built(dir.path().to_str().unwrap(), &m));
-    }
-
-    #[test]
     fn test_is_built_absolute_interpreter_no_false_positive() {
         let dir = tempfile::tempdir().unwrap();
         // /usr/bin/python3 exists on the system but main.py is missing

--- a/crates/bubbaloop/src/daemon/registry.rs
+++ b/crates/bubbaloop/src/daemon/registry.rs
@@ -460,9 +460,20 @@ pub fn check_is_built(node_path: &str, manifest: &NodeManifest) -> bool {
                     }
                 }
             }
-            // General case: find the first token that is a file in the node dir
-            // (handles "pixi run python main.py", "python3 sensor.py", etc.)
+            // General case: find the first token that looks like a script or
+            // binary, skipping flags (`-flag`), and config/data files.
+            // e.g. "pixi run python main.py config.yaml" → matches main.py,
+            //       not config.yaml.
+            const SKIP_EXTS: &[&str] = &[
+                ".yaml", ".yml", ".json", ".toml", ".txt", ".cfg", ".ini", ".env",
+            ];
             tokens.iter().any(|t| {
+                if t.starts_with('-') {
+                    return false;
+                }
+                if SKIP_EXTS.iter().any(|ext| t.ends_with(ext)) {
+                    return false;
+                }
                 let candidate = path.join(t);
                 candidate.exists() && candidate.is_file()
             })
@@ -732,5 +743,84 @@ mod tests {
                 effective_name(&entries[i], &manifest)
             );
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // check_is_built tests
+    // -----------------------------------------------------------------------
+
+    fn manifest_with(node_type: &str, command: Option<&str>) -> NodeManifest {
+        NodeManifest {
+            name: "test-node".to_string(),
+            version: "1.0.0".to_string(),
+            node_type: node_type.to_string(),
+            description: "Test".to_string(),
+            command: command.map(String::from),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_is_built_rust_release() {
+        let dir = tempfile::tempdir().unwrap();
+        let release_dir = dir.path().join("target/release");
+        std::fs::create_dir_all(&release_dir).unwrap();
+        std::fs::write(release_dir.join("test-node"), b"").unwrap();
+        assert!(check_is_built(dir.path().to_str().unwrap(), &manifest_with("rust", None)));
+    }
+
+    #[test]
+    fn test_is_built_rust_debug() {
+        let dir = tempfile::tempdir().unwrap();
+        let debug_dir = dir.path().join("target/debug");
+        std::fs::create_dir_all(&debug_dir).unwrap();
+        std::fs::write(debug_dir.join("test-node"), b"").unwrap();
+        assert!(check_is_built(dir.path().to_str().unwrap(), &manifest_with("rust", None)));
+    }
+
+    #[test]
+    fn test_is_built_rust_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(!check_is_built(dir.path().to_str().unwrap(), &manifest_with("rust", None)));
+    }
+
+    #[test]
+    fn test_is_built_no_command_finds_main_py() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("main.py"), b"").unwrap();
+        assert!(check_is_built(dir.path().to_str().unwrap(), &manifest_with("python", None)));
+    }
+
+    #[test]
+    fn test_is_built_no_command_missing_main_py() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(!check_is_built(dir.path().to_str().unwrap(), &manifest_with("python", None)));
+    }
+
+    #[test]
+    fn test_is_built_module_flag() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("smartpower/nodes")).unwrap();
+        std::fs::write(dir.path().join("smartpower/nodes/runner.py"), b"").unwrap();
+        let m = manifest_with("python", Some("pixi run python -m smartpower.nodes.runner config.yaml"));
+        assert!(check_is_built(dir.path().to_str().unwrap(), &m));
+    }
+
+    #[test]
+    fn test_is_built_config_only_no_false_positive() {
+        let dir = tempfile::tempdir().unwrap();
+        // Only config.yaml exists — must NOT match
+        std::fs::write(dir.path().join("config.yaml"), b"").unwrap();
+        let m = manifest_with("python", Some("pixi run python main.py config.yaml"));
+        assert!(!check_is_built(dir.path().to_str().unwrap(), &m));
+    }
+
+    #[test]
+    fn test_is_built_script_found_despite_config() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("main.py"), b"").unwrap();
+        std::fs::write(dir.path().join("config.yaml"), b"").unwrap();
+        let m = manifest_with("python", Some("pixi run python main.py config.yaml"));
+        assert!(check_is_built(dir.path().to_str().unwrap(), &m));
     }
 }

--- a/crates/bubbaloop/src/daemon/registry.rs
+++ b/crates/bubbaloop/src/daemon/registry.rs
@@ -766,7 +766,10 @@ mod tests {
         let release_dir = dir.path().join("target/release");
         std::fs::create_dir_all(&release_dir).unwrap();
         std::fs::write(release_dir.join("test-node"), b"").unwrap();
-        assert!(check_is_built(dir.path().to_str().unwrap(), &manifest_with("rust", None)));
+        assert!(check_is_built(
+            dir.path().to_str().unwrap(),
+            &manifest_with("rust", None)
+        ));
     }
 
     #[test]
@@ -775,26 +778,38 @@ mod tests {
         let debug_dir = dir.path().join("target/debug");
         std::fs::create_dir_all(&debug_dir).unwrap();
         std::fs::write(debug_dir.join("test-node"), b"").unwrap();
-        assert!(check_is_built(dir.path().to_str().unwrap(), &manifest_with("rust", None)));
+        assert!(check_is_built(
+            dir.path().to_str().unwrap(),
+            &manifest_with("rust", None)
+        ));
     }
 
     #[test]
     fn test_is_built_rust_missing() {
         let dir = tempfile::tempdir().unwrap();
-        assert!(!check_is_built(dir.path().to_str().unwrap(), &manifest_with("rust", None)));
+        assert!(!check_is_built(
+            dir.path().to_str().unwrap(),
+            &manifest_with("rust", None)
+        ));
     }
 
     #[test]
     fn test_is_built_no_command_finds_main_py() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("main.py"), b"").unwrap();
-        assert!(check_is_built(dir.path().to_str().unwrap(), &manifest_with("python", None)));
+        assert!(check_is_built(
+            dir.path().to_str().unwrap(),
+            &manifest_with("python", None)
+        ));
     }
 
     #[test]
     fn test_is_built_no_command_missing_main_py() {
         let dir = tempfile::tempdir().unwrap();
-        assert!(!check_is_built(dir.path().to_str().unwrap(), &manifest_with("python", None)));
+        assert!(!check_is_built(
+            dir.path().to_str().unwrap(),
+            &manifest_with("python", None)
+        ));
     }
 
     #[test]
@@ -802,7 +817,10 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         std::fs::create_dir_all(dir.path().join("smartpower/nodes")).unwrap();
         std::fs::write(dir.path().join("smartpower/nodes/runner.py"), b"").unwrap();
-        let m = manifest_with("python", Some("pixi run python -m smartpower.nodes.runner config.yaml"));
+        let m = manifest_with(
+            "python",
+            Some("pixi run python -m smartpower.nodes.runner config.yaml"),
+        );
         assert!(check_is_built(dir.path().to_str().unwrap(), &m));
     }
 

--- a/crates/bubbaloop/src/daemon/registry.rs
+++ b/crates/bubbaloop/src/daemon/registry.rs
@@ -429,18 +429,47 @@ pub fn list_nodes() -> Result<Vec<(NodeEntry, Option<NodeManifest>)>> {
 pub fn check_is_built(node_path: &str, manifest: &NodeManifest) -> bool {
     let path = Path::new(node_path);
 
-    if let Some(ref command) = manifest.command {
-        let binary_path = path.join(command);
-        binary_path.exists()
-    } else if manifest.node_type == "rust" {
-        // Check for target/release or target/debug binary
+    if manifest.node_type == "rust" {
+        // Rust: check for compiled binary in release or debug
         let release_path = path.join("target/release").join(&manifest.name);
         let debug_path = path.join("target/debug").join(&manifest.name);
         release_path.exists() || debug_path.exists()
+    } else if let Some(ref command) = manifest.command {
+        // `command` can be:
+        //   - a single relative path:  "./my-binary"
+        //   - a shell invocation:      "pixi run python main.py"
+        //                              "pixi run python -m smartpower.nodes.runner config.yaml"
+        //                              "python3 sensor.py"
+        //                              "/usr/bin/python3 main.py"
+        //
+        // Strategy: walk the tokens and return true as soon as we find one
+        // that looks like a file relative to node_path (ends with a known
+        // script extension or exists on disk).
+        let tokens: Vec<&str> = command.split_whitespace().collect();
+        if tokens.len() == 1 {
+            // Single token — treat as a file path relative to the node dir
+            path.join(tokens[0]).exists()
+        } else {
+            // Multi-token shell command.
+            // Special case: `-m module.path` → check for module/path.py
+            if let Some(pos) = tokens.iter().position(|t| *t == "-m") {
+                if let Some(module) = tokens.get(pos + 1) {
+                    let module_file = module.replace('.', "/") + ".py";
+                    if path.join(&module_file).exists() {
+                        return true;
+                    }
+                }
+            }
+            // General case: find the first token that is a file in the node dir
+            // (handles "pixi run python main.py", "python3 sensor.py", etc.)
+            tokens.iter().any(|t| {
+                let candidate = path.join(t);
+                candidate.exists() && candidate.is_file()
+            })
+        }
     } else {
-        // Python - check for main.py and venv
-        let main_py = path.join("main.py");
-        main_py.exists()
+        // No command specified — Python/other script: check for main.py
+        path.join("main.py").exists()
     }
 }
 

--- a/crates/bubbaloop/src/daemon/registry.rs
+++ b/crates/bubbaloop/src/daemon/registry.rs
@@ -428,7 +428,8 @@ pub fn list_nodes() -> Result<Vec<(NodeEntry, Option<NodeManifest>)>> {
 /// Check if a node's binary/script is built.
 ///
 /// Detection order:
-/// 1. Rust nodes: binary in `target/release/<name>` or `target/debug/<name>`
+/// 1. Rust nodes: binary in `target/release/<name>` or `target/debug/<name>`.
+///    Fallback: first relative token in `command` (for non-standard binary locations).
 /// 2. No `command`: check for `main.py` in the node directory
 /// 3. Command with `-m module.path`: check `module/path.py` in node dir
 ///    e.g. `pixi run python -m smartpower.nodes.runner` → `smartpower/nodes/runner.py`
@@ -440,10 +441,24 @@ pub fn check_is_built(node_path: &str, manifest: &NodeManifest) -> bool {
     let path = Path::new(node_path);
 
     if manifest.node_type == "rust" {
-        // Rust: check for compiled binary in release or debug
+        // Standard cargo output locations
         let release_path = path.join("target/release").join(&manifest.name);
         let debug_path = path.join("target/debug").join(&manifest.name);
-        return release_path.exists() || debug_path.exists();
+        if release_path.exists() || debug_path.exists() {
+            return true;
+        }
+        // Fallback: command may point to a non-standard relative binary path
+        // (e.g. `command: "target/aarch64-unknown-linux-gnu/release/my-node"`).
+        // Absolute paths and flags are ignored — they don't live in the node dir.
+        if let Some(ref command) = manifest.command {
+            if let Some(token) = command
+                .split_whitespace()
+                .find(|t| !t.starts_with('-') && !std::path::Path::new(t).is_absolute())
+            {
+                return path.join(token).exists();
+            }
+        }
+        return false;
     }
 
     let Some(ref command) = manifest.command else {
@@ -777,6 +792,20 @@ mod tests {
             dir.path().to_str().unwrap(),
             &manifest_with("rust", None)
         ));
+    }
+
+    #[test]
+    fn test_is_built_rust_non_standard_command() {
+        let dir = tempfile::tempdir().unwrap();
+        // Non-standard cross-compilation target path
+        let cross_dir = dir.path().join("target/aarch64-unknown-linux-gnu/release");
+        std::fs::create_dir_all(&cross_dir).unwrap();
+        std::fs::write(cross_dir.join("test-node"), b"").unwrap();
+        let m = manifest_with(
+            "rust",
+            Some("target/aarch64-unknown-linux-gnu/release/test-node"),
+        );
+        assert!(check_is_built(dir.path().to_str().unwrap(), &m));
     }
 
     #[test]

--- a/crates/bubbaloop/src/daemon/registry.rs
+++ b/crates/bubbaloop/src/daemon/registry.rs
@@ -425,7 +425,17 @@ pub fn list_nodes() -> Result<Vec<(NodeEntry, Option<NodeManifest>)>> {
     Ok(nodes)
 }
 
-/// Check if a node's binary/script is built
+/// Check if a node's binary/script is built.
+///
+/// Detection order:
+/// 1. Rust nodes: binary in `target/release/<name>` or `target/debug/<name>`
+/// 2. No `command`: check for `main.py` in the node directory
+/// 3. Command with `-m module.path`: check `module/path.py` in node dir
+///    e.g. `pixi run python -m smartpower.nodes.runner` → `smartpower/nodes/runner.py`
+/// 4. Command with a `*.py` token: check that file in node dir
+///    e.g. `pixi run python sensor.py` → `sensor.py`
+///    e.g. `python3 main.py` → `main.py`
+/// 5. Anything else (external binary, pixi task, etc.): assume built (`true`)
 pub fn check_is_built(node_path: &str, manifest: &NodeManifest) -> bool {
     let path = Path::new(node_path);
 
@@ -433,55 +443,31 @@ pub fn check_is_built(node_path: &str, manifest: &NodeManifest) -> bool {
         // Rust: check for compiled binary in release or debug
         let release_path = path.join("target/release").join(&manifest.name);
         let debug_path = path.join("target/debug").join(&manifest.name);
-        release_path.exists() || debug_path.exists()
-    } else if let Some(ref command) = manifest.command {
-        // `command` can be:
-        //   - a single relative path:  "./my-binary"
-        //   - a shell invocation:      "pixi run python main.py"
-        //                              "pixi run python -m nodes.runner config.yaml"
-        //                              "python3 sensor.py"
-        //                              "/usr/bin/python3 main.py"
-        //
-        // Strategy: walk the tokens and return true as soon as we find one
-        // that looks like a file relative to node_path (ends with a known
-        // script extension or exists on disk).
-        let tokens: Vec<&str> = command.split_whitespace().collect();
-        if tokens.len() == 1 {
-            // Single token — treat as a file path relative to the node dir
-            path.join(tokens[0]).exists()
-        } else {
-            // Multi-token shell command.
-            // Special case: `-m module.path` → check for module/path.py
-            if let Some(pos) = tokens.iter().position(|t| *t == "-m") {
-                if let Some(module) = tokens.get(pos + 1) {
-                    let module_file = module.replace('.', "/") + ".py";
-                    if path.join(&module_file).exists() {
-                        return true;
-                    }
-                }
-            }
-            // General case: find the first token that looks like a script or
-            // binary, skipping flags (`-flag`), and config/data files.
-            // e.g. "pixi run python main.py config.yaml" → matches main.py,
-            //       not config.yaml.
-            const SKIP_EXTS: &[&str] = &[
-                ".yaml", ".yml", ".json", ".toml", ".txt", ".cfg", ".ini", ".env",
-            ];
-            tokens.iter().any(|t| {
-                if t.starts_with('-') {
-                    return false;
-                }
-                if SKIP_EXTS.iter().any(|ext| t.ends_with(ext)) {
-                    return false;
-                }
-                let candidate = path.join(t);
-                candidate.exists() && candidate.is_file()
-            })
-        }
-    } else {
-        // No command specified — Python/other script: check for main.py
-        path.join("main.py").exists()
+        return release_path.exists() || debug_path.exists();
     }
+
+    let Some(ref command) = manifest.command else {
+        // No command — default Python entrypoint
+        return path.join("main.py").exists();
+    };
+
+    let tokens: Vec<&str> = command.split_whitespace().collect();
+
+    // Check `-m module.path` → module/path.py
+    if let Some(pos) = tokens.iter().position(|t| *t == "-m") {
+        if let Some(module) = tokens.get(pos + 1) {
+            let module_file = module.replace('.', "/") + ".py";
+            return path.join(&module_file).exists();
+        }
+    }
+
+    // Find first *.py token and check it exists in node dir
+    if let Some(script) = tokens.iter().find(|t| t.ends_with(".py")) {
+        return path.join(script).exists();
+    }
+
+    // External binary, pixi task, or other launcher — assume built
+    true
 }
 
 /// Get current timestamp as ISO 8601 string (RFC 3339 format)
@@ -839,6 +825,39 @@ mod tests {
         std::fs::write(dir.path().join("main.py"), b"").unwrap();
         std::fs::write(dir.path().join("config.yaml"), b"").unwrap();
         let m = manifest_with("python", Some("pixi run python main.py config.yaml"));
+        assert!(check_is_built(dir.path().to_str().unwrap(), &m));
+    }
+
+    #[test]
+    fn test_is_built_absolute_interpreter_no_false_positive() {
+        let dir = tempfile::tempdir().unwrap();
+        // /usr/bin/python3 exists on the system but main.py is missing
+        let m = manifest_with("python", Some("/usr/bin/python3 main.py"));
+        assert!(!check_is_built(dir.path().to_str().unwrap(), &m));
+    }
+
+    #[test]
+    fn test_is_built_absolute_interpreter_with_script() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("main.py"), b"").unwrap();
+        let m = manifest_with("python", Some("/usr/bin/python3 main.py"));
+        assert!(check_is_built(dir.path().to_str().unwrap(), &m));
+    }
+
+    #[test]
+    fn test_is_built_non_default_script() {
+        // "pixi run python sensor.py" — script is not main.py
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("sensor.py"), b"").unwrap();
+        let m = manifest_with("python", Some("pixi run python sensor.py"));
+        assert!(check_is_built(dir.path().to_str().unwrap(), &m));
+    }
+
+    #[test]
+    fn test_is_built_pixi_task_no_py_returns_true() {
+        // "pixi run run" — no .py token, external launcher, assume built
+        let dir = tempfile::tempdir().unwrap();
+        let m = manifest_with("python", Some("pixi run run"));
         assert!(check_is_built(dir.path().to_str().unwrap(), &m));
     }
 }

--- a/crates/bubbaloop/src/daemon/registry.rs
+++ b/crates/bubbaloop/src/daemon/registry.rs
@@ -438,7 +438,7 @@ pub fn check_is_built(node_path: &str, manifest: &NodeManifest) -> bool {
         // `command` can be:
         //   - a single relative path:  "./my-binary"
         //   - a shell invocation:      "pixi run python main.py"
-        //                              "pixi run python -m smartpower.nodes.runner config.yaml"
+        //                              "pixi run python -m nodes.runner config.yaml"
         //                              "python3 sensor.py"
         //                              "/usr/bin/python3 main.py"
         //

--- a/crates/bubbaloop/src/daemon/util.rs
+++ b/crates/bubbaloop/src/daemon/util.rs
@@ -19,6 +19,16 @@ pub fn get_machine_id() -> String {
         .replace('-', "_")
 }
 
+/// Get current time in milliseconds since Unix epoch.
+///
+/// Returns 0 if unable to determine current time.
+pub fn now_ms() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
 /// Open a SQLite connection with WAL mode and busy timeout configured.
 ///
 /// All daemon SQLite stores should use this instead of duplicating the pragma setup.

--- a/dashboard/src/components/NodesView.tsx
+++ b/dashboard/src/components/NodesView.tsx
@@ -110,9 +110,7 @@ export function NodesViewPanel({
 
         // Look up target node to route command to correct machine
         const targetNode = nodes.find((n) => n.name === nodeName);
-        const commandKey = targetNode?.machine_id
-          ? `bubbaloop/${targetNode.machine_id}/daemon/command`
-          : "bubbaloop/daemon/command";
+        const commandKey = "bubbaloop/**/daemon/command";
 
         const cmd = NodeCommandProto.create({
           command: commandMap[command] ?? CommandType.COMMAND_TYPE_START,
@@ -206,9 +204,7 @@ export function NodesViewPanel({
 
       // Look up target node to route logs request to correct machine
       const targetNode = nodes.find((n) => n.name === nodeName);
-      const commandKey = targetNode?.machine_id
-        ? `bubbaloop/${targetNode.machine_id}/daemon/command`
-        : "bubbaloop/daemon/command";
+      const commandKey = "bubbaloop/**/daemon/command";
 
       const cmd = NodeCommandProto.create({
         command: CommandType.COMMAND_TYPE_GET_LOGS,

--- a/dashboard/src/components/NodesView.tsx
+++ b/dashboard/src/components/NodesView.tsx
@@ -110,6 +110,9 @@ export function NodesViewPanel({
 
         // Look up target node to route command to correct machine
         const targetNode = nodes.find((n) => n.name === nodeName);
+        // Use wildcard path: the dashboard doesn't know the Zenoh scope/machine-id
+        // at query time. Fan-out is safe because NodeCommand includes target_machine
+        // and each daemon skips commands not addressed to it.
         const commandKey = "bubbaloop/**/daemon/command";
 
         const cmd = NodeCommandProto.create({

--- a/dashboard/src/components/NodesView.tsx
+++ b/dashboard/src/components/NodesView.tsx
@@ -110,8 +110,13 @@ export function NodesViewPanel({
 
         // Look up target node to route command to correct machine
         const targetNode = nodes.find((n) => n.name === nodeName);
-        // Use wildcard path: the dashboard doesn't know the Zenoh scope/machine-id
-        // at query time. Fan-out is safe because NodeCommand includes target_machine
+        if (!targetNode?.machine_id) {
+          setMessage({ text: "Cannot resolve machine for this node", type: "error" });
+          return;
+        }
+
+        // Use wildcard path: the dashboard doesn't know the Zenoh scope.
+        // Fan-out is safe because NodeCommand.target_machine is always set
         // and each daemon skips commands not addressed to it.
         const commandKey = "bubbaloop/**/daemon/command";
 
@@ -120,7 +125,7 @@ export function NodesViewPanel({
           nodeName: nodeName,
           nodePath: "",
           requestId: crypto.randomUUID(),
-          targetMachine: targetNode?.machine_id || "",
+          targetMachine: targetNode.machine_id,
         });
 
         const payload = NodeCommandProto.encode(cmd).finish();
@@ -207,6 +212,9 @@ export function NodesViewPanel({
 
       // Look up target node to route logs request to correct machine
       const targetNode = nodes.find((n) => n.name === nodeName);
+      if (!targetNode?.machine_id) {
+        throw new Error("Cannot resolve machine for this node");
+      }
       const commandKey = "bubbaloop/**/daemon/command";
 
       const cmd = NodeCommandProto.create({
@@ -214,7 +222,7 @@ export function NodesViewPanel({
         nodeName: nodeName,
         nodePath: "",
         requestId: crypto.randomUUID(),
-        targetMachine: targetNode?.machine_id || "",
+        targetMachine: targetNode.machine_id,
       });
 
       const payload = NodeCommandProto.encode(cmd).finish();

--- a/dashboard/src/contexts/NodeDiscoveryContext.tsx
+++ b/dashboard/src/contexts/NodeDiscoveryContext.tsx
@@ -1,14 +1,12 @@
-/**
- * NodeDiscoveryContext — Hybrid node discovery via daemon API + direct manifest queries.
- *
- * Two independent discovery loops:
- * 1. Manifest discovery: queries `bubbaloop/** /manifest` (every 10s, backs off to 30s)
- *    Each running node responds with its JSON manifest.
- * 2. Daemon polling: queries `bubbaloop/** /daemon/nodes` (every 3s) for protobuf NodeList.
- *
- * Results are merged: manifest provides rich metadata, daemon provides runtime state.
- * When daemon is down, nodes discovered via manifest still appear (status = 'unknown').
- */
+// NodeDiscoveryContext — Hybrid node discovery via daemon API + direct manifest queries.
+//
+// Two independent discovery loops:
+// 1. Manifest discovery: queries `bubbaloop/**/manifest` (every 10s, backs off to 30s)
+//    Each running node responds with its JSON manifest.
+// 2. Daemon polling: queries `bubbaloop/**/daemon/nodes` (every 3s) for protobuf NodeList.
+//
+// Results are merged: manifest provides rich metadata, daemon provides runtime state.
+// When daemon is down, nodes discovered via manifest still appear (status = 'unknown').
 
 import {
   createContext,

--- a/dashboard/src/contexts/NodeDiscoveryContext.tsx
+++ b/dashboard/src/contexts/NodeDiscoveryContext.tsx
@@ -4,7 +4,7 @@
  * Two independent discovery loops:
  * 1. Manifest discovery: queries `bubbaloop/** /manifest` (every 10s, backs off to 30s)
  *    Each running node responds with its JSON manifest.
- * 2. Daemon polling: queries `bubbaloop/daemon/nodes` (every 3s) for protobuf NodeList.
+ * 2. Daemon polling: queries `bubbaloop/** /daemon/nodes` (every 3s) for protobuf NodeList.
  *
  * Results are merged: manifest provides rich metadata, daemon provides runtime state.
  * When daemon is down, nodes discovered via manifest still appear (status = 'unknown').

--- a/dashboard/src/contexts/NodeDiscoveryContext.tsx
+++ b/dashboard/src/contexts/NodeDiscoveryContext.tsx
@@ -242,7 +242,7 @@ export function NodeDiscoveryProvider({
     if (!currentSession) return [];
 
     try {
-      const receiver = await currentSession.get("bubbaloop/daemon/nodes", {
+      const receiver = await currentSession.get("bubbaloop/**/daemon/nodes", {
         timeout: Duration.milliseconds.of(5000),
       });
 

--- a/dashboard/src/contexts/__tests__/NodeDiscoveryContext.test.tsx
+++ b/dashboard/src/contexts/__tests__/NodeDiscoveryContext.test.tsx
@@ -235,7 +235,7 @@ describe('NodeDiscoveryContext', () => {
           await vi.advanceTimersByTimeAsync(100);
         });
 
-        expect(mockGet).toHaveBeenCalledWith('bubbaloop/daemon/nodes', { timeout: 5000 });
+        expect(mockGet).toHaveBeenCalledWith('bubbaloop/**/daemon/nodes', { timeout: 5000 });
       });
 
       it('sets daemonConnected=true after receiving daemon data', async () => {
@@ -268,7 +268,7 @@ describe('NodeDiscoveryContext', () => {
 
         const sample = createMockSample('bubbaloop/daemon/nodes', nodeListData);
         const reply = createMockReply(sample);
-        const responses = new Map([['bubbaloop/daemon/nodes', [reply]]]);
+        const responses = new Map([['bubbaloop/**/daemon/nodes', [reply]]]);
         const session = createMockSession(responses);
         const wrapper = makeWrapper(session);
 
@@ -343,7 +343,7 @@ describe('NodeDiscoveryContext', () => {
 
         const sample = createMockSample('bubbaloop/daemon/nodes', nodeListData);
         const reply = createMockReply(sample);
-        const responses = new Map([['bubbaloop/daemon/nodes', [reply]]]);
+        const responses = new Map([['bubbaloop/**/daemon/nodes', [reply]]]);
         const session = createMockSession(responses);
         const wrapper = makeWrapper(session);
 
@@ -371,7 +371,7 @@ describe('NodeDiscoveryContext', () => {
 
         const sample = createMockSample('bubbaloop/daemon/nodes', nodeListData);
         const reply = createMockReply(sample);
-        const responses = new Map([['bubbaloop/daemon/nodes', [reply]]]);
+        const responses = new Map([['bubbaloop/**/daemon/nodes', [reply]]]);
         const session = createMockSession(responses);
         const wrapper = makeWrapper(session);
 
@@ -394,7 +394,7 @@ describe('NodeDiscoveryContext', () => {
         mockGetSamplePayload.mockReturnValue(nodeListData);
 
         const errorReply = createMockReplyError();
-        const responses = new Map([['bubbaloop/daemon/nodes', [errorReply]]]);
+        const responses = new Map([['bubbaloop/**/daemon/nodes', [errorReply]]]);
         const session = createMockSession(responses);
         const wrapper = makeWrapper(session);
 
@@ -538,7 +538,7 @@ describe('NodeDiscoveryContext', () => {
 
         const sample = createMockSample('bubbaloop/daemon/nodes', nodeListData);
         const reply = createMockReply(sample);
-        const responses = new Map([['bubbaloop/daemon/nodes', [reply]]]);
+        const responses = new Map([['bubbaloop/**/daemon/nodes', [reply]]]);
         const session = createMockSession(responses);
         const wrapper = makeWrapper(session);
 
@@ -653,7 +653,7 @@ describe('NodeDiscoveryContext', () => {
         const manifestReply = createMockReply(manifestSample);
 
         const responses = new Map([
-          ['bubbaloop/daemon/nodes', [daemonReply]],
+          ['bubbaloop/**/daemon/nodes', [daemonReply]],
           ['bubbaloop/**/manifest', [manifestReply]],
         ]);
 
@@ -725,7 +725,7 @@ describe('NodeDiscoveryContext', () => {
 
         const sample = createMockSample('bubbaloop/daemon/nodes', nodeListData);
         const reply = createMockReply(sample);
-        const responses = new Map([['bubbaloop/daemon/nodes', [reply]]]);
+        const responses = new Map([['bubbaloop/**/daemon/nodes', [reply]]]);
         const session = createMockSession(responses);
         const wrapper = makeWrapper(session);
 
@@ -786,7 +786,7 @@ describe('NodeDiscoveryContext', () => {
 
         const sample = createMockSample('bubbaloop/daemon/nodes', nodeListData);
         const reply = createMockReply(sample);
-        const responses = new Map([['bubbaloop/daemon/nodes', [reply]]]);
+        const responses = new Map([['bubbaloop/**/daemon/nodes', [reply]]]);
         const session = createMockSession(responses);
         const wrapper = makeWrapper(session);
 

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -264,11 +264,11 @@ Because the gateway is a Zenoh convention (not hardcoded to the CLI), you can bu
 
 ## Quick Start Workflow
 
-1. `list_nodes` → see all skillets with status
-2. `get_node_health` → get details for a specific skillet
+1. `list_nodes` → see all nodes with status
+2. `get_node_health` → get details for a specific node
 3. `get_node_schema` → understand its data format
 4. `get_stream_info` → get Zenoh topic for live data
-5. `send_command` → trigger actions on the skillet
+5. `send_command` → trigger actions on the node
 6. `schedule_task` → automate recurring agent jobs
 
 ## Architecture: Dual-Plane Model
@@ -889,9 +889,9 @@ defence-in-depth security to prevent damage to existing platforms.
 
 ---
 
-## Skillets (Nodes)
+## Nodes
 
-A "skillet" is a self-describing sensor/actuator capability. Each skillet:
+A node is a self-describing sensor/actuator capability. Each node:
 
 - **Has a manifest** (JSON) describing its capabilities, published topics, commands, hardware requirements
 - **Publishes data** on Zenoh topics (protobuf-encoded for efficiency)
@@ -899,14 +899,14 @@ A "skillet" is a self-describing sensor/actuator capability. Each skillet:
 - **Reports health** via periodic heartbeats on `bubbaloop/{scope}/{machine_id}/{node_name}/heartbeat`
 - **Serves its schema** for runtime introspection on `bubbaloop/{scope}/{machine_id}/{node_name}/schema`
 
-### Skillet Lifecycle States
+### Node Lifecycle States
 
 1. **Installed:** Source code cloned to `~/.bubbaloop/nodes/{node_name}/`
 2. **Built:** Binary compiled to `~/.bubbaloop/nodes/{node_name}/target/release/{node_name}`
 3. **Running:** systemd service active, publishing to Zenoh
 4. **Healthy:** Receiving heartbeats within expected interval
 
-### Skillet Discovery Pattern
+### Node Discovery Pattern
 
 ```
 1. list_nodes                    # Get names and status
@@ -1025,7 +1025,7 @@ bubbaloop/{scope}/{machine_id}/{node_name}/{topic}
 
 - `scope`: Deployment environment (default: "local")
 - `machine_id`: Unique machine identifier (hostname-based)
-- `node_name`: Skillet instance name
+- `node_name`: Node instance name
 - `topic`: Published topic (manifest, status, schema, command, etc.)
 
 ### Protobuf Decoding

--- a/docs/guides/create-your-first-node.md
+++ b/docs/guides/create-your-first-node.md
@@ -155,5 +155,5 @@ The `bubbaloop-schemas` crate provides these protobuf types:
 - The SDK handles health heartbeats automatically — no manual setup needed
 - Add custom protobuf messages in `protos/` and reference them in `run()`
 - Add node-specific config fields to your `Config` struct and `config.yaml`
-- See [Skillet Development Guide](../skillet-development.md) for the full SDK reference
+- See [Node Development Guide](../node-development.md) for the full SDK reference
 - See [Node Marketplace](node-marketplace.md) for publishing and discovery

--- a/docs/node-development.md
+++ b/docs/node-development.md
@@ -1,6 +1,6 @@
-# Skillet Development Guide
+# Node Development Guide
 
-> A "skillet" is a self-describing sensor or actuator capability in bubbaloop. Historically called "nodes", skillets are the core building blocks of the platform.
+> A "node" is a self-describing sensor or actuator capability in bubbaloop. Historically called "nodes", nodes are the core building blocks of the platform.
 
 ## Where Nodes Live
 
@@ -78,9 +78,9 @@ ln -s ~/my-nodes/my-sensor ~/.bubbaloop/nodes/my-sensor
 bubbaloop node add ~/.bubbaloop/nodes/my-sensor
 ```
 
-## What is a Skillet?
+## What is a node?
 
-A skillet is an autonomous process that:
+A node is an autonomous process that:
 - Connects to the Zenoh data plane
 - Publishes sensor data (protobuf-encoded)
 - Serves a manifest describing its capabilities
@@ -88,11 +88,11 @@ A skillet is an autonomous process that:
 - Reports health via periodic heartbeats
 - Manages its own lifecycle (start, stop, restart)
 
-Skillets run as systemd user services managed by the bubbaloop daemon. They can run on any machine — the daemon scopes all topics by `scope` and `machine_id` for multi-machine deployments.
+nodes run as systemd user services managed by the bubbaloop daemon. They can run on any machine — the daemon scopes all topics by `scope` and `machine_id` for multi-machine deployments.
 
-> **Recommended:** Use the [Node SDK](#node-sdk-recommended) to create Rust skillets with ~50 lines of code. The manual approach below is for advanced use cases or Python nodes.
+> **Recommended:** Use the [Node SDK](#node-sdk-recommended) to create Rust nodes with ~50 lines of code. The manual approach below is for advanced use cases or Python nodes.
 
-## Anatomy of a Skillet
+## Anatomy of a node
 
 ### Required Components
 
@@ -106,7 +106,7 @@ Skillets run as systemd user services managed by the bubbaloop daemon. They can 
 
 ### Zenoh Topics
 
-Every skillet operates within a scoped topic hierarchy:
+Every node operates within a scoped topic hierarchy:
 
 ```
 bubbaloop/{scope}/{machine_id}/{node_name}/schema      → FileDescriptorSet bytes
@@ -130,7 +130,7 @@ bubbaloop/{scope}/{machine_id}/health/{node_name}      → Periodic heartbeat
 
 ### Manifest Format
 
-The manifest is a JSON document served via Zenoh queryable that describes the skillet's capabilities:
+The manifest is a JSON document served via Zenoh queryable that describes the node's capabilities:
 
 ```json
 {
@@ -160,9 +160,9 @@ The manifest is a JSON document served via Zenoh queryable that describes the sk
 }
 ```
 
-### Schema Contract (Protobuf Skillets)
+### Schema Contract (Protobuf nodes)
 
-Every skillet that publishes protobuf messages **MUST** serve its FileDescriptorSet via a Zenoh queryable. This enables runtime schema discovery for dashboards, AI agents, and cross-node type checking.
+Every node that publishes protobuf messages **MUST** serve its FileDescriptorSet via a Zenoh queryable. This enables runtime schema discovery for dashboards, AI agents, and cross-node type checking.
 
 **Requirements:**
 
@@ -197,7 +197,7 @@ Every skillet that publishes protobuf messages **MUST** serve its FileDescriptor
        .compile_protos(&["protos/my_node.proto", "protos/header.proto"], &["protos/"])?;
    ```
 
-4. **Include all .proto files** the skillet uses (including `header.proto` from bubbaloop-schemas):
+4. **Include all .proto files** the node uses (including `header.proto` from bubbaloop-schemas):
    - Copy header.proto into node's `protos/` directory
    - Reference it in your message definitions: `import "header.proto";`
 
@@ -216,7 +216,7 @@ Every skillet that publishes protobuf messages **MUST** serve its FileDescriptor
 - Serving JSON instead of raw FileDescriptorSet bytes
 - Missing `header.proto` in FileDescriptorSet
 
-## Creating a Rust Skillet
+## Creating a Rust node
 
 ### Step 1: Scaffold
 
@@ -266,7 +266,7 @@ message SensorReading {
 
 ### Step 3: Implement the main loop
 
-Example from `openmeteo` skillet:
+Example from `openmeteo` node:
 
 ```rust
 // src/main.rs
@@ -536,9 +536,9 @@ bubbaloop node list
 bubbaloop node stop my-sensor
 ```
 
-## Creating a Python Skillet
+## Creating a Python node
 
-Python skillets follow the same contract but use `eclipse-zenoh` and `protobuf` for serialization.
+Python nodes follow the same contract but use `eclipse-zenoh` and `protobuf` for serialization.
 
 ### Step 1: Scaffold
 
@@ -566,7 +566,7 @@ Same as Rust (Step 2 above).
 
 ### Step 3: Implement the main loop
 
-Example from `network-monitor` skillet:
+Example from `network-monitor` node:
 
 ```python
 #!/usr/bin/env python3
@@ -850,7 +850,7 @@ Same as Rust (Step 7 above).
 
 ## node.yaml Format
 
-The `node.yaml` file is the marketplace metadata that describes your skillet:
+The `node.yaml` file is the marketplace metadata that describes your node:
 
 ```yaml
 name: my-sensor
@@ -886,8 +886,35 @@ requires:
 - `type` — `"rust"` or `"python"`
 - `description` — Human-readable description
 - `author` — Your name or team
-- `build` — Command to build the skillet
-- `command` — Command to run the skillet
+- `build` — Command to build the node
+- `command` — Command to run the node (see below)
+
+**`command` values:**
+
+| Value                              | When to use                            | Example                                                      |
+| ---------------------------------- | -------------------------------------- | ------------------------------------------------------------ |
+| *(omit)*                           | Python node with `main.py` — default   | —                                                            |
+| `./target/release/<name>`          | Rust binary (default path)             | `./target/release/my-node`                                   |
+| `pixi run python main.py`          | Python script via pixi                 | `pixi run python main.py`                                    |
+| `pixi run python <script>`         | Python non-default entrypoint via pixi | `pixi run python sensor.py`                                  |
+| `pixi run python -m pkg.module`    | Python package module via pixi         | `pixi run python -m smartpower.nodes.runner config.yaml`     |
+| `python3 <script>`                 | Python without pixi                    | `python3 main.py`                                            |
+| `/abs/path/to/binary`              | Absolute path to any executable        | `/usr/local/bin/my-tool`                                     |
+
+The daemon resolves relative paths to the node directory and absolute tool paths:
+
+- `pixi` → `~/.pixi/bin/pixi`
+- `cargo` → `~/.cargo/bin/cargo`
+
+**`is_built` detection logic for `command`:**
+
+The daemon checks whether the node's main artifact exists on disk before allowing it to start.
+The detection order for multi-token commands is:
+
+1. If `-m module.path` is present → checks for `module/path.py` in the node directory.
+   Example: `pixi run python -m smartpower.nodes.runner config.yaml` → checks `smartpower/nodes/runner.py`. Config files (e.g. `config.yaml`) are intentionally skipped.
+2. Otherwise → looks for the first token that exists as a file in the node directory.
+   Example: `pixi run python main.py` → finds `main.py`.
 
 **Optional fields:**
 - `capabilities` — List of skill types: `sensor`, `actuator`, `processor`, `gateway`
@@ -939,7 +966,7 @@ queryable = session.declare_queryable("my-sensor/schema")
 
 ### 3. Include header.proto in your FileDescriptorSet
 
-The `Header` message is the standard metadata envelope for all skillet messages:
+The `Header` message is the standard metadata envelope for all node messages:
 
 ```protobuf
 message Header {
@@ -952,7 +979,7 @@ message Header {
 }
 ```
 
-Every skillet message should include a `Header` as the first field:
+Every node message should include a `Header` as the first field:
 
 ```protobuf
 message SensorReading {
@@ -978,7 +1005,7 @@ Load at startup and validate all fields (bounds checking, required fields, forma
 
 ### 5. Graceful shutdown on SIGTERM
 
-The daemon sends SIGTERM when stopping a skillet. Always handle it gracefully:
+The daemon sends SIGTERM when stopping a node. Always handle it gracefully:
 
 ```rust
 // Rust: tokio::sync::watch channel pattern
@@ -1007,7 +1034,7 @@ signal.signal(signal.SIGTERM, signal_handler)
 
 ### 6. Publish health heartbeats every 5 seconds
 
-The daemon marks a skillet unhealthy if no heartbeat arrives for 30 seconds. Publish every 5 seconds for safety margin:
+The daemon marks a node unhealthy if no heartbeat arrives for 30 seconds. Publish every 5 seconds for safety margin:
 
 ```rust
 // Rust: spawn background task
@@ -1077,7 +1104,7 @@ if not (0.01 <= rate_hz <= 1000.0):
 
 ## Node SDK (Recommended)
 
-The `bubbaloop-node-sdk` crate reduces Rust skillet boilerplate from ~300 lines to ~50 lines. It provides:
+The `bubbaloop-node-sdk` crate reduces Rust node boilerplate from ~300 lines to ~50 lines. It provides:
 
 - Automatic Zenoh session creation (client mode, enforced)
 - Automatic health heartbeat publishing (5s interval)
@@ -1087,7 +1114,7 @@ The `bubbaloop-node-sdk` crate reduces Rust skillet boilerplate from ~300 lines 
 - Automatic scope/machine_id resolution
 - Automatic logging initialization
 
-**With the SDK, a complete skillet will look like this:**
+**With the SDK, a complete node will look like this:**
 
 ```rust
 use bubbaloop_node_sdk::{Node, NodeContext};
@@ -1190,11 +1217,11 @@ prost-build = "0.14"
 
 **Status:** Shipped. See `crates/bubbaloop-node-sdk/` in the bubbaloop repo.
 
-**Migration path:** Existing skillets continue to work unchanged. New Rust skillets should use the SDK. The SDK is a standalone crate (not in workspace), depended on via git, following the same pattern as `bubbaloop-schemas`.
+**Migration path:** Existing nodes continue to work unchanged. New Rust nodes should use the SDK. The SDK is a standalone crate (not in workspace), depended on via git, following the same pattern as `bubbaloop-schemas`.
 
-## Complete Skillet Checklist
+## Complete node Checklist
 
-Before submitting a new skillet, verify ALL items:
+Before submitting a new node, verify ALL items:
 
 ### Structure
 - [ ] `node.yaml` exists with: name, version, type, description, author, build, command
@@ -1238,7 +1265,7 @@ Before submitting a new skillet, verify ALL items:
 - [ ] Manual integration test: verify data publishing with `z_sub`
 - [ ] End-to-end test: register with daemon, verify `bubbaloop node list` shows HEALTHY
 
-## Reference Skillets
+## Reference nodes
 
 **Rust examples:**
 - `openmeteo/` — Weather data publisher (HTTP API, auto-discovery, complex config)
@@ -1248,14 +1275,14 @@ Before submitting a new skillet, verify ALL items:
 - `network-monitor/` — Network connectivity checks (HTTP, DNS, ping)
 
 **Best practices reference:**
-- `rtsp-camera/` is the compliance reference — only skillet with full validation tests
+- `rtsp-camera/` is the compliance reference — only node with full validation tests
 - `openmeteo/` demonstrates config defaults and graceful degradation
 - `network-monitor/` demonstrates Python patterns (protobuf compilation, signal handling)
 
 ## Getting Help
 
 - **Architecture overview:** `/home/nvidia/bubbaloop/ARCHITECTURE.md` (lines 85-220: Node Contract)
-- **Official skillets repo:** https://github.com/kornia/bubbaloop-nodes-official
+- **Official nodes repo:** https://github.com/kornia/bubbaloop-nodes-official
 - **Node SDK design:** `/home/nvidia/bubbaloop/docs/plans/2026-02-24-node-sdk-design.md`
 - **Bubbaloop CLI reference:** `bubbaloop node --help`
 - **Zenoh documentation:** https://zenoh.io/docs/

--- a/docs/node-development.md
+++ b/docs/node-development.md
@@ -1,6 +1,6 @@
 # Node Development Guide
 
-> A "node" is a self-describing sensor or actuator capability in bubbaloop. Historically called "nodes", nodes are the core building blocks of the platform.
+> A "node" is a self-describing sensor or actuator capability in bubbaloop. Historically called "skillets", nodes are the core building blocks of the platform.
 
 ## Where Nodes Live
 
@@ -88,7 +88,7 @@ A node is an autonomous process that:
 - Reports health via periodic heartbeats
 - Manages its own lifecycle (start, stop, restart)
 
-nodes run as systemd user services managed by the bubbaloop daemon. They can run on any machine — the daemon scopes all topics by `scope` and `machine_id` for multi-machine deployments.
+Nodes run as systemd user services managed by the bubbaloop daemon. They can run on any machine — the daemon scopes all topics by `scope` and `machine_id` for multi-machine deployments.
 
 > **Recommended:** Use the [Node SDK](#node-sdk-recommended) to create Rust nodes with ~50 lines of code. The manual approach below is for advanced use cases or Python nodes.
 

--- a/docs/node-development.md
+++ b/docs/node-development.md
@@ -911,10 +911,13 @@ The daemon resolves relative paths to the node directory and absolute tool paths
 The daemon checks whether the node's main artifact exists on disk before allowing it to start.
 The detection order for multi-token commands is:
 
-1. If `-m module.path` is present → checks for `module/path.py` in the node directory.
-   Example: `pixi run python -m smartpower.nodes.runner config.yaml` → checks `smartpower/nodes/runner.py`. Config files (e.g. `config.yaml`) are intentionally skipped.
-2. Otherwise → looks for the first token that exists as a file in the node directory.
-   Example: `pixi run python main.py` → finds `main.py`.
+1. **Rust nodes:** Checks for binary in `target/release/<name>` or `target/debug/<name>`. Fallback: first non-flag, non-absolute token in `command` (for non-standard cross-compilation paths).
+2. **No command (Python):** Defaults to `main.py`.
+3. **Command with `-m module.path`:** Converts dots to slashes and checks `module/path.py`.
+   Example: `pixi run python -m smartpower.nodes.runner` → checks `smartpower/nodes/runner.py`.
+4. **Command with `*.py` token:** Checks for that script file.
+   Example: `pixi run python sensor.py` → finds `sensor.py`.
+5. **Anything else (external binary, pixi task, etc.):** Assumes built (optimistic fallback).
 
 **Optional fields:**
 - `capabilities` — List of skill types: `sensor`, `actuator`, `processor`, `gateway`
@@ -1219,7 +1222,7 @@ prost-build = "0.14"
 
 **Migration path:** Existing nodes continue to work unchanged. New Rust nodes should use the SDK. The SDK is a standalone crate (not in workspace), depended on via git, following the same pattern as `bubbaloop-schemas`.
 
-## Complete node Checklist
+## Complete Node Checklist
 
 Before submitting a new node, verify ALL items:
 

--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -18,11 +18,11 @@ bubbaloop node add .
 bubbaloop node start my-sensor
 ```
 
-See the [Skillet Development Guide](skillet-development.md#node-sdk-recommended) for the full SDK reference.
+See the [Node Development Guide](node-development.md#node-sdk-recommended) for the full SDK reference.
 
 ### Manual Setup (Advanced)
 
-For full control over the Zenoh lifecycle, see the [Skillet Development Guide](skillet-development.md) which documents the raw Zenoh + argh + ctrlc pattern used by production nodes.
+For full control over the Zenoh lifecycle, see the [Node Development Guide](node-development.md) which documents the raw Zenoh + argh + ctrlc pattern used by production nodes.
 
 ---
 
@@ -75,13 +75,13 @@ prost-build = "0.14"
 
 ### Step 2: src/main.rs
 
-For the manual implementation pattern, see the [Skillet Development Guide](skillet-development.md#manual-implementation-raw-zenoh) which shows the complete pattern:
+For the manual implementation pattern, see the [Node Development Guide](node-development.md#manual-implementation-raw-zenoh) which shows the complete pattern:
 - Zenoh client session creation
 - argh CLI parsing
 - ctrlc signal handling
 - Publish/subscribe loops with proper shutdown
 
-The skillet guide includes working examples with health heartbeats, schema queryables, and protobuf encoding.
+The node development guide includes working examples with health heartbeats, schema queryables, and protobuf encoding.
 
 ---
 
@@ -262,7 +262,7 @@ python main.py -c config.yaml -e tcp/localhost:7447
 
 ## Common Patterns
 
-For common patterns including subscribing to topics, using protobuf messages, health heartbeats, and multiple publishers, see the [Skillet Development Guide](skillet-development.md#common-patterns) which documents:
+For common patterns including subscribing to topics, using protobuf messages, health heartbeats, and multiple publishers, see the [Node Development Guide](node-development.md#common-patterns) which documents:
 
 - **Subscribe to topics**: Raw Zenoh subscriber patterns with proper shutdown handling
 - **Protobuf encoding/decoding**: Using `bubbaloop-schemas` with prost

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -464,4 +464,4 @@ bubbaloop debug topics       # List active topics
 
 - [Troubleshooting](troubleshooting.md) — Common issues and solutions
 - [Configuration](../getting-started/configuration.md) — Config file reference
-- [Skillet Development](../skillet-development.md) — Node development and publishing guide
+- [Node Development](../node-development.md) — Node development and publishing guide


### PR DESCRIPTION
## Summary

- **Node discovery**: Added `bubbaloop/**/daemon/nodes` queryable to daemon so the dashboard can list installed nodes via Zenoh GET
- **Daemon client mode**: Switched daemon Zenoh session from `peer` to `client` so queryables are routed through zenohd and reachable by the dashboard
- **Start/stop/restart commands**: Added `bubbaloop/**/daemon/command` queryable (replaces pub/sub) so dashboard command buttons return a response
- **`is_built` detection**: Fixed `check_is_built()` to handle multi-word commands (e.g. `pixi run python -m module.path`) — detects `-m module.path` → `module/path.py`, falls back to first file token
- **Dashboard query path**: Fixed `NodeDiscoveryContext.tsx` to use wildcard `bubbaloop/**/daemon/nodes` instead of hardcoded machine-scoped path
- **Docs**: Renamed `skillet-development.md` → `node-development.md`, replaced all "skillet" references with "node" across 5 docs, added `command` field documentation with `is_built` detection rules

## Test plan

- [x] `bubbaloop daemon` starts and registers both `nodes` and `command` queryables (check logs: `[Gateway] Nodes queryable registered`)
- [x] Dashboard shows all installed nodes
- [x] Stopped nodes appear as "Stopped", not "Failed"
- [x] Start / Stop / Restart buttons return success response from daemon
- [x] Python node with `command: pixi run python -m smartpower.nodes.runner config.yaml` shows `is_built: true`
- [x] `pixi run check` passes