### PR TITLE
feat(sdk): bubbaloop/global+local key spaces, always-on SHM, local=bool API

### DIFF
--- a/crates/bubbaloop-node/src/context.rs
+++ b/crates/bubbaloop-node/src/context.rs
@@ -14,20 +14,25 @@ pub struct NodeContext {
 }
 
 impl NodeContext {
-    /// Build a fully-qualified scoped topic: `bubbaloop/{scope}/{machine_id}/{suffix}`
+    /// Build a global scoped topic: `bubbaloop/{scope}/{machine_id}/{suffix}`
+    ///
+    /// Use for data that is visible network-wide (dashboards, other machines).
     pub fn topic(&self, suffix: &str) -> String {
         format!("bubbaloop/{}/{}/{}", self.scope, self.machine_id, suffix)
     }
 
     /// Build a machine-local topic: `local/{machine_id}/{suffix}`
     ///
-    /// Use this for data that must stay on the same machine (e.g. SHM raw frames).
-    /// These topics are NOT under `bubbaloop/**` and will never cross the WebSocket bridge.
+    /// Use for data that must stay on this machine — e.g. raw RGBA frames passed
+    /// from a camera node to a detector via SHM. These topics are outside
+    /// `bubbaloop/**` and never cross the WebSocket bridge.
     pub fn local_topic(&self, suffix: &str) -> String {
         format!("local/{}/{}", self.machine_id, suffix)
     }
 
-    /// Create a protobuf publisher with `APPLICATION_PROTOBUF` encoding and schema suffix.
+    // ── Global publishers (network-visible, bubbaloop/** key space) ──────────
+
+    /// Create a protobuf publisher with `APPLICATION_PROTOBUF` encoding.
     pub async fn publisher_proto<T>(
         &self,
         suffix: &str,
@@ -43,28 +48,28 @@ impl NodeContext {
         crate::publisher::JsonPublisher::new(&self.session, &self.topic(suffix)).await
     }
 
-    /// Create a raw publisher that sends [`ZBytes`](zenoh::bytes::ZBytes) with no encoding.
-    ///
-    /// The caller owns the byte layout. SHM zero-copy is used automatically
-    /// when the session has it enabled and the subscriber is on the same machine.
-    pub async fn publisher_raw(&self, suffix: &str) -> Result<crate::publisher::RawPublisher> {
-        crate::publisher::RawPublisher::new(&self.session, &self.topic(suffix)).await
-    }
+    // ── Local publisher/subscriber (SHM, machine-local key space) ───────────
 
-    /// Create a raw publisher on a machine-local topic (`local/{machine_id}/{suffix}`).
+    /// Create a local publisher that sends raw [`ZBytes`](zenoh::bytes::ZBytes) to
+    /// `local/{machine_id}/{suffix}` with SHM zero-copy.
     ///
-    /// Identical to [`publisher_raw`](Self::publisher_raw) but uses [`local_topic`](Self::local_topic).
-    /// Use this for SHM frame data that must never cross the WebSocket bridge.
-    pub async fn publisher_raw_local(
-        &self,
-        suffix: &str,
-    ) -> Result<crate::publisher::RawPublisher> {
+    /// Payload never leaves the machine. Counterpart: [`subscriber_local`](Self::subscriber_local).
+    pub async fn publisher_local(&self, suffix: &str) -> Result<crate::publisher::RawPublisher> {
         crate::publisher::RawPublisher::new(&self.session, &self.local_topic(suffix)).await
     }
 
-    /// Create a typed subscriber that auto-decodes protobuf messages.
+    /// Create a local subscriber that receives raw [`ZBytes`](zenoh::bytes::ZBytes) from
+    /// `local/{machine_id}/{suffix}` with SHM zero-copy.
     ///
-    /// `suffix` is appended to the scoped base topic.
+    /// Uses a small FIFO (4 slots) — older frames are dropped when the consumer is slow.
+    /// Counterpart: [`publisher_local`](Self::publisher_local).
+    pub async fn subscriber_local(&self, suffix: &str) -> Result<crate::subscriber::RawSubscriber> {
+        crate::subscriber::RawSubscriber::new(&self.session, &self.local_topic(suffix)).await
+    }
+
+    // ── Global subscribers (network-visible, bubbaloop/** key space) ─────────
+
+    /// Create a typed subscriber that auto-decodes protobuf messages.
     pub async fn subscriber<T>(&self, suffix: &str) -> Result<crate::subscriber::TypedSubscriber<T>>
     where
         T: prost::Message + Default,
@@ -74,37 +79,32 @@ impl NodeContext {
 
     /// Create a raw subscriber that yields [`ZBytes`](zenoh::bytes::ZBytes) with no decoding.
     ///
-    /// Counterpart to [`publisher_raw`](Self::publisher_raw). The caller decodes the bytes.
     /// Uses a small FIFO (4 slots) — older frames are dropped when the consumer is slow.
     pub async fn subscriber_raw(&self, suffix: &str) -> Result<crate::subscriber::RawSubscriber> {
         crate::subscriber::RawSubscriber::new(&self.session, &self.topic(suffix)).await
-    }
-
-    /// Create a raw subscriber on a machine-local topic (`local/{machine_id}/{suffix}`).
-    ///
-    /// Counterpart to [`publisher_raw_local`](Self::publisher_raw_local).
-    pub async fn subscriber_raw_local(
-        &self,
-        suffix: &str,
-    ) -> Result<crate::subscriber::RawSubscriber> {
-        crate::subscriber::RawSubscriber::new(&self.session, &self.local_topic(suffix)).await
     }
 }
 
 #[cfg(test)]
 mod tests {
-    #[test]
-    fn topic_format() {
-        let scope = "prod";
-        let machine_id = "jetson_01";
-        let suffix = "camera/front/compressed";
-        let result = format!("bubbaloop/{}/{}/{}", scope, machine_id, suffix);
-        assert_eq!(result, "bubbaloop/prod/jetson_01/camera/front/compressed");
+    use super::*;
+
+    fn make_ctx(scope: &str, machine_id: &str) -> String {
+        format!("bubbaloop/{}/{}/sensor/data", scope, machine_id)
     }
 
     #[test]
-    fn topic_format_local_scope() {
-        let result = format!("bubbaloop/{}/{}/{}", "local", "my_host", "sensor/data");
-        assert_eq!(result, "bubbaloop/local/my_host/sensor/data");
+    fn topic_format() {
+        assert_eq!(
+            make_ctx("prod", "jetson_01"),
+            "bubbaloop/prod/jetson_01/sensor/data"
+        );
+    }
+
+    #[test]
+    fn local_topic_format() {
+        let machine_id = "jetson_01";
+        let result = format!("local/{}/tapo_terrace/raw", machine_id);
+        assert_eq!(result, "local/jetson_01/tapo_terrace/raw");
     }
 }

--- a/crates/bubbaloop-node/src/context.rs
+++ b/crates/bubbaloop-node/src/context.rs
@@ -5,7 +5,6 @@ use crate::error::Result;
 /// Context provided to nodes by the SDK runtime.
 pub struct NodeContext {
     pub session: Arc<zenoh::Session>,
-    pub scope: String,
     pub machine_id: String,
     /// Per-instance name (from config `name` field, or the node type name).
     /// Ensures multi-instance deployments don't collide on health/schema topics.
@@ -14,17 +13,19 @@ pub struct NodeContext {
 }
 
 impl NodeContext {
-    /// Build a global scoped topic: `bubbaloop/{scope}/{machine_id}/{suffix}`
+    /// Build a global topic: `bubbaloop/global/{machine_id}/{suffix}`
+    ///
+    /// Visible across the network — subscribed to by the dashboard and other machines.
     pub fn topic(&self, suffix: &str) -> String {
-        format!("bubbaloop/{}/{}/{}", self.scope, self.machine_id, suffix)
+        format!("bubbaloop/global/{}/{}", self.machine_id, suffix)
     }
 
-    /// Build a machine-local topic: `local/{machine_id}/{suffix}`
+    /// Build a machine-local topic: `bubbaloop/local/{machine_id}/{suffix}`
     ///
-    /// Local topics never cross the WebSocket bridge — use for SHM-only data
-    /// (e.g. raw RGBA frames from a camera node to a detector on the same machine).
+    /// SHM-only, never crosses the WebSocket bridge. Use for large binary payloads
+    /// (e.g. raw RGBA frames) consumed only by processes on the same machine.
     pub fn local_topic(&self, suffix: &str) -> String {
-        format!("local/{}/{}", self.machine_id, suffix)
+        format!("bubbaloop/local/{}/{}", self.machine_id, suffix)
     }
 
     fn resolve_topic(&self, suffix: &str, local: bool) -> String {
@@ -101,18 +102,17 @@ impl NodeContext {
 mod tests {
     #[test]
     fn topic_format() {
-        let (scope, machine_id, suffix) = ("prod", "jetson_01", "camera/front/compressed");
         assert_eq!(
-            format!("bubbaloop/{}/{}/{}", scope, machine_id, suffix),
-            "bubbaloop/prod/jetson_01/camera/front/compressed"
+            format!("bubbaloop/global/{}/{}", "jetson_01", "camera/front/compressed"),
+            "bubbaloop/global/jetson_01/camera/front/compressed"
         );
     }
 
     #[test]
     fn local_topic_format() {
         assert_eq!(
-            format!("local/{}/{}", "jetson_01", "tapo_terrace/raw"),
-            "local/jetson_01/tapo_terrace/raw"
+            format!("bubbaloop/local/{}/{}", "jetson_01", "tapo_terrace/raw"),
+            "bubbaloop/local/jetson_01/tapo_terrace/raw"
         );
     }
 }

--- a/crates/bubbaloop-node/src/context.rs
+++ b/crates/bubbaloop-node/src/context.rs
@@ -15,22 +15,27 @@ pub struct NodeContext {
 
 impl NodeContext {
     /// Build a global scoped topic: `bubbaloop/{scope}/{machine_id}/{suffix}`
-    ///
-    /// Use for data that is visible network-wide (dashboards, other machines).
     pub fn topic(&self, suffix: &str) -> String {
         format!("bubbaloop/{}/{}/{}", self.scope, self.machine_id, suffix)
     }
 
     /// Build a machine-local topic: `local/{machine_id}/{suffix}`
     ///
-    /// Use for data that must stay on this machine — e.g. raw RGBA frames passed
-    /// from a camera node to a detector via SHM. These topics are outside
-    /// `bubbaloop/**` and never cross the WebSocket bridge.
+    /// Local topics never cross the WebSocket bridge — use for SHM-only data
+    /// (e.g. raw RGBA frames from a camera node to a detector on the same machine).
     pub fn local_topic(&self, suffix: &str) -> String {
         format!("local/{}/{}", self.machine_id, suffix)
     }
 
-    // ── Global publishers (network-visible, bubbaloop/** key space) ──────────
+    fn resolve_topic(&self, suffix: &str, local: bool) -> String {
+        if local {
+            self.local_topic(suffix)
+        } else {
+            self.topic(suffix)
+        }
+    }
+
+    // ── Publishers ───────────────────────────────────────────────────────────
 
     /// Create a protobuf publisher with `APPLICATION_PROTOBUF` encoding.
     pub async fn publisher_proto<T>(
@@ -48,26 +53,23 @@ impl NodeContext {
         crate::publisher::JsonPublisher::new(&self.session, &self.topic(suffix)).await
     }
 
-    // ── Local publisher/subscriber (SHM, machine-local key space) ───────────
-
-    /// Create a local publisher that sends raw [`ZBytes`](zenoh::bytes::ZBytes) to
-    /// `local/{machine_id}/{suffix}` with SHM zero-copy.
+    /// Create a raw publisher that sends [`ZBytes`](zenoh::bytes::ZBytes) with no encoding.
     ///
-    /// Payload never leaves the machine. Counterpart: [`subscriber_local`](Self::subscriber_local).
-    pub async fn publisher_local(&self, suffix: &str) -> Result<crate::publisher::RawPublisher> {
-        crate::publisher::RawPublisher::new(&self.session, &self.local_topic(suffix)).await
+    /// When `local = true`, publishes to `local/{machine_id}/{suffix}` — SHM zero-copy,
+    /// never crosses the WebSocket bridge. Use this for large binary payloads (e.g. RGBA
+    /// frames) that only need to reach a consumer on the same machine.
+    ///
+    /// When `local = false` (default), publishes to `bubbaloop/{scope}/{machine_id}/{suffix}`.
+    pub async fn publisher_raw(
+        &self,
+        suffix: &str,
+        local: bool,
+    ) -> Result<crate::publisher::RawPublisher> {
+        crate::publisher::RawPublisher::new(&self.session, &self.resolve_topic(suffix, local), local)
+            .await
     }
 
-    /// Create a local subscriber that receives raw [`ZBytes`](zenoh::bytes::ZBytes) from
-    /// `local/{machine_id}/{suffix}` with SHM zero-copy.
-    ///
-    /// Uses a small FIFO (4 slots) — older frames are dropped when the consumer is slow.
-    /// Counterpart: [`publisher_local`](Self::publisher_local).
-    pub async fn subscriber_local(&self, suffix: &str) -> Result<crate::subscriber::RawSubscriber> {
-        crate::subscriber::RawSubscriber::new(&self.session, &self.local_topic(suffix)).await
-    }
-
-    // ── Global subscribers (network-visible, bubbaloop/** key space) ─────────
+    // ── Subscribers ──────────────────────────────────────────────────────────
 
     /// Create a typed subscriber that auto-decodes protobuf messages.
     pub async fn subscriber<T>(&self, suffix: &str) -> Result<crate::subscriber::TypedSubscriber<T>>
@@ -79,32 +81,38 @@ impl NodeContext {
 
     /// Create a raw subscriber that yields [`ZBytes`](zenoh::bytes::ZBytes) with no decoding.
     ///
+    /// When `local = true`, subscribes to `local/{machine_id}/{suffix}` — SHM zero-copy,
+    /// machine-local only. Counterpart to `publisher_raw(suffix, true)`.
+    ///
+    /// When `local = false` (default), subscribes to `bubbaloop/{scope}/{machine_id}/{suffix}`.
+    ///
     /// Uses a small FIFO (4 slots) — older frames are dropped when the consumer is slow.
-    pub async fn subscriber_raw(&self, suffix: &str) -> Result<crate::subscriber::RawSubscriber> {
-        crate::subscriber::RawSubscriber::new(&self.session, &self.topic(suffix)).await
+    pub async fn subscriber_raw(
+        &self,
+        suffix: &str,
+        local: bool,
+    ) -> Result<crate::subscriber::RawSubscriber> {
+        crate::subscriber::RawSubscriber::new(&self.session, &self.resolve_topic(suffix, local))
+            .await
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
-    fn make_ctx(scope: &str, machine_id: &str) -> String {
-        format!("bubbaloop/{}/{}/sensor/data", scope, machine_id)
-    }
-
     #[test]
     fn topic_format() {
+        let (scope, machine_id, suffix) = ("prod", "jetson_01", "camera/front/compressed");
         assert_eq!(
-            make_ctx("prod", "jetson_01"),
-            "bubbaloop/prod/jetson_01/sensor/data"
+            format!("bubbaloop/{}/{}/{}", scope, machine_id, suffix),
+            "bubbaloop/prod/jetson_01/camera/front/compressed"
         );
     }
 
     #[test]
     fn local_topic_format() {
-        let machine_id = "jetson_01";
-        let result = format!("local/{}/tapo_terrace/raw", machine_id);
-        assert_eq!(result, "local/jetson_01/tapo_terrace/raw");
+        assert_eq!(
+            format!("local/{}/{}", "jetson_01", "tapo_terrace/raw"),
+            "local/jetson_01/tapo_terrace/raw"
+        );
     }
 }

--- a/crates/bubbaloop-node/src/context.rs
+++ b/crates/bubbaloop-node/src/context.rs
@@ -19,6 +19,14 @@ impl NodeContext {
         format!("bubbaloop/{}/{}/{}", self.scope, self.machine_id, suffix)
     }
 
+    /// Build a machine-local topic: `local/{machine_id}/{suffix}`
+    ///
+    /// Use this for data that must stay on the same machine (e.g. SHM raw frames).
+    /// These topics are NOT under `bubbaloop/**` and will never cross the WebSocket bridge.
+    pub fn local_topic(&self, suffix: &str) -> String {
+        format!("local/{}/{}", self.machine_id, suffix)
+    }
+
     /// Create a protobuf publisher with `APPLICATION_PROTOBUF` encoding and schema suffix.
     pub async fn publisher_proto<T>(
         &self,
@@ -43,6 +51,17 @@ impl NodeContext {
         crate::publisher::RawPublisher::new(&self.session, &self.topic(suffix)).await
     }
 
+    /// Create a raw publisher on a machine-local topic (`local/{machine_id}/{suffix}`).
+    ///
+    /// Identical to [`publisher_raw`](Self::publisher_raw) but uses [`local_topic`](Self::local_topic).
+    /// Use this for SHM frame data that must never cross the WebSocket bridge.
+    pub async fn publisher_raw_local(
+        &self,
+        suffix: &str,
+    ) -> Result<crate::publisher::RawPublisher> {
+        crate::publisher::RawPublisher::new(&self.session, &self.local_topic(suffix)).await
+    }
+
     /// Create a typed subscriber that auto-decodes protobuf messages.
     ///
     /// `suffix` is appended to the scoped base topic.
@@ -59,6 +78,16 @@ impl NodeContext {
     /// Uses a small FIFO (4 slots) — older frames are dropped when the consumer is slow.
     pub async fn subscriber_raw(&self, suffix: &str) -> Result<crate::subscriber::RawSubscriber> {
         crate::subscriber::RawSubscriber::new(&self.session, &self.topic(suffix)).await
+    }
+
+    /// Create a raw subscriber on a machine-local topic (`local/{machine_id}/{suffix}`).
+    ///
+    /// Counterpart to [`publisher_raw_local`](Self::publisher_raw_local).
+    pub async fn subscriber_raw_local(
+        &self,
+        suffix: &str,
+    ) -> Result<crate::subscriber::RawSubscriber> {
+        crate::subscriber::RawSubscriber::new(&self.session, &self.local_topic(suffix)).await
     }
 }
 

--- a/crates/bubbaloop-node/src/health.rs
+++ b/crates/bubbaloop-node/src/health.rs
@@ -5,16 +5,15 @@ use crate::error::{NodeError, Result};
 
 /// Spawn a background task that publishes health heartbeats every 5 seconds.
 ///
-/// Publishes `"ok"` to `bubbaloop/{scope}/{machine_id}/{node_name}/health`.
+/// Publishes `"ok"` to `bubbaloop/global/{machine_id}/{node_name}/health`.
 /// Stops when the shutdown signal fires.
 pub async fn spawn_health_heartbeat(
     session: Arc<zenoh::Session>,
-    scope: &str,
     machine_id: &str,
     node_name: &str,
     mut shutdown_rx: watch::Receiver<()>,
 ) -> Result<tokio::task::JoinHandle<()>> {
-    let health_topic = format!("bubbaloop/{}/{}/{}/health", scope, machine_id, node_name);
+    let health_topic = format!("bubbaloop/global/{}/{}/health", machine_id, node_name);
     log::info!("Health heartbeat: {}", health_topic);
     let publisher = session
         .declare_publisher(health_topic)

--- a/crates/bubbaloop-node/src/lib.rs
+++ b/crates/bubbaloop-node/src/lib.rs
@@ -117,7 +117,6 @@ pub async fn run_node<N: Node>() -> anyhow::Result<()> {
         args.config.display()
     );
 
-    let scope = std::env::var("BUBBALOOP_SCOPE").unwrap_or_else(|_| "local".to_string());
     let machine_id = std::env::var("BUBBALOOP_MACHINE_ID")
         .unwrap_or_else(|_| {
             hostname::get()
@@ -125,14 +124,13 @@ pub async fn run_node<N: Node>() -> anyhow::Result<()> {
                 .unwrap_or_else(|_| "unknown".to_string())
         })
         .replace('-', "_");
-    log::info!("Scope: {}, Machine ID: {}", scope, machine_id);
+    log::info!("Machine ID: {}", machine_id);
 
     let (shutdown_tx, _) = shutdown::setup_shutdown()?;
     let session = zenoh_session::open_zenoh_session(&args.endpoint).await?;
 
     let _schema_queryable = schema::declare_schema_queryable(
         &session,
-        &scope,
         &machine_id,
         &instance_name,
         N::descriptor(),
@@ -141,7 +139,6 @@ pub async fn run_node<N: Node>() -> anyhow::Result<()> {
 
     let _health_handle = health::spawn_health_heartbeat(
         session.clone(),
-        &scope,
         &machine_id,
         &instance_name,
         shutdown_tx.subscribe(),
@@ -150,7 +147,6 @@ pub async fn run_node<N: Node>() -> anyhow::Result<()> {
 
     let ctx = NodeContext {
         session: session.clone(),
-        scope,
         machine_id,
         instance_name,
         shutdown_rx: shutdown_tx.subscribe(),

--- a/crates/bubbaloop-node/src/lib.rs
+++ b/crates/bubbaloop-node/src/lib.rs
@@ -128,7 +128,7 @@ pub async fn run_node<N: Node>() -> anyhow::Result<()> {
     log::info!("Scope: {}, Machine ID: {}", scope, machine_id);
 
     let (shutdown_tx, _) = shutdown::setup_shutdown()?;
-    let session = zenoh_session::open_zenoh_session(&args.endpoint, true).await?;
+    let session = zenoh_session::open_zenoh_session(&args.endpoint).await?;
 
     let _schema_queryable = schema::declare_schema_queryable(
         &session,

--- a/crates/bubbaloop-node/src/publisher.rs
+++ b/crates/bubbaloop-node/src/publisher.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 use zenoh::bytes::Encoding;
+use zenoh::qos::CongestionControl;
 
 use crate::error::{NodeError, Result};
 
@@ -77,26 +78,38 @@ impl JsonPublisher {
 /// A declared raw-bytes publisher with no encoding.
 ///
 /// Publishes pre-built [`ZBytes`] payloads directly — no serialization, no encoding header.
-/// The caller controls the byte layout. Works with any Zenoh transport; if the session
-/// has SHM enabled (via [`NodeContextBuilder::with_shm`](crate::NodeContextBuilder::with_shm)),
-/// zero-copy delivery is used automatically when both sides run on the same machine.
+/// The caller controls the byte layout.
 ///
 /// Created via [`NodeContext::publisher_raw`](crate::NodeContext::publisher_raw).
+/// When `local = true`, the publisher targets a machine-local topic
+/// (`local/{machine_id}/suffix`) and uses `CongestionControl::Block` — required for
+/// SHM so the publisher waits for the subscriber to read the SHM buffer instead of
+/// silently dropping frames.
 pub struct RawPublisher {
     publisher: zenoh::pubsub::Publisher<'static>,
 }
 
 impl RawPublisher {
-    pub(crate) async fn new(session: &Arc<zenoh::Session>, key_expr: &str) -> Result<Self> {
-        let publisher = session
-            .declare_publisher(key_expr.to_string())
+    pub(crate) async fn new(
+        session: &Arc<zenoh::Session>,
+        key_expr: &str,
+        local: bool,
+    ) -> Result<Self> {
+        let mut builder = session.declare_publisher(key_expr.to_string());
+        if local {
+            // CongestionControl::Block is required for SHM publishers:
+            // the publisher must wait for the subscriber to release the SHM buffer
+            // rather than silently dropping messages when the subscriber is slow.
+            builder = builder.congestion_control(CongestionControl::Block);
+        }
+        let publisher = builder
             .await
             .map_err(|e| NodeError::PublisherDeclare {
                 topic: key_expr.to_string(),
                 source: e,
             })?;
 
-        log::debug!("RawPublisher declared on '{}'", key_expr);
+        log::debug!("RawPublisher declared on '{}' (local={})", key_expr, local);
         Ok(Self { publisher })
     }
 

--- a/crates/bubbaloop-node/src/schema.rs
+++ b/crates/bubbaloop-node/src/schema.rs
@@ -5,17 +5,16 @@ use crate::error::{NodeError, Result};
 
 /// Declare a Zenoh queryable that serves the node's protobuf FileDescriptorSet.
 ///
-/// Responds to queries on `bubbaloop/{scope}/{machine_id}/{node_name}/schema`.
+/// Responds to queries on `bubbaloop/global/{machine_id}/{node_name}/schema`.
 /// Does NOT use `.complete(true)` — that would block wildcard queries
-/// like `bubbaloop/**/schema` used by the dashboard for discovery.
+/// like `bubbaloop/global/**/schema` used by the dashboard for discovery.
 pub async fn declare_schema_queryable(
     session: &Arc<zenoh::Session>,
-    scope: &str,
     machine_id: &str,
     node_name: &str,
     descriptor: &'static [u8],
 ) -> Result<zenoh::query::Queryable<()>> {
-    let schema_key = format!("bubbaloop/{}/{}/{}/schema", scope, machine_id, node_name);
+    let schema_key = format!("bubbaloop/global/{}/{}/schema", machine_id, node_name);
 
     let queryable = session
         .declare_queryable(&schema_key)

--- a/crates/bubbaloop-node/src/zenoh_session.rs
+++ b/crates/bubbaloop-node/src/zenoh_session.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use crate::error::{NodeError, Result};
 
-/// Open a Zenoh session in client mode.
+/// Open a Zenoh session in client mode with SHM transport always enabled.
 ///
 /// Resolution order for endpoint:
 /// 1. `ZENOH_ENDPOINT` env var (for compatibility with existing nodes)
@@ -10,11 +10,11 @@ use crate::error::{NodeError, Result};
 /// 3. Provided `endpoint` argument
 /// 4. Default: `tcp/127.0.0.1:7447`
 ///
-/// When `shm` is true, enables the SHM transport for zero-copy same-machine delivery.
-/// [`run_node`](crate::run_node) always enables SHM so nodes using
-/// [`publisher_shm`](crate::context::NodeContext::publisher_shm) or
-/// [`subscriber_shm`](crate::context::NodeContext::subscriber_shm) work out of the box.
-pub async fn open_zenoh_session(endpoint: &Option<String>, shm: bool) -> Result<Arc<zenoh::Session>> {
+/// SHM is always enabled — all publishers and subscribers on the session
+/// benefit from zero-copy delivery automatically when both sides are on the
+/// same machine. Use [`local_topic`](crate::context::NodeContext::local_topic)
+/// for data that must stay machine-local (e.g. raw RGBA frames).
+pub async fn open_zenoh_session(endpoint: &Option<String>) -> Result<Arc<zenoh::Session>> {
     let endpoint = std::env::var("ZENOH_ENDPOINT")
         .or_else(|_| std::env::var("BUBBALOOP_ZENOH_ENDPOINT"))
         .ok()
@@ -50,15 +50,13 @@ pub async fn open_zenoh_session(endpoint: &Option<String>, shm: bool) -> Result<
             key: "scouting/gossip/enabled",
             source: e,
         })?;
-    if shm {
-        config
-            .insert_json5("transport/shared_memory/enabled", "true")
-            .map_err(|e| NodeError::ZenohConfig {
-                key: "transport/shared_memory/enabled",
-                source: e,
-            })?;
-        log::info!("Zenoh SHM transport enabled");
-    }
+    config
+        .insert_json5("transport/shared_memory/enabled", "true")
+        .map_err(|e| NodeError::ZenohConfig {
+            key: "transport/shared_memory/enabled",
+            source: e,
+        })?;
+    log::info!("Zenoh SHM transport enabled");
 
     let session = zenoh::open(config).await.map_err(NodeError::ZenohSession)?;
 

--- a/crates/bubbaloop/src/daemon/gateway.rs
+++ b/crates/bubbaloop/src/daemon/gateway.rs
@@ -270,37 +270,37 @@ pub struct CommandResultJson {
 
 /// Build the daemon command topic (CLI → Daemon).
 ///
-/// Format: `bubbaloop/{scope}/{machine}/daemon/command`
-pub fn command_topic(scope: &str, machine_id: &str) -> String {
-    format!("bubbaloop/{}/{}/daemon/command", scope, machine_id)
+/// Format: `bubbaloop/global/{machine}/daemon/command`
+pub fn command_topic(_scope: &str, machine_id: &str) -> String {
+    format!("bubbaloop/global/{}/daemon/command", machine_id)
 }
 
 /// Build the daemon events topic (Daemon → CLI).
 ///
-/// Format: `bubbaloop/{scope}/{machine}/daemon/events`
-pub fn events_topic(scope: &str, machine_id: &str) -> String {
-    format!("bubbaloop/{}/{}/daemon/events", scope, machine_id)
+/// Format: `bubbaloop/global/{machine}/daemon/events`
+pub fn events_topic(_scope: &str, machine_id: &str) -> String {
+    format!("bubbaloop/global/{}/daemon/events", machine_id)
 }
 
 /// Build the daemon manifest topic (queryable).
 ///
-/// Format: `bubbaloop/{scope}/{machine}/daemon/manifest`
-pub fn manifest_topic(scope: &str, machine_id: &str) -> String {
-    format!("bubbaloop/{}/{}/daemon/manifest", scope, machine_id)
+/// Format: `bubbaloop/global/{machine}/daemon/manifest`
+pub fn manifest_topic(_scope: &str, machine_id: &str) -> String {
+    format!("bubbaloop/global/{}/daemon/manifest", machine_id)
 }
 
 /// Build a wildcard pattern for discovering daemon manifests on ALL machines.
 ///
-/// Format: `bubbaloop/{scope}/*/daemon/manifest`
-pub fn manifest_wildcard(scope: &str) -> String {
-    format!("bubbaloop/{}/*/daemon/manifest", scope)
+/// Format: `bubbaloop/global/*/daemon/manifest`
+pub fn manifest_wildcard(_scope: &str) -> String {
+    "bubbaloop/global/*/daemon/manifest".to_string()
 }
 
 /// Build the daemon nodes topic (queryable — returns JSON NodeListJson).
 ///
-/// Format: `bubbaloop/{scope}/{machine}/daemon/nodes`
-pub fn nodes_topic(scope: &str, machine_id: &str) -> String {
-    format!("bubbaloop/{}/{}/daemon/nodes", scope, machine_id)
+/// Format: `bubbaloop/global/{machine}/daemon/nodes`
+pub fn nodes_topic(_scope: &str, machine_id: &str) -> String {
+    format!("bubbaloop/global/{}/daemon/nodes", machine_id)
 }
 
 #[cfg(test)]

--- a/crates/bubbaloop/src/daemon/gateway.rs
+++ b/crates/bubbaloop/src/daemon/gateway.rs
@@ -460,7 +460,7 @@ mod tests {
     fn command_topic_format() {
         assert_eq!(
             command_topic("local", "jetson01"),
-            "bubbaloop/local/jetson01/daemon/command"
+            "bubbaloop/global/jetson01/daemon/command"
         );
     }
 
@@ -468,7 +468,7 @@ mod tests {
     fn events_topic_format() {
         assert_eq!(
             events_topic("local", "jetson01"),
-            "bubbaloop/local/jetson01/daemon/events"
+            "bubbaloop/global/jetson01/daemon/events"
         );
     }
 
@@ -476,7 +476,7 @@ mod tests {
     fn manifest_topic_format() {
         assert_eq!(
             manifest_topic("local", "jetson01"),
-            "bubbaloop/local/jetson01/daemon/manifest"
+            "bubbaloop/global/jetson01/daemon/manifest"
         );
     }
 
@@ -484,7 +484,7 @@ mod tests {
     fn manifest_wildcard_format() {
         assert_eq!(
             manifest_wildcard("local"),
-            "bubbaloop/local/*/daemon/manifest"
+            "bubbaloop/global/*/daemon/manifest"
         );
     }
 }

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -222,7 +222,7 @@ function BrowserCheck() {
 export default function App() {
   const zenohConfig = useMemo(() => ({ endpoint: ZENOH_ENDPOINT }), []);
   const { session, status, error, reconnect } = useZenohSession(zenohConfig);
-  const { topics: availableTopics } = useZenohTopicDiscovery(session, "**");
+  const { topics: availableTopics } = useZenohTopicDiscovery(session, "bubbaloop/global/**");
   const [currentView, setCurrentView] = useState<AppView>("dashboard");
 
   return (

--- a/dashboard/src/components/CameraView.tsx
+++ b/dashboard/src/components/CameraView.tsx
@@ -211,10 +211,10 @@ export function CameraView({
 
     const cameraHint = cameraName?.toLowerCase();
 
-    // Collect all camera topics matching camera/*/compressed pattern
+    // Collect all compressed frame topics (topic ends with /compressed)
     const cameraTopics = availableTopics.filter(dt => {
       const d = dt.display.toLowerCase();
-      return /camera\/[^/]+\/compressed/.test(d);
+      return d.endsWith('/compressed');
     });
 
     console.log(`[CameraView] Auto-detect: hint="${cameraHint}", availableTopics=${availableTopics.length}, cameraTopics=${cameraTopics.length}`, cameraTopics.map(t => t.display));
@@ -224,7 +224,7 @@ export function CameraView({
     // Try exact name match first, then fall back to first discovered camera
     const match = (cameraHint && cameraTopics.find(dt => {
       const d = dt.display.toLowerCase();
-      return d.includes(`camera/${cameraHint}/compressed`);
+      return d.includes(`${cameraHint}/compressed`);
     })) || cameraTopics[0];
 
     autoDetectedRef.current = true;
@@ -407,7 +407,7 @@ export function CameraView({
       <div className="camera-footer">
         {(() => {
           // Filter to only show CompressedImage topics
-          const cameraTopics = availableTopics.filter(t => t.display.includes('camera') && t.display.includes('compressed'));
+          const cameraTopics = availableTopics.filter(t => t.display.endsWith('/compressed'));
           return cameraTopics.length > 0 ? (
             <select
               className="topic-select"

--- a/dashboard/src/components/NodesView.tsx
+++ b/dashboard/src/components/NodesView.tsx
@@ -97,7 +97,7 @@ export function NodesViewPanel({
         }),
       );
 
-      const receiver = await session.get("bubbaloop/**/daemon/command", {
+      const receiver = await session.get("bubbaloop/global/**/daemon/command", {
         payload,
         timeout: Duration.milliseconds.of(10000),
       });

--- a/dashboard/src/components/NodesView.tsx
+++ b/dashboard/src/components/NodesView.tsx
@@ -175,7 +175,7 @@ export function NodesViewPanel({
 
       const result = await sendDaemonCommand(nodeName, "get_logs", targetNode.machine_id);
       if (result.success) {
-        return result.output || "No logs available";
+        return result.output || result.message || "No logs available";
       }
       throw new Error(result.message || "Failed to fetch logs");
     },

--- a/dashboard/src/components/__tests__/CameraView.test.tsx
+++ b/dashboard/src/components/__tests__/CameraView.test.tsx
@@ -165,7 +165,7 @@ describe('CameraView', () => {
     expect(liveBadge).toBeInTheDocument();
   });
 
-  it('renders topic dropdown with camera topics filtered by camera and compressed', () => {
+  it('renders topic dropdown with topics ending in /compressed', () => {
     const cameraTopics = [
       { display: 'bubbaloop/m1/camera/entrance/compressed', raw: '0/camera%entrance%compressed/type/hash' },
       { display: 'bubbaloop/m1/camera/parking/compressed', raw: '0/camera%parking%compressed/type/hash' },
@@ -181,7 +181,7 @@ describe('CameraView', () => {
 
     const select = document.querySelector('select.topic-select') as HTMLSelectElement;
     expect(select).toBeInTheDocument();
-    // Only camera topics with 'camera' and 'compressed' in display should appear
+    // Only topics whose display ends with '/compressed' should appear
     const options = select.querySelectorAll('option');
     const optionTexts = Array.from(options).map(o => o.textContent);
     expect(optionTexts).toContain('bubbaloop/m1/camera/entrance/compressed');

--- a/dashboard/src/contexts/NodeDiscoveryContext.tsx
+++ b/dashboard/src/contexts/NodeDiscoveryContext.tsx
@@ -1,9 +1,9 @@
 // NodeDiscoveryContext — Hybrid node discovery via daemon API + direct manifest queries.
 //
 // Two independent discovery loops:
-// 1. Manifest discovery: queries `bubbaloop/**/manifest` (every 10s, backs off to 30s)
+// 1. Manifest discovery: queries `bubbaloop/global/**/manifest` (every 10s, backs off to 30s)
 //    Each running node responds with its JSON manifest.
-// 2. Daemon polling: queries `bubbaloop/**/daemon/nodes` (every 3s) for protobuf NodeList.
+// 2. Daemon polling: queries `bubbaloop/global/**/daemon/nodes` (every 3s) for protobuf NodeList.
 //
 // Results are merged: manifest provides rich metadata, daemon provides runtime state.
 // When daemon is down, nodes discovered via manifest still appear (status = 'unknown').
@@ -290,7 +290,7 @@ export function NodeDiscoveryProvider({
     if (!currentSession) return [];
 
     try {
-      const receiver = await currentSession.get("bubbaloop/**/daemon/nodes", {
+      const receiver = await currentSession.get("bubbaloop/global/**/daemon/nodes", {
         timeout: Duration.milliseconds.of(5000),
       });
 
@@ -403,7 +403,7 @@ export function NodeDiscoveryProvider({
     try {
       setManifestDiscoveryActive(true);
 
-      const receiver = await currentSession.get("bubbaloop/**/manifest", {
+      const receiver = await currentSession.get("bubbaloop/global/**/manifest", {
         timeout: Duration.milliseconds.of(5000),
       });
 

--- a/dashboard/src/contexts/__tests__/NodeDiscoveryContext.test.tsx
+++ b/dashboard/src/contexts/__tests__/NodeDiscoveryContext.test.tsx
@@ -235,7 +235,7 @@ describe('NodeDiscoveryContext', () => {
           await vi.advanceTimersByTimeAsync(100);
         });
 
-        expect(mockGet).toHaveBeenCalledWith('bubbaloop/**/daemon/nodes', { timeout: 5000 });
+        expect(mockGet).toHaveBeenCalledWith('bubbaloop/global/**/daemon/nodes', { timeout: 5000 });
       });
 
       it('sets daemonConnected=true after receiving daemon data', async () => {
@@ -268,7 +268,7 @@ describe('NodeDiscoveryContext', () => {
 
         const sample = createMockSample('bubbaloop/daemon/nodes', nodeListData);
         const reply = createMockReply(sample);
-        const responses = new Map([['bubbaloop/**/daemon/nodes', [reply]]]);
+        const responses = new Map([['bubbaloop/global/**/daemon/nodes', [reply]]]);
         const session = createMockSession(responses);
         const wrapper = makeWrapper(session);
 
@@ -343,7 +343,7 @@ describe('NodeDiscoveryContext', () => {
 
         const sample = createMockSample('bubbaloop/daemon/nodes', nodeListData);
         const reply = createMockReply(sample);
-        const responses = new Map([['bubbaloop/**/daemon/nodes', [reply]]]);
+        const responses = new Map([['bubbaloop/global/**/daemon/nodes', [reply]]]);
         const session = createMockSession(responses);
         const wrapper = makeWrapper(session);
 
@@ -371,7 +371,7 @@ describe('NodeDiscoveryContext', () => {
 
         const sample = createMockSample('bubbaloop/daemon/nodes', nodeListData);
         const reply = createMockReply(sample);
-        const responses = new Map([['bubbaloop/**/daemon/nodes', [reply]]]);
+        const responses = new Map([['bubbaloop/global/**/daemon/nodes', [reply]]]);
         const session = createMockSession(responses);
         const wrapper = makeWrapper(session);
 
@@ -424,7 +424,7 @@ describe('NodeDiscoveryContext', () => {
           await vi.advanceTimersByTimeAsync(2100);
         });
 
-        expect(mockGet).toHaveBeenCalledWith('bubbaloop/**/manifest', { timeout: 5000 });
+        expect(mockGet).toHaveBeenCalledWith('bubbaloop/global/**/manifest', { timeout: 5000 });
       });
 
       it('parses manifest JSON from zenoh replies', async () => {
@@ -465,7 +465,7 @@ describe('NodeDiscoveryContext', () => {
 
         mockGetSamplePayload.mockReturnValue(manifestData);
 
-        const responses = new Map([['bubbaloop/**/manifest', [reply]]]);
+        const responses = new Map([['bubbaloop/global/**/manifest', [reply]]]);
         const session = createMockSession(responses);
         const wrapper = makeWrapper(session);
 
@@ -490,7 +490,7 @@ describe('NodeDiscoveryContext', () => {
 
         mockGetSamplePayload.mockReturnValue(invalidData);
 
-        const responses = new Map([['bubbaloop/**/manifest', [reply]]]);
+        const responses = new Map([['bubbaloop/global/**/manifest', [reply]]]);
         const session = createMockSession(responses);
         const wrapper = makeWrapper(session);
 
@@ -538,7 +538,7 @@ describe('NodeDiscoveryContext', () => {
 
         const sample = createMockSample('bubbaloop/daemon/nodes', nodeListData);
         const reply = createMockReply(sample);
-        const responses = new Map([['bubbaloop/**/daemon/nodes', [reply]]]);
+        const responses = new Map([['bubbaloop/global/**/daemon/nodes', [reply]]]);
         const session = createMockSession(responses);
         const wrapper = makeWrapper(session);
 
@@ -577,7 +577,7 @@ describe('NodeDiscoveryContext', () => {
 
         mockGetSamplePayload.mockReturnValue(manifestData);
 
-        const responses = new Map([['bubbaloop/**/manifest', [reply]]]);
+        const responses = new Map([['bubbaloop/global/**/manifest', [reply]]]);
         const session = createMockSession(responses);
         const wrapper = makeWrapper(session);
 
@@ -653,8 +653,8 @@ describe('NodeDiscoveryContext', () => {
         const manifestReply = createMockReply(manifestSample);
 
         const responses = new Map([
-          ['bubbaloop/**/daemon/nodes', [daemonReply]],
-          ['bubbaloop/**/manifest', [manifestReply]],
+          ['bubbaloop/global/**/daemon/nodes', [daemonReply]],
+          ['bubbaloop/global/**/manifest', [manifestReply]],
         ]);
 
         const session = createMockSession(responses);
@@ -725,7 +725,7 @@ describe('NodeDiscoveryContext', () => {
 
         const sample = createMockSample('bubbaloop/daemon/nodes', nodeListData);
         const reply = createMockReply(sample);
-        const responses = new Map([['bubbaloop/**/daemon/nodes', [reply]]]);
+        const responses = new Map([['bubbaloop/global/**/daemon/nodes', [reply]]]);
         const session = createMockSession(responses);
         const wrapper = makeWrapper(session);
 
@@ -786,7 +786,7 @@ describe('NodeDiscoveryContext', () => {
 
         const sample = createMockSample('bubbaloop/daemon/nodes', nodeListData);
         const reply = createMockReply(sample);
-        const responses = new Map([['bubbaloop/**/daemon/nodes', [reply]]]);
+        const responses = new Map([['bubbaloop/global/**/daemon/nodes', [reply]]]);
         const session = createMockSession(responses);
         const wrapper = makeWrapper(session);
 

--- a/dashboard/src/hooks/__tests__/useLiveliness.test.ts
+++ b/dashboard/src/hooks/__tests__/useLiveliness.test.ts
@@ -74,7 +74,7 @@ describe('useLiveliness', () => {
     renderHook(() => useLiveliness(mockSession));
 
     await waitFor(() => {
-      expect(declareSubscriberSpy).toHaveBeenCalledWith('bubbaloop/**', {
+      expect(declareSubscriberSpy).toHaveBeenCalledWith('bubbaloop/global/**', {
         callback: expect.any(Function),
       });
     });

--- a/dashboard/src/hooks/useLiveliness.ts
+++ b/dashboard/src/hooks/useLiveliness.ts
@@ -53,7 +53,7 @@ export function useLiveliness(
         }
 
         const subscriber = await livelinessApi.declare_subscriber(
-          "bubbaloop/**",
+          "bubbaloop/global/**",
           {
             callback: (sample: any) => {
               const keyExpr =

--- a/dashboard/src/lib/__tests__/schema-registry.test.ts
+++ b/dashboard/src/lib/__tests__/schema-registry.test.ts
@@ -188,17 +188,17 @@ describe('extractTopicPrefix', () => {
 });
 
 describe('extractMachineId', () => {
-  it('extracts from scoped vanilla topic', () => {
-    const topic = 'bubbaloop/local/nvidia_orin00/system-telemetry/health';
+  it('extracts from global system-telemetry topic', () => {
+    const topic = 'bubbaloop/global/nvidia_orin00/system-telemetry/health';
     expect(extractMachineId(topic)).toBe('nvidia_orin00');
   });
 
-  it('extracts from machine-scoped daemon', () => {
-    const topic = 'bubbaloop/nvidia-orin00/daemon/nodes';
+  it('extracts from global daemon topic', () => {
+    const topic = 'bubbaloop/global/nvidia-orin00/daemon/nodes';
     expect(extractMachineId(topic)).toBe('nvidia-orin00');
   });
 
-  it('returns null for legacy daemon', () => {
+  it('returns null for legacy daemon (no global/local)', () => {
     const topic = 'bubbaloop/daemon/nodes';
     expect(extractMachineId(topic)).toBe(null);
   });
@@ -208,19 +208,24 @@ describe('extractMachineId', () => {
     expect(extractMachineId(topic)).toBe(null);
   });
 
-  it('handles system telemetry topic', () => {
-    const topic = 'bubbaloop/local/m1/system-telemetry/metrics';
+  it('handles global system telemetry topic', () => {
+    const topic = 'bubbaloop/global/m1/system-telemetry/metrics';
     expect(extractMachineId(topic)).toBe('m1');
   });
 
-  it('handles weather topics', () => {
-    const topic = 'bubbaloop/local/nvidia_orin00/weather/current';
+  it('handles global weather topics', () => {
+    const topic = 'bubbaloop/global/nvidia_orin00/weather/current';
     expect(extractMachineId(topic)).toBe('nvidia_orin00');
   });
 
-  it('handles health topics', () => {
-    const topic = 'bubbaloop/local/nvidia_orin00/system-telemetry/health';
+  it('handles global health topics', () => {
+    const topic = 'bubbaloop/global/nvidia_orin00/system-telemetry/health';
     expect(extractMachineId(topic)).toBe('nvidia_orin00');
+  });
+
+  it('returns null for local SHM topics', () => {
+    const topic = 'bubbaloop/local/nvidia_orin00/tapo_entrance/raw';
+    expect(extractMachineId(topic)).toBe(null);
   });
 
   it('returns null for topics with insufficient segments', () => {

--- a/dashboard/src/lib/__tests__/zenoh.test.ts
+++ b/dashboard/src/lib/__tests__/zenoh.test.ts
@@ -3,38 +3,48 @@ import { extractMachineId, getSamplePayload, normalizeKeyExpr } from '../zenoh';
 import type { Sample } from '@eclipse-zenoh/zenoh-ts';
 
 describe('extractMachineId', () => {
-  describe('vanilla zenoh format', () => {
-    it('extracts machine id from machine-scoped daemon path', () => {
-      expect(extractMachineId('bubbaloop/nvidia-orin00/daemon/nodes')).toBe('nvidia-orin00');
+  describe('global format (bubbaloop/global/{machine}/...)', () => {
+    it('extracts machine id from global daemon path', () => {
+      expect(extractMachineId('bubbaloop/global/nvidia-orin00/daemon/nodes')).toBe('nvidia-orin00');
     });
 
-    it('extracts machine id from machine-scoped daemon API path', () => {
-      expect(extractMachineId('bubbaloop/jetson-nano/daemon/api/health')).toBe('jetson-nano');
+    it('extracts machine id from global daemon API path', () => {
+      expect(extractMachineId('bubbaloop/global/jetson-nano/daemon/api/health')).toBe('jetson-nano');
     });
 
-    it('extracts machine id from full-scoped path', () => {
-      expect(extractMachineId('bubbaloop/local/nvidia_orin00/system-telemetry/health')).toBe('nvidia_orin00');
+    it('extracts machine id from global system-telemetry path', () => {
+      expect(extractMachineId('bubbaloop/global/nvidia_orin00/system-telemetry/health')).toBe('nvidia_orin00');
     });
 
-    it('extracts machine id from full-scoped camera path', () => {
-      expect(extractMachineId('bubbaloop/production/orin_02/camera/entrance/compressed')).toBe('orin_02');
+    it('extracts machine id from global camera path', () => {
+      expect(extractMachineId('bubbaloop/global/orin_02/camera/entrance/compressed')).toBe('orin_02');
     });
 
     it('handles machine id with special characters', () => {
-      expect(extractMachineId('bubbaloop/jetson-nano_01/daemon/api')).toBe('jetson-nano_01');
+      expect(extractMachineId('bubbaloop/global/jetson-nano_01/daemon/api')).toBe('jetson-nano_01');
     });
 
     it('handles machine id with underscores', () => {
-      expect(extractMachineId('bubbaloop/local/nvidia_orin_00/weather/current')).toBe('nvidia_orin_00');
+      expect(extractMachineId('bubbaloop/global/nvidia_orin_00/weather/current')).toBe('nvidia_orin_00');
     });
   });
 
-  describe('legacy format (returns null)', () => {
-    it('returns null for legacy daemon path', () => {
+  describe('local format (bubbaloop/local/{machine}/...) — not network-visible', () => {
+    it('returns null for local SHM topic', () => {
+      expect(extractMachineId('bubbaloop/local/nvidia_orin00/tapo_entrance/raw')).toBeNull();
+    });
+
+    it('returns null for local health topic', () => {
+      expect(extractMachineId('bubbaloop/local/nvidia_orin00/system-telemetry/health')).toBeNull();
+    });
+  });
+
+  describe('unrecognized/legacy format (returns null)', () => {
+    it('returns null for old 2-segment daemon path', () => {
       expect(extractMachineId('bubbaloop/daemon/nodes')).toBeNull();
     });
 
-    it('returns null for legacy daemon API path', () => {
+    it('returns null for old 2-segment daemon API path', () => {
       expect(extractMachineId('bubbaloop/daemon/api/health')).toBeNull();
     });
 
@@ -44,6 +54,10 @@ describe('extractMachineId', () => {
 
     it('returns null for fleet with deeper path', () => {
       expect(extractMachineId('bubbaloop/fleet/nodes/list')).toBeNull();
+    });
+
+    it('returns null for old scope-prefixed path without global/local', () => {
+      expect(extractMachineId('bubbaloop/production/orin_02/camera/compressed')).toBeNull();
     });
   });
 
@@ -207,36 +221,36 @@ describe('getSamplePayload', () => {
   });
 });
 
-describe('extractMachineId: production topology variants', () => {
-  it('extracts machine id from production scope with camera topic', () => {
-    expect(extractMachineId('bubbaloop/production/factory_cam01/camera/entrance/compressed')).toBe('factory_cam01');
+describe('extractMachineId: global topology variants', () => {
+  it('extracts machine id from global camera topic', () => {
+    expect(extractMachineId('bubbaloop/global/factory_cam01/camera/entrance/compressed')).toBe('factory_cam01');
   });
 
-  it('extracts machine id from staging scope', () => {
-    expect(extractMachineId('bubbaloop/staging/test_device_01/metrics/health')).toBe('test_device_01');
+  it('extracts machine id from global health topic', () => {
+    expect(extractMachineId('bubbaloop/global/test_device_01/metrics/health')).toBe('test_device_01');
   });
 
-  it('extracts machine id from dev scope with weather topic', () => {
-    expect(extractMachineId('bubbaloop/dev/orin_dev01/weather/current')).toBe('orin_dev01');
+  it('extracts machine id from global weather topic', () => {
+    expect(extractMachineId('bubbaloop/global/orin_dev01/weather/current')).toBe('orin_dev01');
   });
 
-  it('extracts machine id from deeply nested data path', () => {
-    expect(extractMachineId('bubbaloop/local/nvidia_orin00/camera/entrance/side/compressed')).toBe('nvidia_orin00');
+  it('extracts machine id from global deeply nested data path', () => {
+    expect(extractMachineId('bubbaloop/global/nvidia_orin00/camera/entrance/side/compressed')).toBe('nvidia_orin00');
   });
 
   it('extracts machine id with numeric-only machine name', () => {
-    expect(extractMachineId('bubbaloop/local/42/sensor/temperature')).toBe('42');
+    expect(extractMachineId('bubbaloop/global/42/sensor/temperature')).toBe('42');
   });
 
-  it('returns null for bubbaloop with only scope (two segments)', () => {
-    expect(extractMachineId('bubbaloop/production')).toBeNull();
+  it('returns null for bubbaloop/global with only two segments', () => {
+    expect(extractMachineId('bubbaloop/global')).toBeNull();
   });
 
-  it('handles machine-scoped daemon with deep API path', () => {
-    expect(extractMachineId('bubbaloop/jetson-nano-02/daemon/api/schemas')).toBe('jetson-nano-02');
+  it('handles global daemon with deep API path', () => {
+    expect(extractMachineId('bubbaloop/global/jetson-nano-02/daemon/api/schemas')).toBe('jetson-nano-02');
   });
 
-  it('returns null for fleet with machine-like second segment', () => {
+  it('returns null for old scope-based path (not global/local)', () => {
     expect(extractMachineId('bubbaloop/fleet/nvidia_orin00')).toBeNull();
   });
 });

--- a/dashboard/src/lib/schema-registry.ts
+++ b/dashboard/src/lib/schema-registry.ts
@@ -230,7 +230,7 @@ export class SchemaRegistry {
   async discoverAllNodeSchemas(session: Session, _machineIds?: string[]): Promise<number> {
     // Always use broad wildcard to avoid machine ID format mismatches
     // (e.g., nvidia_orin00 vs nvidia-orin00)
-    const pattern = 'bubbaloop/**/schema';
+    const pattern = 'bubbaloop/global/**/schema';
 
     let discovered = 0;
     try {

--- a/dashboard/src/lib/subscription-manager.ts
+++ b/dashboard/src/lib/subscription-manager.ts
@@ -534,7 +534,7 @@ export class ZenohSubscriptionManager {
     }
 
     try {
-      const subscriber = await endpoint.session.declareSubscriber('bubbaloop/**', {
+      const subscriber = await endpoint.session.declareSubscriber('bubbaloop/global/**', {
         handler: (sample) => {
           this.handleMonitorSample(sample, endpointId);
         },

--- a/dashboard/src/lib/subscription-manager.ts
+++ b/dashboard/src/lib/subscription-manager.ts
@@ -534,7 +534,7 @@ export class ZenohSubscriptionManager {
     }
 
     try {
-      const subscriber = await endpoint.session.declareSubscriber('**', {
+      const subscriber = await endpoint.session.declareSubscriber('bubbaloop/**', {
         handler: (sample) => {
           this.handleMonitorSample(sample, endpointId);
         },
@@ -579,11 +579,20 @@ export class ZenohSubscriptionManager {
    * Handle a sample from the monitor wildcard subscription.
    * Aggregates stats by topic key expression.
    */
+  // Topics whose payloads should never be buffered by the monitor (raw binary frames).
+  private static readonly MONITOR_SKIP_SUFFIXES = ['/raw'];
+
   private handleMonitorSample(sample: Sample, endpointId: string): void {
     const endpoint = this.endpoints.get(endpointId);
     if (!endpoint) return;
 
     const keyExpr = sample.keyexpr().toString();
+
+    // Skip raw binary frame topics — they are SHM-local and their payloads
+    // (1–8 MB each) must not flow through the WebSocket bridge.
+    if (ZenohSubscriptionManager.MONITOR_SKIP_SUFFIXES.some(s => keyExpr.endsWith(s))) {
+      return;
+    }
     const now = Date.now();
 
     // Get or create monitored topic stats (use key expression directly)

--- a/dashboard/src/lib/subscription-manager.ts
+++ b/dashboard/src/lib/subscription-manager.ts
@@ -579,20 +579,13 @@ export class ZenohSubscriptionManager {
    * Handle a sample from the monitor wildcard subscription.
    * Aggregates stats by topic key expression.
    */
-  // Topics whose payloads should never be buffered by the monitor (raw binary frames).
-  private static readonly MONITOR_SKIP_SUFFIXES = ['/raw'];
-
   private handleMonitorSample(sample: Sample, endpointId: string): void {
     const endpoint = this.endpoints.get(endpointId);
     if (!endpoint) return;
 
+    // Monitor subscribes to 'bubbaloop/**' only — local SHM topics (local/{machine_id}/...)
+    // are outside this key space and never arrive here.
     const keyExpr = sample.keyexpr().toString();
-
-    // Skip raw binary frame topics — they are SHM-local and their payloads
-    // (1–8 MB each) must not flow through the WebSocket bridge.
-    if (ZenohSubscriptionManager.MONITOR_SKIP_SUFFIXES.some(s => keyExpr.endsWith(s))) {
-      return;
-    }
     const now = Date.now();
 
     // Get or create monitored topic stats (use key expression directly)

--- a/dashboard/src/lib/zenoh.ts
+++ b/dashboard/src/lib/zenoh.ts
@@ -294,19 +294,22 @@ export interface UseTopicDiscoveryResult {
 /**
  * Normalize a raw Zenoh key expression to a human-readable form.
  *
- * Vanilla Zenoh format: strips the leading "bubbaloop/" prefix only.
- * Does NOT strip machine/scope segments -- they're needed to distinguish topics.
+ * Strips the leading "bubbaloop/global/" prefix so the display shows the
+ * machine-id and resource only.
  *
  * Examples:
- *   "bubbaloop/local/nvidia_orin00/camera/entrance/compressed" -> "local/nvidia_orin00/camera/entrance/compressed"
- *   "bubbaloop/nvidia-orin00/daemon/nodes"                     -> "nvidia-orin00/daemon/nodes"
- *   "bubbaloop/local/nvidia_orin00/system-telemetry/health"    -> "local/nvidia_orin00/system-telemetry/health"
- *   "bubbaloop/daemon/nodes"                                   -> "daemon/nodes"
+ *   "bubbaloop/global/nvidia_orin00/camera/entrance/compressed" -> "nvidia_orin00/camera/entrance/compressed"
+ *   "bubbaloop/global/nvidia_orin00/system-telemetry/health"    -> "nvidia_orin00/system-telemetry/health"
  */
 export function normalizeKeyExpr(keyExpr: string): { display: string; raw: string } {
   const parts = keyExpr.split('/');
 
-  // Vanilla zenoh: strip "bubbaloop/" prefix only
+  // New format: "bubbaloop/global/{machine_id}/..." → strip "bubbaloop/global/"
+  if (parts[0] === 'bubbaloop' && parts[1] === 'global' && parts.length >= 3) {
+    return { display: parts.slice(2).join('/'), raw: keyExpr };
+  }
+
+  // Fallback: strip only the "bubbaloop/" prefix
   if (parts[0] === 'bubbaloop' && parts.length >= 2) {
     return { display: parts.slice(1).join('/'), raw: keyExpr };
   }
@@ -317,30 +320,22 @@ export function normalizeKeyExpr(keyExpr: string): { display: string; raw: strin
 /**
  * Extract machine ID from a Zenoh key expression.
  *
- * Vanilla Zenoh format:
- * - "bubbaloop/{machine}/daemon/..."  -> machine (machine-scoped daemon)
- * - "bubbaloop/{scope}/{machine}/..." -> machine (full-scoped, 4+ segments)
+ * New format: "bubbaloop/global/{machine_id}/..." -> machine_id (parts[2])
+ * Local SHM: "bubbaloop/local/{machine_id}/..." -> null (not network-visible)
  *
- * Returns null for legacy paths like "bubbaloop/daemon/nodes" or "bubbaloop/fleet/..."
+ * Returns null for local or unrecognized paths.
  */
 export function extractMachineId(keyExpr: string): string | null {
   const parts = keyExpr.split('/');
 
-  // Vanilla zenoh: "bubbaloop/..."
   if (parts[0] === 'bubbaloop') {
-    // Legacy paths: "bubbaloop/daemon/..." or "bubbaloop/fleet/..."
-    const knownNamespaces = ['daemon', 'fleet'];
-    if (parts.length >= 2 && knownNamespaces.includes(parts[1])) {
+    // Local SHM topics — not network-visible
+    if (parts[1] === 'local') {
       return null;
     }
 
-    // Machine-scoped daemon: "bubbaloop/{machine}/daemon/..." -> return parts[1]
-    if (parts.length >= 3 && parts[2] === 'daemon') {
-      return parts[1];
-    }
-
-    // Full-scoped: "bubbaloop/{scope}/{machine}/{resource}/..." -> return parts[2]
-    if (parts.length >= 4) {
+    // New global format: "bubbaloop/global/{machine_id}/..."
+    if (parts[1] === 'global' && parts.length >= 3) {
       return parts[2];
     }
   }

--- a/python-sdk/bubbaloop_sdk/context.py
+++ b/python-sdk/bubbaloop_sdk/context.py
@@ -43,9 +43,8 @@ class NodeContext:
     sides are on the same machine.
     """
 
-    def __init__(self, session: zenoh.Session, scope: str, machine_id: str, instance_name: str):
+    def __init__(self, session: zenoh.Session, machine_id: str, instance_name: str):
         self.session = session
-        self.scope = scope
         self.machine_id = machine_id
         self.instance_name = instance_name
         self._shutdown = threading.Event()
@@ -67,7 +66,6 @@ class NodeContext:
         field from your config so multi-instance deployments don't collide.
         Falls back to the hostname.
         """
-        scope = os.environ.get("BUBBALOOP_SCOPE", "local")
         machine_id = os.environ.get("BUBBALOOP_MACHINE_ID", _hostname())
         ep = endpoint or os.environ.get("BUBBALOOP_ZENOH_ENDPOINT", "tcp/127.0.0.1:7447")
         name = instance_name or machine_id
@@ -80,23 +78,23 @@ class NodeContext:
         conf.insert_json5("transport/shared_memory/enabled", "true")
         session = zenoh.open(conf)
 
-        return cls(session, scope, machine_id, name)
+        return cls(session, machine_id, name)
 
     # ------------------------------------------------------------------
     # Topic helpers
     # ------------------------------------------------------------------
 
     def topic(self, suffix: str) -> str:
-        """Return ``bubbaloop/{scope}/{machine_id}/{suffix}``."""
-        return f"bubbaloop/{self.scope}/{self.machine_id}/{suffix}"
+        """Return ``bubbaloop/global/{machine_id}/{suffix}``."""
+        return f"bubbaloop/global/{self.machine_id}/{suffix}"
 
     def local_topic(self, suffix: str) -> str:
-        """Return ``local/{machine_id}/{suffix}``.
+        """Return ``bubbaloop/local/{machine_id}/{suffix}``.
 
-        Use this for data that must stay on the same machine (e.g. SHM raw frames).
-        These topics are NOT under ``bubbaloop/**`` and will never cross the WebSocket bridge.
+        SHM-only — never crosses the WebSocket bridge. Use for large binary payloads
+        consumed only by processes on the same machine (e.g. raw RGBA camera frames).
         """
-        return f"local/{self.machine_id}/{suffix}"
+        return f"bubbaloop/local/{self.machine_id}/{suffix}"
 
     # ------------------------------------------------------------------
     # Shutdown

--- a/python-sdk/bubbaloop_sdk/context.py
+++ b/python-sdk/bubbaloop_sdk/context.py
@@ -12,9 +12,12 @@ Usage::
         time.sleep(30)
     ctx.close()
 
-For nodes that publish/subscribe via SHM, use the builder::
-
-    ctx = NodeContext.builder().with_shm().connect(endpoint=ep, instance_name=name)
+SHM transport is always enabled — all publishers and subscribers on the
+session benefit from zero-copy delivery automatically when both sides are on
+the same machine. Use ``publisher_raw_local`` / ``subscriber_raw_local`` for
+data that must stay machine-local (e.g. raw RGBA frames from camera to
+detector) — these topics are outside ``bubbaloop/**`` and never cross the
+WebSocket bridge.
 """
 
 import os
@@ -29,45 +32,15 @@ def _hostname() -> str:
     return socket.gethostname().replace("-", "_")
 
 
-class NodeContextBuilder:
-    """Fluent builder for NodeContext.
-
-    Usage::
-
-        ctx = NodeContext.builder().with_shm().connect(endpoint=ep, instance_name=name)
-    """
-
-    def __init__(self) -> None:
-        self._shm = False
-
-    def with_shm(self) -> "NodeContextBuilder":
-        """Enable Zenoh SHM transport for zero-copy same-machine delivery.
-
-        When enabled, Zenoh automatically uses shared memory for any publisher/subscriber
-        pair running on the same machine — this applies to JSON, protobuf, and raw
-        publishers alike. Falls back to normal transport for cross-machine communication.
-        """
-        self._shm = True
-        return self
-
-    def connect(
-        self,
-        endpoint: str | None = None,
-        instance_name: str | None = None,
-    ) -> "NodeContext":
-        """Build and connect the NodeContext with the configured options."""
-        return NodeContext.connect(
-            endpoint=endpoint,
-            instance_name=instance_name,
-            shm=self._shm,
-        )
-
-
 class NodeContext:
     """Zenoh session + scope/machine_id + shutdown signal for a bubbaloop node.
 
-    Create with :meth:`connect` or :meth:`builder`. Cleanup with :meth:`close`
-    (or use as a context manager).
+    Create with :meth:`connect`. Cleanup with :meth:`close` (or use as a
+    context manager).
+
+    SHM transport is always enabled on the session. All publishers and
+    subscribers benefit from zero-copy delivery automatically when both
+    sides are on the same machine.
     """
 
     def __init__(self, session: zenoh.Session, scope: str, machine_id: str, instance_name: str):
@@ -80,16 +53,10 @@ class NodeContext:
             signal.signal(sig, lambda s, f: self._shutdown.set())
 
     @classmethod
-    def builder(cls) -> NodeContextBuilder:
-        """Return a fluent builder for creating a NodeContext with custom options."""
-        return NodeContextBuilder()
-
-    @classmethod
     def connect(
         cls,
         endpoint: str | None = None,
         instance_name: str | None = None,
-        shm: bool = False,
     ) -> "NodeContext":
         """Connect to a Zenoh router and return a ready NodeContext.
 
@@ -99,10 +66,6 @@ class NodeContext:
         ``instance_name`` is used for health and schema topics. Pass the ``name``
         field from your config so multi-instance deployments don't collide.
         Falls back to the hostname.
-
-        Prefer :meth:`builder` when SHM transport is needed::
-
-            ctx = NodeContext.builder().with_shm().connect(...)
         """
         scope = os.environ.get("BUBBALOOP_SCOPE", "local")
         machine_id = os.environ.get("BUBBALOOP_MACHINE_ID", _hostname())
@@ -114,14 +77,13 @@ class NodeContext:
         conf.insert_json5("connect/endpoints", f'["{ep}"]')
         conf.insert_json5("scouting/multicast/enabled", "false")
         conf.insert_json5("scouting/gossip/enabled", "false")
-        if shm:
-            conf.insert_json5("transport/shared_memory/enabled", "true")
+        conf.insert_json5("transport/shared_memory/enabled", "true")
         session = zenoh.open(conf)
 
         return cls(session, scope, machine_id, name)
 
     # ------------------------------------------------------------------
-    # Topic helper
+    # Topic helpers
     # ------------------------------------------------------------------
 
     def topic(self, suffix: str) -> str:
@@ -164,10 +126,10 @@ class NodeContext:
         return ProtoPublisher._declare(self.session, self.topic(suffix), type_name)
 
     def publisher_raw(self, suffix: str) -> "RawPublisher":
-        """Declare a raw publisher at ``topic(suffix)`` that sends bytes with no encoding.
+        """Declare a raw publisher at ``topic(suffix)`` with no encoding.
 
         The caller owns the byte layout. SHM zero-copy is used automatically
-        when the session has it enabled and the subscriber is on the same machine.
+        since the session always has it enabled.
         """
         from .publisher import RawPublisher
         return RawPublisher._declare(self.session, self.topic(suffix))
@@ -193,8 +155,7 @@ class NodeContext:
     def subscriber_raw(self, suffix: str) -> "RawSubscriber":
         """Declare a raw subscriber at ``topic(suffix)`` that yields ``bytes`` with no decoding.
 
-        Counterpart to :meth:`publisher_raw`. The caller decodes the bytes.
-        SHM zero-copy is used automatically when the session has it enabled.
+        Counterpart to :meth:`publisher_raw`. SHM zero-copy is used automatically.
         """
         from .subscriber import RawSubscriber
         return RawSubscriber(self.session, self.topic(suffix))
@@ -203,7 +164,7 @@ class NodeContext:
         """Declare a raw subscriber at ``local_topic(suffix)``.
 
         Counterpart to :meth:`publisher_raw_local`. Use for SHM frame data
-        that never crosses the WebSocket bridge.
+        that must never cross the WebSocket bridge.
         """
         from .subscriber import RawSubscriber
         return RawSubscriber(self.session, self.local_topic(suffix))

--- a/python-sdk/bubbaloop_sdk/context.py
+++ b/python-sdk/bubbaloop_sdk/context.py
@@ -128,6 +128,14 @@ class NodeContext:
         """Return ``bubbaloop/{scope}/{machine_id}/{suffix}``."""
         return f"bubbaloop/{self.scope}/{self.machine_id}/{suffix}"
 
+    def local_topic(self, suffix: str) -> str:
+        """Return ``local/{machine_id}/{suffix}``.
+
+        Use this for data that must stay on the same machine (e.g. SHM raw frames).
+        These topics are NOT under ``bubbaloop/**`` and will never cross the WebSocket bridge.
+        """
+        return f"local/{self.machine_id}/{suffix}"
+
     # ------------------------------------------------------------------
     # Shutdown
     # ------------------------------------------------------------------
@@ -164,6 +172,15 @@ class NodeContext:
         from .publisher import RawPublisher
         return RawPublisher._declare(self.session, self.topic(suffix))
 
+    def publisher_raw_local(self, suffix: str) -> "RawPublisher":
+        """Declare a raw publisher at ``local_topic(suffix)``.
+
+        Identical to :meth:`publisher_raw` but uses :meth:`local_topic`.
+        Use this for SHM frame data that must never cross the WebSocket bridge.
+        """
+        from .publisher import RawPublisher
+        return RawPublisher._declare(self.session, self.local_topic(suffix))
+
     # ------------------------------------------------------------------
     # Subscribers
     # ------------------------------------------------------------------
@@ -181,6 +198,15 @@ class NodeContext:
         """
         from .subscriber import RawSubscriber
         return RawSubscriber(self.session, self.topic(suffix))
+
+    def subscriber_raw_local(self, suffix: str) -> "RawSubscriber":
+        """Declare a raw subscriber at ``local_topic(suffix)``.
+
+        Counterpart to :meth:`publisher_raw_local`. Use for SHM frame data
+        that never crosses the WebSocket bridge.
+        """
+        from .subscriber import RawSubscriber
+        return RawSubscriber(self.session, self.local_topic(suffix))
 
     # ------------------------------------------------------------------
     # Cleanup

--- a/python-sdk/bubbaloop_sdk/context.py
+++ b/python-sdk/bubbaloop_sdk/context.py
@@ -134,11 +134,12 @@ class NodeContext:
         from .publisher import RawPublisher
         return RawPublisher._declare(self.session, self.topic(suffix))
 
-    def publisher_raw_local(self, suffix: str) -> "RawPublisher":
-        """Declare a raw publisher at ``local_topic(suffix)``.
+    def publisher_local(self, suffix: str) -> "RawPublisher":
+        """Declare a local SHM publisher at ``local_topic(suffix)``.
 
-        Identical to :meth:`publisher_raw` but uses :meth:`local_topic`.
-        Use this for SHM frame data that must never cross the WebSocket bridge.
+        Publishes raw bytes to ``local/{machine_id}/{suffix}`` with SHM zero-copy.
+        Payload never leaves the machine — never crosses the WebSocket bridge.
+        Counterpart: :meth:`subscriber_local`.
         """
         from .publisher import RawPublisher
         return RawPublisher._declare(self.session, self.local_topic(suffix))
@@ -160,11 +161,11 @@ class NodeContext:
         from .subscriber import RawSubscriber
         return RawSubscriber(self.session, self.topic(suffix))
 
-    def subscriber_raw_local(self, suffix: str) -> "RawSubscriber":
-        """Declare a raw subscriber at ``local_topic(suffix)``.
+    def subscriber_local(self, suffix: str) -> "RawSubscriber":
+        """Declare a local SHM subscriber at ``local_topic(suffix)``.
 
-        Counterpart to :meth:`publisher_raw_local`. Use for SHM frame data
-        that must never cross the WebSocket bridge.
+        Receives raw bytes from ``local/{machine_id}/{suffix}`` with SHM zero-copy.
+        Counterpart: :meth:`publisher_local`.
         """
         from .subscriber import RawSubscriber
         return RawSubscriber(self.session, self.local_topic(suffix))

--- a/python-sdk/bubbaloop_sdk/context.py
+++ b/python-sdk/bubbaloop_sdk/context.py
@@ -125,24 +125,18 @@ class NodeContext:
         type_name = msg_class.DESCRIPTOR.full_name if msg_class is not None else None
         return ProtoPublisher._declare(self.session, self.topic(suffix), type_name)
 
-    def publisher_raw(self, suffix: str) -> "RawPublisher":
-        """Declare a raw publisher at ``topic(suffix)`` with no encoding.
+    def publisher_raw(self, suffix: str, local: bool = False) -> "RawPublisher":
+        """Declare a raw publisher with no encoding.
 
-        The caller owns the byte layout. SHM zero-copy is used automatically
-        since the session always has it enabled.
+        When ``local=True``, publishes to ``local/{machine_id}/{suffix}`` with SHM-specific
+        settings: ``congestion_control=Block`` so the publisher waits for the subscriber to
+        release the SHM buffer instead of silently dropping frames. Never crosses the bridge.
+
+        When ``local=False`` (default), publishes to ``bubbaloop/{scope}/{machine_id}/{suffix}``.
         """
         from .publisher import RawPublisher
-        return RawPublisher._declare(self.session, self.topic(suffix))
-
-    def publisher_local(self, suffix: str) -> "RawPublisher":
-        """Declare a local SHM publisher at ``local_topic(suffix)``.
-
-        Publishes raw bytes to ``local/{machine_id}/{suffix}`` with SHM zero-copy.
-        Payload never leaves the machine — never crosses the WebSocket bridge.
-        Counterpart: :meth:`subscriber_local`.
-        """
-        from .publisher import RawPublisher
-        return RawPublisher._declare(self.session, self.local_topic(suffix))
+        key = self.local_topic(suffix) if local else self.topic(suffix)
+        return RawPublisher._declare(self.session, key, local=local)
 
     # ------------------------------------------------------------------
     # Subscribers
@@ -153,22 +147,17 @@ class NodeContext:
         from .subscriber import TypedSubscriber
         return TypedSubscriber(self.session, self.topic(suffix), msg_class)
 
-    def subscriber_raw(self, suffix: str) -> "RawSubscriber":
-        """Declare a raw subscriber at ``topic(suffix)`` that yields ``bytes`` with no decoding.
+    def subscriber_raw(self, suffix: str, local: bool = False) -> "RawSubscriber":
+        """Declare a raw subscriber that yields ``bytes`` with no decoding.
 
-        Counterpart to :meth:`publisher_raw`. SHM zero-copy is used automatically.
+        When ``local=True``, subscribes to ``local/{machine_id}/{suffix}`` — SHM zero-copy,
+        machine-local only. Counterpart to ``publisher_raw(suffix, local=True)``.
+
+        When ``local=False`` (default), subscribes to ``bubbaloop/{scope}/{machine_id}/{suffix}``.
         """
         from .subscriber import RawSubscriber
-        return RawSubscriber(self.session, self.topic(suffix))
-
-    def subscriber_local(self, suffix: str) -> "RawSubscriber":
-        """Declare a local SHM subscriber at ``local_topic(suffix)``.
-
-        Receives raw bytes from ``local/{machine_id}/{suffix}`` with SHM zero-copy.
-        Counterpart: :meth:`publisher_local`.
-        """
-        from .subscriber import RawSubscriber
-        return RawSubscriber(self.session, self.local_topic(suffix))
+        key = self.local_topic(suffix) if local else self.topic(suffix)
+        return RawSubscriber(self.session, key)
 
     # ------------------------------------------------------------------
     # Cleanup

--- a/python-sdk/bubbaloop_sdk/health.py
+++ b/python-sdk/bubbaloop_sdk/health.py
@@ -8,17 +8,16 @@ import zenoh
 
 def start_health_heartbeat(
     session: zenoh.Session,
-    scope: str,
     machine_id: str,
     instance_name: str,
     shutdown: threading.Event,
     interval_secs: float = 5.0,
 ) -> threading.Thread:
-    """Publish 'ok' to ``{instance_name}/health`` every ``interval_secs``.
+    """Publish 'ok' to ``bubbaloop/global/{machine_id}/{instance_name}/health`` every ``interval_secs``.
 
     Returns the daemon thread (already started). Stops when ``shutdown`` is set.
     """
-    topic = f"bubbaloop/{scope}/{machine_id}/{instance_name}/health"
+    topic = f"bubbaloop/global/{machine_id}/{instance_name}/health"
     pub = session.declare_publisher(topic)
 
     def _loop():

--- a/python-sdk/bubbaloop_sdk/node.py
+++ b/python-sdk/bubbaloop_sdk/node.py
@@ -53,10 +53,8 @@ def run_node(node_class) -> None:
 
     ctx = NodeContext.connect(endpoint=args.endpoint, instance_name=instance_name)
 
-    start_health_heartbeat(
-        ctx.session, ctx.scope, ctx.machine_id, instance_name, ctx._shutdown
-    )
-    log.info("Health heartbeat: bubbaloop/%s/%s/%s/health", ctx.scope, ctx.machine_id, instance_name)
+    start_health_heartbeat(ctx.session, ctx.machine_id, instance_name, ctx._shutdown)
+    log.info("Health heartbeat: bubbaloop/global/%s/%s/health", ctx.machine_id, instance_name)
 
     node = node_class(ctx, config)
     log.info("Initialized. Running…")

--- a/python-sdk/bubbaloop_sdk/node.py
+++ b/python-sdk/bubbaloop_sdk/node.py
@@ -51,7 +51,7 @@ def run_node(node_class) -> None:
     log = logging.getLogger(instance_name)
     log.info("Starting (type=%s, config=%s)", node_class.name, args.config)
 
-    ctx = NodeContext.builder().with_shm().connect(endpoint=args.endpoint, instance_name=instance_name)
+    ctx = NodeContext.connect(endpoint=args.endpoint, instance_name=instance_name)
 
     start_health_heartbeat(
         ctx.session, ctx.scope, ctx.machine_id, instance_name, ctx._shutdown

--- a/python-sdk/bubbaloop_sdk/publisher.py
+++ b/python-sdk/bubbaloop_sdk/publisher.py
@@ -60,28 +60,29 @@ class ProtoPublisher:
 
 
 class RawPublisher:
-    """Declared publisher for zero-copy same-machine delivery via Zenoh SHM.
+    """Declared publisher for raw byte payloads with no encoding overhead.
 
-    Publishes raw ``bytes`` or ``bytearray`` payloads with no encoding overhead.
-    The session must have SHM enabled (use ``NodeContext.builder().with_shm()``).
+    When ``local=True``, uses ``congestion_control=Block`` — the publisher waits for
+    the subscriber to release the SHM buffer instead of silently dropping frames.
+    Topic is ``local/{machine_id}/suffix`` (never crosses the WebSocket bridge).
 
-    Usage::
-
-        ctx = NodeContext.builder().with_shm().connect()
-        pub = ctx.publisher_raw("camera/raw")
-        pub.put(rgba_bytes)  # delivered zero-copy to same-machine subscribers
+    When ``local=False`` (default), uses standard drop-on-congestion and publishes
+    to the global ``bubbaloop/**`` topic space.
     """
 
     def __init__(self, declared_publisher: zenoh.Publisher):
         self._pub = declared_publisher
 
     @classmethod
-    def _declare(cls, session: zenoh.Session, topic: str) -> "RawPublisher":
-        pub = session.declare_publisher(topic)
+    def _declare(cls, session: zenoh.Session, topic: str, local: bool = False) -> "RawPublisher":
+        kwargs = {}
+        if local:
+            kwargs["congestion_control"] = zenoh.CongestionControl.BLOCK
+        pub = session.declare_publisher(topic, **kwargs)
         return cls(pub)
 
     def put(self, data: bytes | bytearray) -> None:
-        """Publish raw bytes over Zenoh SHM."""
+        """Publish raw bytes."""
         self._pub.put(bytes(data))
 
     def undeclare(self) -> None:


### PR DESCRIPTION
## Summary

- **Topic structure**: `bubbaloop/global/{machine_id}/{suffix}` (network-visible) and `bubbaloop/local/{machine_id}/{suffix}` (SHM-only, never crosses bridge)
- **SHM always on**: Session always enables SHM transport — no opt-in config needed
- **`publisher_raw(suffix, local=bool)` / `subscriber_raw(suffix, local=bool)`**: single method, `local=True` → local topic + `CongestionControl::Block` for SHM
- **Removes**: `scope` from `NodeContext`, `NodeContextBuilder`, `with_shm()`
- **Dashboard**: monitor subscribes to `bubbaloop/global/**` only — local SHM topics are structurally invisible

## Test plan
- [ ] Camera nodes publish compressed to `bubbaloop/global/{machine_id}/tapo_terrace/compressed`
- [ ] Raw RGBA frames go to `bubbaloop/local/{machine_id}/tapo_terrace/raw` (bridge RAM stays low)
- [ ] Dashboard stats widget populates from `bubbaloop/global/**`
- [ ] Python nodes (system-telemetry, network-monitor, openmeteo) publish to `bubbaloop/global/`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)