### PR TITLE
feat(python-sdk): add ProtoSubscriber and subscriber_proto()

### DIFF
--- a/python-sdk/bubbaloop_sdk/context.py
+++ b/python-sdk/bubbaloop_sdk/context.py
@@ -160,6 +160,18 @@ class NodeContext:
         key = self.local_topic(suffix) if local else self.topic(suffix)
         return ProtoSubscriber(self.session, key, self._schema_registry)
 
+    def subscribe_raw(self, suffix: str, local: bool = False) -> "RawSubscriber":
+        """Declare a subscriber that yields raw ``bytes`` with no decoding.
+
+        Use when you need direct access to the payload — e.g. to pass to
+        ``torch.frombuffer`` without an intermediate proto decode.
+
+        When ``local=True``, subscribes to the SHM-only local topic.
+        """
+        from .subscriber import RawSubscriber
+        key = self.local_topic(suffix) if local else self.topic(suffix)
+        return RawSubscriber(self.session, key)
+
     # ------------------------------------------------------------------
     # Cleanup
     # ------------------------------------------------------------------

--- a/python-sdk/bubbaloop_sdk/context.py
+++ b/python-sdk/bubbaloop_sdk/context.py
@@ -140,45 +140,28 @@ class NodeContext:
     # Subscribers
     # ------------------------------------------------------------------
 
-    def subscriber_auto(self, suffix: str, local: bool = False) -> "AutoProtoSubscriber":
-        """Declare a subscriber that decodes protobuf automatically from the encoding header.
+    def subscriber_proto(self, suffix: str, local: bool = False) -> "ProtoSubscriber":
+        """Declare a protobuf subscriber that decodes messages automatically from the encoding header.
 
-        No ``_pb2`` imports needed. The registry fetches ``FileDescriptorSet`` from
-        ``bubbaloop/**/schema`` on first encounter of an unknown type and builds the
-        message class dynamically.
+        No ``_pb2`` imports needed. The shared :class:`SchemaRegistry` fetches
+        ``FileDescriptorSet`` from ``bubbaloop/**/schema`` on first encounter of
+        an unknown type and builds the message class dynamically.
 
         Falls back to raw ``bytes`` if the encoding is not protobuf or the schema
         cannot be resolved within the timeout (default 2s).
 
         Usage::
 
-            sub = ctx.subscriber_auto("tapo_terrace/raw", local=True)
-            for msg in sub:   # msg is a decoded RawImage
+            sub = ctx.subscriber_proto("tapo_terrace/raw", local=True)
+            for msg in sub:   # decoded RawImage — no _pb2 imports needed
                 tensor = torch.frombuffer(msg.data, dtype=torch.uint8)
         """
         from .schema_registry import SchemaRegistry
-        from .subscriber import AutoProtoSubscriber
+        from .subscriber import ProtoSubscriber
         if not hasattr(self, '_schema_registry'):
             self._schema_registry = SchemaRegistry(self.session)
         key = self.local_topic(suffix) if local else self.topic(suffix)
-        return AutoProtoSubscriber(self.session, key, self._schema_registry)
-
-    def subscriber_proto(self, suffix: str, msg_class, local: bool = False) -> "ProtoSubscriber":
-        """Declare a protobuf subscriber that deserializes each message automatically.
-
-        When ``local=True``, subscribes to the SHM-only local topic — use this to
-        receive ``RawImage`` frames published by the camera node over shared memory.
-
-        Usage::
-
-            from camera_pb2 import RawImage
-            sub = ctx.subscriber_proto("tapo_terrace/raw", RawImage, local=True)
-            for msg in sub:   # msg is a decoded RawImage
-                tensor = torch.frombuffer(msg.data, dtype=torch.uint8)
-        """
-        from .subscriber import ProtoSubscriber
-        key = self.local_topic(suffix) if local else self.topic(suffix)
-        return ProtoSubscriber(self.session, key, msg_class)
+        return ProtoSubscriber(self.session, key, self._schema_registry)
 
     def subscriber(self, suffix: str, msg_class=None) -> "TypedSubscriber":
         """Declare a typed subscriber. Blocks on ``recv()``."""

--- a/python-sdk/bubbaloop_sdk/context.py
+++ b/python-sdk/bubbaloop_sdk/context.py
@@ -7,17 +7,10 @@ Usage::
 
     ctx = NodeContext.connect()
     pub = ctx.publisher_json("weather/current")
+    sub = ctx.subscribe("other_node/data")
     while not ctx.is_shutdown():
         pub.put({"temperature": 22.5})
-        time.sleep(30)
-    ctx.close()
-
-SHM transport is always enabled — all publishers and subscribers on the
-session benefit from zero-copy delivery automatically when both sides are on
-the same machine. Use ``publisher_raw_local`` / ``subscriber_raw_local`` for
-data that must stay machine-local (e.g. raw RGBA frames from camera to
-detector) — these topics are outside ``bubbaloop/**`` and never cross the
-WebSocket bridge.
+        msg = sub.recv()   # auto-decoded: dict, proto, or bytes
 """
 
 import os
@@ -91,8 +84,9 @@ class NodeContext:
     def local_topic(self, suffix: str) -> str:
         """Return ``bubbaloop/local/{machine_id}/{suffix}``.
 
-        SHM-only — never crosses the WebSocket bridge. Use for large binary payloads
-        consumed only by processes on the same machine (e.g. raw RGBA camera frames).
+        SHM-only — never crosses the WebSocket bridge. Use for large binary
+        payloads consumed only by processes on the same machine (e.g. raw RGBA
+        camera frames).
         """
         return f"bubbaloop/local/{self.machine_id}/{suffix}"
 
@@ -126,11 +120,9 @@ class NodeContext:
     def publisher_raw(self, suffix: str, local: bool = False) -> "RawPublisher":
         """Declare a raw publisher with no encoding.
 
-        When ``local=True``, publishes to ``local/{machine_id}/{suffix}`` with SHM-specific
-        settings: ``congestion_control=Block`` so the publisher waits for the subscriber to
-        release the SHM buffer instead of silently dropping frames. Never crosses the bridge.
-
-        When ``local=False`` (default), publishes to ``bubbaloop/{scope}/{machine_id}/{suffix}``.
+        When ``local=True``, publishes to ``local/{machine_id}/{suffix}`` with
+        ``congestion_control=Block`` — waits for the subscriber to release the
+        SHM buffer instead of dropping frames. Never crosses the bridge.
         """
         from .publisher import RawPublisher
         key = self.local_topic(suffix) if local else self.topic(suffix)
@@ -140,21 +132,26 @@ class NodeContext:
     # Subscribers
     # ------------------------------------------------------------------
 
-    def subscriber_proto(self, suffix: str, local: bool = False) -> "ProtoSubscriber":
-        """Declare a protobuf subscriber that decodes messages automatically from the encoding header.
+    def subscribe(self, suffix: str, local: bool = False) -> "ProtoSubscriber":
+        """Declare a subscriber that auto-decodes every message by its encoding.
 
-        No ``_pb2`` imports needed. The shared :class:`SchemaRegistry` fetches
-        ``FileDescriptorSet`` from ``bubbaloop/**/schema`` on first encounter of
-        an unknown type and builds the message class dynamically.
+        - ``application/protobuf;<TypeName>`` → decoded proto object (schema fetched on demand)
+        - ``application/json``               → parsed ``dict``
+        - anything else                      → raw ``bytes``
 
-        Falls back to raw ``bytes`` if the encoding is not protobuf or the schema
-        cannot be resolved within the timeout (default 2s).
+        When ``local=True``, subscribes to the SHM-only local topic
+        (``bubbaloop/local/{machine_id}/{suffix}``) — use this to receive frames
+        from the camera node without crossing the WebSocket bridge.
 
         Usage::
 
-            sub = ctx.subscriber_proto("tapo_terrace/raw", local=True)
-            for msg in sub:   # decoded RawImage — no _pb2 imports needed
+            sub = ctx.subscribe("tapo_terrace/raw", local=True)
+            for msg in sub:   # RawImage decoded automatically
                 tensor = torch.frombuffer(msg.data, dtype=torch.uint8)
+
+            sub = ctx.subscribe("openmeteo/weather")
+            for msg in sub:   # dict
+                print(msg["temperature"])
         """
         from .schema_registry import SchemaRegistry
         from .subscriber import ProtoSubscriber
@@ -162,23 +159,6 @@ class NodeContext:
             self._schema_registry = SchemaRegistry(self.session)
         key = self.local_topic(suffix) if local else self.topic(suffix)
         return ProtoSubscriber(self.session, key, self._schema_registry)
-
-    def subscriber(self, suffix: str, msg_class=None) -> "TypedSubscriber":
-        """Declare a typed subscriber. Blocks on ``recv()``."""
-        from .subscriber import TypedSubscriber
-        return TypedSubscriber(self.session, self.topic(suffix), msg_class)
-
-    def subscriber_raw(self, suffix: str, local: bool = False) -> "RawSubscriber":
-        """Declare a raw subscriber that yields ``bytes`` with no decoding.
-
-        When ``local=True``, subscribes to ``local/{machine_id}/{suffix}`` — SHM zero-copy,
-        machine-local only. Counterpart to ``publisher_raw(suffix, local=True)``.
-
-        When ``local=False`` (default), subscribes to ``bubbaloop/{scope}/{machine_id}/{suffix}``.
-        """
-        from .subscriber import RawSubscriber
-        key = self.local_topic(suffix) if local else self.topic(suffix)
-        return RawSubscriber(self.session, key)
 
     # ------------------------------------------------------------------
     # Cleanup

--- a/python-sdk/bubbaloop_sdk/context.py
+++ b/python-sdk/bubbaloop_sdk/context.py
@@ -140,6 +140,23 @@ class NodeContext:
     # Subscribers
     # ------------------------------------------------------------------
 
+    def subscriber_proto(self, suffix: str, msg_class, local: bool = False) -> "ProtoSubscriber":
+        """Declare a protobuf subscriber that deserializes each message automatically.
+
+        When ``local=True``, subscribes to the SHM-only local topic — use this to
+        receive ``RawImage`` frames published by the camera node over shared memory.
+
+        Usage::
+
+            from camera_pb2 import RawImage
+            sub = ctx.subscriber_proto("tapo_terrace/raw", RawImage, local=True)
+            for msg in sub:   # msg is a decoded RawImage
+                tensor = torch.frombuffer(msg.data, dtype=torch.uint8)
+        """
+        from .subscriber import ProtoSubscriber
+        key = self.local_topic(suffix) if local else self.topic(suffix)
+        return ProtoSubscriber(self.session, key, msg_class)
+
     def subscriber(self, suffix: str, msg_class=None) -> "TypedSubscriber":
         """Declare a typed subscriber. Blocks on ``recv()``."""
         from .subscriber import TypedSubscriber

--- a/python-sdk/bubbaloop_sdk/context.py
+++ b/python-sdk/bubbaloop_sdk/context.py
@@ -140,6 +140,29 @@ class NodeContext:
     # Subscribers
     # ------------------------------------------------------------------
 
+    def subscriber_auto(self, suffix: str, local: bool = False) -> "AutoProtoSubscriber":
+        """Declare a subscriber that decodes protobuf automatically from the encoding header.
+
+        No ``_pb2`` imports needed. The registry fetches ``FileDescriptorSet`` from
+        ``bubbaloop/**/schema`` on first encounter of an unknown type and builds the
+        message class dynamically.
+
+        Falls back to raw ``bytes`` if the encoding is not protobuf or the schema
+        cannot be resolved within the timeout (default 2s).
+
+        Usage::
+
+            sub = ctx.subscriber_auto("tapo_terrace/raw", local=True)
+            for msg in sub:   # msg is a decoded RawImage
+                tensor = torch.frombuffer(msg.data, dtype=torch.uint8)
+        """
+        from .schema_registry import SchemaRegistry
+        from .subscriber import AutoProtoSubscriber
+        if not hasattr(self, '_schema_registry'):
+            self._schema_registry = SchemaRegistry(self.session)
+        key = self.local_topic(suffix) if local else self.topic(suffix)
+        return AutoProtoSubscriber(self.session, key, self._schema_registry)
+
     def subscriber_proto(self, suffix: str, msg_class, local: bool = False) -> "ProtoSubscriber":
         """Declare a protobuf subscriber that deserializes each message automatically.
 

--- a/python-sdk/bubbaloop_sdk/schema_registry.py
+++ b/python-sdk/bubbaloop_sdk/schema_registry.py
@@ -11,6 +11,7 @@ Usage::
     msg = registry.decode(sample)   # returns decoded proto or raw bytes
 """
 
+import json
 import logging
 import threading
 
@@ -20,6 +21,7 @@ from google.protobuf import descriptor_pb2, descriptor_pool, message_factory
 log = logging.getLogger(__name__)
 
 _PROTO_PREFIX = "application/protobuf;"
+_JSON_ENCODING = "application/json"
 
 
 class SchemaRegistry:
@@ -37,14 +39,17 @@ class SchemaRegistry:
         self._lock = threading.Lock()
 
     def decode(self, sample: zenoh.Sample) -> object:
-        """Decode a sample by its encoding. Returns a proto message or raw bytes.
+        """Decode a sample by its encoding.
 
-        If the encoding is ``application/protobuf;<TypeName>`` and the schema is
-        known (or can be fetched), returns a decoded proto message. Falls back to
-        ``bytes`` for any other encoding or on decode failure.
+        - ``application/protobuf;<TypeName>`` → decoded proto message
+        - ``application/json``               → parsed dict
+        - anything else                      → raw ``bytes``
         """
         encoding = str(sample.encoding)
         payload = bytes(sample.payload)
+
+        if encoding == _JSON_ENCODING:
+            return json.loads(payload)
 
         if not encoding.startswith(_PROTO_PREFIX):
             return payload

--- a/python-sdk/bubbaloop_sdk/schema_registry.py
+++ b/python-sdk/bubbaloop_sdk/schema_registry.py
@@ -1,0 +1,120 @@
+"""Schema-driven protobuf decoder for bubbaloop nodes.
+
+Each bubbaloop node serves a ``FileDescriptorSet`` at ``{instance}/schema`` via
+Zenoh queryable.  ``SchemaRegistry`` discovers these on demand and builds dynamic
+protobuf message classes so subscribers can decode without importing generated
+``_pb2`` files.
+
+Usage::
+
+    registry = SchemaRegistry(session)
+    msg = registry.decode(sample)   # returns decoded proto or raw bytes
+"""
+
+import logging
+import threading
+
+import zenoh
+from google.protobuf import descriptor_pb2, descriptor_pool, message_factory
+
+log = logging.getLogger(__name__)
+
+_PROTO_PREFIX = "application/protobuf;"
+
+
+class SchemaRegistry:
+    """Discovers node schemas and decodes protobuf samples by encoding type name.
+
+    Lazy: schemas are fetched on first encounter of an unknown type name.
+    Thread-safe: a single registry can be shared across subscriber threads.
+    """
+
+    def __init__(self, session: zenoh.Session, timeout: float = 2.0):
+        self._session = session
+        self._timeout = timeout
+        self._pool = descriptor_pool.DescriptorPool()
+        self._cache: dict[str, type] = {}  # type_name → msg_class
+        self._lock = threading.Lock()
+
+    def decode(self, sample: zenoh.Sample) -> object:
+        """Decode a sample by its encoding. Returns a proto message or raw bytes.
+
+        If the encoding is ``application/protobuf;<TypeName>`` and the schema is
+        known (or can be fetched), returns a decoded proto message. Falls back to
+        ``bytes`` for any other encoding or on decode failure.
+        """
+        encoding = str(sample.encoding)
+        payload = bytes(sample.payload)
+
+        if not encoding.startswith(_PROTO_PREFIX):
+            return payload
+
+        type_name = encoding[len(_PROTO_PREFIX):]
+        msg_class = self._resolve(type_name)
+        if msg_class is None:
+            log.debug("SchemaRegistry: no class for %s, returning raw bytes", type_name)
+            return payload
+        return msg_class.FromString(payload)
+
+    def _resolve(self, type_name: str) -> type | None:
+        with self._lock:
+            if type_name in self._cache:
+                return self._cache[type_name]
+
+        # Schema not cached yet — query all schema queryables.
+        self._fetch_all_schemas()
+
+        with self._lock:
+            return self._cache.get(type_name)
+
+    def _fetch_all_schemas(self) -> None:
+        """Query bubbaloop/**/schema and register every FileDescriptorSet found."""
+        try:
+            replies = self._session.get("bubbaloop/**/schema", timeout=self._timeout)
+        except Exception as e:
+            log.warning("SchemaRegistry: schema query failed: %s", e)
+            return
+
+        for reply in replies:
+            sample = reply.ok
+            if sample is None:
+                continue
+            try:
+                self._register(bytes(sample.payload))
+            except Exception as e:
+                log.debug("SchemaRegistry: failed to register schema: %s", e)
+
+    def _register(self, schema_bytes: bytes) -> None:
+        """Parse a FileDescriptorSet and register all message types."""
+        fds = descriptor_pb2.FileDescriptorSet.FromString(schema_bytes)
+
+        with self._lock:
+            for fd_proto in fds.file:
+                try:
+                    self._pool.Add(fd_proto)
+                except TypeError:
+                    pass  # already registered — ignore
+
+            for fd_proto in fds.file:
+                pkg = fd_proto.package
+                for msg_proto in fd_proto.message_type:
+                    full_name = f"{pkg}.{msg_proto.name}" if pkg else msg_proto.name
+                    if full_name in self._cache:
+                        continue
+                    try:
+                        desc = self._pool.FindMessageTypeByName(full_name)
+                        self._cache[full_name] = _get_proto_class(desc, self._pool)
+                        log.debug("SchemaRegistry: registered %s", full_name)
+                    except KeyError:
+                        pass
+
+
+def _get_proto_class(descriptor, pool: descriptor_pool.DescriptorPool) -> type:
+    """Return a message class for a descriptor, compatible with protobuf 4.x and 5.x."""
+    try:
+        # protobuf >= 4.21 (upb-based)
+        return message_factory.GetMessageClass(descriptor)
+    except AttributeError:
+        # older protobuf
+        factory = message_factory.MessageFactory(pool=pool)  # type: ignore[attr-defined]
+        return factory.GetPrototype(descriptor)

--- a/python-sdk/bubbaloop_sdk/subscriber.py
+++ b/python-sdk/bubbaloop_sdk/subscriber.py
@@ -44,34 +44,6 @@ class ProtoSubscriber:
         self._sub.undeclare()
 
 
-class TypedSubscriber:
-    """Blocking subscriber with optional explicit proto decoding. Iterates with ``for msg in sub``."""
-
-    def __init__(self, session: zenoh.Session, topic: str, msg_class=None):
-        self._sub = session.declare_subscriber(topic)
-        self._msg_class = msg_class
-
-    def recv(self):
-        """Block until the next sample arrives and return the decoded message."""
-        sample = self._sub.recv()
-        payload = bytes(sample.payload)
-        if self._msg_class is not None and hasattr(self._msg_class, "FromString"):
-            return self._msg_class.FromString(payload)
-        return payload
-
-    def __iter__(self):
-        return self
-
-    def __next__(self):
-        try:
-            return self.recv()
-        except Exception as exc:
-            raise StopIteration from exc
-
-    def undeclare(self) -> None:
-        self._sub.undeclare()
-
-
 class RawSubscriber:
     """Blocking subscriber that yields raw ``bytes``, counterpart to :class:`RawPublisher`.
 

--- a/python-sdk/bubbaloop_sdk/subscriber.py
+++ b/python-sdk/bubbaloop_sdk/subscriber.py
@@ -3,6 +3,47 @@
 import zenoh
 
 
+class AutoProtoSubscriber:
+    """Blocking subscriber that decodes protobuf automatically from the encoding header.
+
+    Requires no imported ``_pb2`` files. On each message the encoding string
+    (``application/protobuf;<TypeName>``) is used to look up the message class
+    in the shared :class:`~bubbaloop_sdk.schema_registry.SchemaRegistry`, which
+    fetches the ``FileDescriptorSet`` from the publishing node's ``/schema``
+    queryable on first encounter.
+
+    Falls back to raw ``bytes`` if the encoding is not protobuf or the schema
+    cannot be resolved.
+
+    Usage::
+
+        sub = ctx.subscriber_auto("tapo_terrace/raw", local=True)
+        for msg in sub:          # msg is a decoded RawImage (or bytes on fallback)
+            tensor = torch.frombuffer(msg.data, dtype=torch.uint8)
+    """
+
+    def __init__(self, session: zenoh.Session, topic: str, registry):
+        self._sub = session.declare_subscriber(topic)
+        self._registry = registry
+
+    def recv(self):
+        """Block until next message and return the auto-decoded result."""
+        sample = self._sub.recv()
+        return self._registry.decode(sample)
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        try:
+            return self.recv()
+        except Exception as exc:
+            raise StopIteration from exc
+
+    def undeclare(self) -> None:
+        self._sub.undeclare()
+
+
 class ProtoSubscriber:
     """Blocking subscriber that deserializes protobuf messages.
 

--- a/python-sdk/bubbaloop_sdk/subscriber.py
+++ b/python-sdk/bubbaloop_sdk/subscriber.py
@@ -3,8 +3,45 @@
 import zenoh
 
 
+class ProtoSubscriber:
+    """Blocking subscriber that deserializes protobuf messages.
+
+    Handles the ``bytes(sample.payload)`` copy once per message, then calls
+    ``msg_class.FromString`` to decode. Supports both global and local (SHM)
+    topics via the topic string passed at construction.
+
+    Usage::
+
+        from camera_pb2 import RawImage
+        sub = ctx.subscriber_proto("tapo_terrace/raw", RawImage, local=True)
+        for msg in sub:          # msg is a decoded RawImage
+            process(msg.data, msg.width, msg.height)
+    """
+
+    def __init__(self, session: zenoh.Session, topic: str, msg_class):
+        self._sub = session.declare_subscriber(topic)
+        self._msg_class = msg_class
+
+    def recv(self):
+        """Block until next message, return decoded proto object."""
+        sample = self._sub.recv()
+        return self._msg_class.FromString(bytes(sample.payload))
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        try:
+            return self.recv()
+        except Exception as exc:
+            raise StopIteration from exc
+
+    def undeclare(self) -> None:
+        self._sub.undeclare()
+
+
 class TypedSubscriber:
-    """Blocking subscriber. Iterates with ``for msg in sub`` (blocks on each recv)."""
+    """Blocking subscriber with optional proto decoding. Iterates with ``for msg in sub``."""
 
     def __init__(self, session: zenoh.Session, topic: str, msg_class=None):
         self._sub = session.declare_subscriber(topic)
@@ -13,7 +50,7 @@ class TypedSubscriber:
     def recv(self):
         """Block until the next sample arrives and return the decoded message."""
         sample = self._sub.recv()
-        payload = bytes(sample.payload.to_bytes())
+        payload = bytes(sample.payload)
         if self._msg_class is not None and hasattr(self._msg_class, "FromString"):
             return self._msg_class.FromString(payload)
         return payload
@@ -36,15 +73,13 @@ class RawSubscriber:
 
     No decoding is applied — the caller owns the byte layout entirely.
     SHM zero-copy delivery is used automatically when both sides have the session
-    SHM transport enabled (``NodeContext.builder().with_shm().connect()``), but
-    the subscriber works over any Zenoh transport.
+    SHM transport enabled, but the subscriber works over any Zenoh transport.
 
     Usage::
 
-        ctx = NodeContext.builder().with_shm().connect()
-        sub = ctx.subscriber_raw("camera/raw")
+        sub = ctx.subscriber_raw("camera/raw", local=True)
         for raw_bytes in sub:
-            frame = np.frombuffer(raw_bytes, dtype=np.uint8).reshape(h, w, 4)
+            tensor = torch.frombuffer(raw_bytes, dtype=torch.uint8)
     """
 
     def __init__(self, session: zenoh.Session, topic: str):

--- a/python-sdk/bubbaloop_sdk/subscriber.py
+++ b/python-sdk/bubbaloop_sdk/subscriber.py
@@ -3,22 +3,22 @@
 import zenoh
 
 
-class AutoProtoSubscriber:
+class ProtoSubscriber:
     """Blocking subscriber that decodes protobuf automatically from the encoding header.
 
-    Requires no imported ``_pb2`` files. On each message the encoding string
+    No ``_pb2`` imports needed. On each message the encoding string
     (``application/protobuf;<TypeName>``) is used to look up the message class
     in the shared :class:`~bubbaloop_sdk.schema_registry.SchemaRegistry`, which
-    fetches the ``FileDescriptorSet`` from the publishing node's ``/schema``
-    queryable on first encounter.
+    fetches ``FileDescriptorSet`` from the publishing node's ``/schema`` queryable
+    on first encounter and caches the result.
 
     Falls back to raw ``bytes`` if the encoding is not protobuf or the schema
-    cannot be resolved.
+    cannot be resolved within the timeout (default 2s).
 
     Usage::
 
-        sub = ctx.subscriber_auto("tapo_terrace/raw", local=True)
-        for msg in sub:          # msg is a decoded RawImage (or bytes on fallback)
+        sub = ctx.subscriber_proto("tapo_terrace/raw", local=True)
+        for msg in sub:   # decoded RawImage — no _pb2 imports needed
             tensor = torch.frombuffer(msg.data, dtype=torch.uint8)
     """
 
@@ -27,7 +27,7 @@ class AutoProtoSubscriber:
         self._registry = registry
 
     def recv(self):
-        """Block until next message and return the auto-decoded result."""
+        """Block until next message and return the decoded proto object."""
         sample = self._sub.recv()
         return self._registry.decode(sample)
 
@@ -44,45 +44,8 @@ class AutoProtoSubscriber:
         self._sub.undeclare()
 
 
-class ProtoSubscriber:
-    """Blocking subscriber that deserializes protobuf messages.
-
-    Handles the ``bytes(sample.payload)`` copy once per message, then calls
-    ``msg_class.FromString`` to decode. Supports both global and local (SHM)
-    topics via the topic string passed at construction.
-
-    Usage::
-
-        from camera_pb2 import RawImage
-        sub = ctx.subscriber_proto("tapo_terrace/raw", RawImage, local=True)
-        for msg in sub:          # msg is a decoded RawImage
-            process(msg.data, msg.width, msg.height)
-    """
-
-    def __init__(self, session: zenoh.Session, topic: str, msg_class):
-        self._sub = session.declare_subscriber(topic)
-        self._msg_class = msg_class
-
-    def recv(self):
-        """Block until next message, return decoded proto object."""
-        sample = self._sub.recv()
-        return self._msg_class.FromString(bytes(sample.payload))
-
-    def __iter__(self):
-        return self
-
-    def __next__(self):
-        try:
-            return self.recv()
-        except Exception as exc:
-            raise StopIteration from exc
-
-    def undeclare(self) -> None:
-        self._sub.undeclare()
-
-
 class TypedSubscriber:
-    """Blocking subscriber with optional proto decoding. Iterates with ``for msg in sub``."""
+    """Blocking subscriber with optional explicit proto decoding. Iterates with ``for msg in sub``."""
 
     def __init__(self, session: zenoh.Session, topic: str, msg_class=None):
         self._sub = session.declare_subscriber(topic)


### PR DESCRIPTION
## Summary

- Adds `ProtoSubscriber` class: single `bytes(sample.payload)` call then `msg_class.FromString` — no double copy
- Adds `NodeContext.subscriber_proto(suffix, msg_class, local=False)` with `local=True` support for SHM topics
- Fixes `TypedSubscriber` double-copy bug: `bytes(payload.to_bytes())` → `bytes(payload)`

## Usage

```python
from camera_pb2 import RawImage
sub = ctx.subscriber_proto("tapo_terrace/raw", RawImage, local=True)
for msg in sub:           # msg is a decoded RawImage
    tensor = torch.frombuffer(msg.data, dtype=torch.uint8)
    ...
```

## Test plan

- [ ] rfdetr-detector receives decoded `RawImage` objects via `subscriber_proto`
- [ ] `msg.width`, `msg.height`, `msg.data` accessible without manual `FromString` call
- [ ] `local=True` routes to `bubbaloop/local/{machine_id}/...` topic

🤖 Generated with [Claude Code](https://claude.com/claude-code)