### PR TITLE
feat(sdk,dashboard): SHM proto publisher + remote dashboard fixes

### DIFF
--- a/crates/bubbaloop-node/src/context.rs
+++ b/crates/bubbaloop-node/src/context.rs
@@ -70,6 +70,31 @@ impl NodeContext {
             .await
     }
 
+    /// Create a raw SHM publisher that tags payloads with `APPLICATION_PROTOBUF` encoding.
+    ///
+    /// Like [`publisher_raw`](Self::publisher_raw) but sets the protobuf encoding header
+    /// so subscribers can auto-decode the payload by type name. Use this when you manually
+    /// serialize a proto into an SHM buffer and want schema-aware subscribers to decode it.
+    ///
+    /// Always local (`local/{machine_id}/{suffix}`) with `CongestionControl::Block`.
+    pub async fn publisher_raw_proto<T>(
+        &self,
+        suffix: &str,
+    ) -> Result<crate::publisher::RawPublisher>
+    where
+        T: prost::Message + Default + crate::MessageTypeName,
+    {
+        let encoding =
+            zenoh::bytes::Encoding::APPLICATION_PROTOBUF.with_schema(T::type_name());
+        crate::publisher::RawPublisher::with_encoding(
+            &self.session,
+            &self.local_topic(suffix),
+            true,
+            Some(encoding),
+        )
+        .await
+    }
+
     // ── Subscribers ──────────────────────────────────────────────────────────
 
     /// Create a typed subscriber that auto-decodes protobuf messages.

--- a/crates/bubbaloop-node/src/publisher.rs
+++ b/crates/bubbaloop-node/src/publisher.rs
@@ -75,16 +75,17 @@ impl JsonPublisher {
     }
 }
 
-/// A declared raw-bytes publisher with no encoding.
-///
-/// Publishes pre-built [`ZBytes`] payloads directly — no serialization, no encoding header.
-/// The caller controls the byte layout.
+/// A declared raw-bytes publisher for pre-built [`ZBytes`] payloads (e.g. SHM buffers).
 ///
 /// Created via [`NodeContext::publisher_raw`](crate::NodeContext::publisher_raw).
+///
 /// When `local = true`, the publisher targets a machine-local topic
 /// (`local/{machine_id}/suffix`) and uses `CongestionControl::Block` — required for
 /// SHM so the publisher waits for the subscriber to read the SHM buffer instead of
 /// silently dropping frames.
+///
+/// An optional encoding can be set so subscribers can auto-decode the payload
+/// (e.g. `APPLICATION_PROTOBUF;TypeName` for proto-serialized SHM buffers).
 pub struct RawPublisher {
     publisher: zenoh::pubsub::Publisher<'static>,
 }
@@ -95,25 +96,32 @@ impl RawPublisher {
         key_expr: &str,
         local: bool,
     ) -> Result<Self> {
+        Self::with_encoding(session, key_expr, local, None).await
+    }
+
+    pub(crate) async fn with_encoding(
+        session: &Arc<zenoh::Session>,
+        key_expr: &str,
+        local: bool,
+        encoding: Option<Encoding>,
+    ) -> Result<Self> {
         let mut builder = session.declare_publisher(key_expr.to_string());
         if local {
-            // CongestionControl::Block is required for SHM publishers:
-            // the publisher must wait for the subscriber to release the SHM buffer
-            // rather than silently dropping messages when the subscriber is slow.
             builder = builder.congestion_control(CongestionControl::Block);
         }
-        let publisher = builder
-            .await
-            .map_err(|e| NodeError::PublisherDeclare {
-                topic: key_expr.to_string(),
-                source: e,
-            })?;
+        if let Some(enc) = encoding {
+            builder = builder.encoding(enc);
+        }
+        let publisher = builder.await.map_err(|e| NodeError::PublisherDeclare {
+            topic: key_expr.to_string(),
+            source: e,
+        })?;
 
         log::debug!("RawPublisher declared on '{}' (local={})", key_expr, local);
         Ok(Self { publisher })
     }
 
-    /// Publish a raw [`ZBytes`] payload with no encoding.
+    /// Publish a raw [`ZBytes`] payload.
     pub async fn put(&self, payload: zenoh::bytes::ZBytes) -> Result<()> {
         self.publisher
             .put(payload)

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -7,81 +7,131 @@ Real-time camera dashboard with H264 decoding via WebCodecs.
 - **H264 decoding** — WebCodecs API (hardware accelerated)
 - **Drag-and-drop** — reorder cameras by dragging
 - **Maximize/restore** — expand any camera to full width
-- **Auto-discovery** — topics discovered automatically
+- **Auto-discovery** — topics discovered automatically via `bubbaloop/global/**`
 - **Live stats** — FPS, frame count, resolution per camera
 - **Metadata panel** — timestamps, latency, sequence numbers
-- **HTTPS support** — self-signed cert for remote access
-- **Single-port** — Zenoh WebSocket proxied through Vite
+- **HTTPS support** — self-signed certs or Tailscale serve for remote access
+- **Single-port** — Zenoh WebSocket proxied through `serve.mjs`
 
 ## Quick Start
 
+### Prerequisites
+
+- **zenohd** running on `tcp/127.0.0.1:7447`
+- **zenoh-bridge-remote-api** running in **client mode** on WS port 10001
+
+### 1. Build the dashboard
+
 ```bash
-pixi run bridge     # Terminal 1: zenoh bridge
-pixi run cameras   # Terminal 2: camera streams
-pixi run dashboard  # Terminal 3: dashboard
+cd dashboard
+npm install
+npm run build
 ```
 
-**Local:** http://localhost:5173
-**Remote:** https://\<ip\>:5173 (accept self-signed cert)
+### 2. Run the production server
 
-## Usage
+```bash
+node serve.mjs [--port 8080] [--bridge-port 10001] [--no-tls]
+```
 
-### Connection
+`serve.mjs` serves static files from `dist/` and proxies `/zenoh` WebSocket connections to the Zenoh bridge. This is the recommended way to run in production.
 
-Auto-connects via built-in proxy. Status in header:
-- 🟢 Connected | 🟡 Connecting | 🔴 Error (click ↻)
+**Options:**
+- `--port` — HTTP(S) port (default: 8080)
+- `--bridge-port` — Zenoh bridge WS port (default: 10001)
+- `--no-tls` — Force plain HTTP even if certs exist in `certs/`
 
-### Camera Controls
+### 3. HTTPS for remote access
 
-| Action | How |
-|--------|-----|
-| Add | Click "Add Camera" |
-| Edit | ✏️ icon |
-| Metadata | ⓘ icon |
-| Remove | ✕ icon |
-| Reorder | Drag grip |
-| Maximize | Expand icon |
+**Option A: Tailscale serve (recommended)**
 
-### Live Stats
+Provides trusted TLS certs with no browser warnings:
 
-Each camera shows: **FPS** · **frames** · **resolution** · **LIVE/INIT**
+```bash
+sudo tailscale serve --bg --https=443 http://localhost:8080
+# Access at: https://<hostname>.<tailnet>.ts.net/
+```
 
-### Metadata Panel (ⓘ)
+Run `serve.mjs` with `--no-tls` when using Tailscale (Tailscale handles TLS).
 
-Shows format, data size, sequence, frame ID, timestamps, and **latency** (acq → pub).
+**Option B: Self-signed certs**
+
+```bash
+mkdir -p certs
+openssl req -x509 -newkey rsa:2048 \
+  -keyout certs/key.pem -out certs/cert.pem \
+  -days 365 -nodes -subj "/CN=localhost" \
+  -addext "subjectAltName=IP:<your-ip>,DNS:localhost"
+node serve.mjs --port 8080
+# Access at: https://<your-ip>:8080/ (accept cert warning)
+```
+
+### 4. Zenoh bridge setup
+
+The bridge **must** run in client mode to avoid buffering all topics:
+
+```bash
+zenoh-bridge-remote-api --ws-port 10001 -e tcp/127.0.0.1:7447 -m client --no-multicast-scouting
+```
+
+**Important:** Peer mode (the default) causes the bridge to eagerly subscribe to all Zenoh topics, including high-bandwidth camera streams. This leads to excessive memory usage (GBs) even when no browser is connected.
+
+### systemd service example
+
+```ini
+[Unit]
+Description=Bubbaloop Dashboard
+After=bubbaloop-bridge.service
+
+[Service]
+Type=simple
+WorkingDirectory=/path/to/bubbaloop/dashboard
+ExecStart=/usr/bin/node serve.mjs --port 8080 --no-tls
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+```
 
 ## Development
 
 ```bash
-pixi run dashboard          # Dev server
-pixi run dashboard-build    # Production build
+npm run dev       # Vite dev server with HMR
+npm run build     # Production build
+npm run preview   # Preview production build (no WS proxy)
 ```
 
-Or with npm:
-
-```bash
-cd dashboard && npm install && npm run dev
-```
+Note: `npm run preview` (vite preview) does **not** proxy `/zenoh` — use `node serve.mjs` for production with WebSocket support.
 
 ## Architecture
 
 ```
-RTSP Cameras → cameras_node (GStreamer) → zenoh-bridge → Dashboard (WebCodecs)
-                                         ↓
-                              Vite proxies /zenoh → WS:10000
+RTSP Camera → camera_node (GStreamer/H264) → zenohd (tcp/7447)
+                                                ↓
+                              zenoh-bridge-remote-api (WS:10001, client mode)
+                                                ↓
+                              serve.mjs (HTTP:8080, proxies /zenoh → WS:10001)
+                                                ↓
+                              [optional] tailscale serve (HTTPS:443 → HTTP:8080)
+                                                ↓
+                                            Browser (WebCodecs H264 decode)
 ```
 
 ## Browser Support
 
 | Browser | Version |
 |---------|---------|
-| Chrome  | 94+ ✅ |
-| Edge    | 94+ ✅ |
-| Safari  | 16.4+ ✅ |
-| Firefox | ❌ No WebCodecs |
+| Chrome  | 94+ |
+| Edge    | 94+ |
+| Safari  | 16.4+ |
+| Firefox | Not supported (no WebCodecs) |
+| iOS Chrome/Safari | 16.4+ (WebKit) |
 
 ## Troubleshooting
 
-- **"WebSocket disconnected"** — Check `pixi run bridge` is running
-- **"Waiting for keyframe"** — Check `pixi run cameras` is running
-- **"WebCodecs not supported"** — Use Chrome/Edge/Safari, access via localhost or HTTPS
+- **"WebSocket disconnected"** — Check the bridge is running and `serve.mjs` is proxying `/zenoh`
+- **"Waiting for keyframe"** — Check camera node is publishing to `bubbaloop/global/**/compressed`
+- **"WebCodecs not supported"** — Use Chrome/Edge/Safari; must access via HTTPS or localhost
+- **Bridge using GBs of RAM** — Ensure bridge runs with `-m client`, not the default peer mode
+- **No topics in dashboard** — Check bridge is connected to zenohd: `ss -tnp | grep 7447`

--- a/dashboard/serve.mjs
+++ b/dashboard/serve.mjs
@@ -8,7 +8,6 @@ import http from 'node:http';
 import https from 'node:https';
 import fs from 'node:fs';
 import path from 'node:path';
-import net from 'node:net';
 import os from 'node:os';
 import { fileURLToPath } from 'node:url';
 
@@ -108,15 +107,18 @@ server.on('upgrade', (req, clientSocket, head) => {
     // Bi-directional pipe
     bridgeSocket.pipe(clientSocket);
     clientSocket.pipe(bridgeSocket);
+
+    bridgeSocket.on('error', () => clientSocket.destroy());
+    clientSocket.on('error', () => bridgeSocket.destroy());
   });
 
   proxyReq.on('error', () => clientSocket.destroy());
-  clientSocket.on('error', () => proxyReq.destroy());
 
+  if (head.length > 0) proxyReq.write(head);
   proxyReq.end();
 });
 
-server.listen(PORT, '0.0.0.0', () => {
+server.listen(PORT, '127.0.0.1', () => {
   const proto = useHttps ? 'https' : 'http';
   console.log(`\n  Bubbaloop Dashboard Server ${useHttps ? '(HTTPS)' : '(HTTP)'}\n`);
   console.log(`  Local:   ${proto}://localhost:${PORT}/`);

--- a/dashboard/serve.mjs
+++ b/dashboard/serve.mjs
@@ -5,6 +5,7 @@
  * Usage: node serve.mjs [--port 8080] [--bridge-port 10001]
  */
 import http from 'node:http';
+import https from 'node:https';
 import fs from 'node:fs';
 import path from 'node:path';
 import net from 'node:net';
@@ -57,12 +58,24 @@ function serveFile(res, filePath) {
   });
 }
 
-const server = http.createServer((req, res) => {
+// Use HTTPS if certs exist and --no-tls is not set, otherwise plain HTTP
+const certsDir = path.join(__dirname, 'certs');
+const certPath = path.join(certsDir, 'cert.pem');
+const keyPath = path.join(certsDir, 'key.pem');
+const noTls = args.includes('--no-tls');
+const useHttps = !noTls && fs.existsSync(certPath) && fs.existsSync(keyPath);
+
+const handler = (req, res) => {
   res.setHeader('Access-Control-Allow-Origin', '*');
-  const url = new URL(req.url, `http://${req.headers.host}`);
+  const proto = useHttps ? 'https' : 'http';
+  const url = new URL(req.url, `${proto}://${req.headers.host}`);
   const filePath = path.join(DIST, url.pathname === '/' ? 'index.html' : url.pathname);
   serveFile(res, filePath);
-});
+};
+
+const server = useHttps
+  ? https.createServer({ key: fs.readFileSync(keyPath), cert: fs.readFileSync(certPath) }, handler)
+  : http.createServer(handler);
 
 // WebSocket proxy: upgrade /zenoh to the Zenoh bridge
 server.on('upgrade', (req, clientSocket, head) => {
@@ -71,33 +84,46 @@ server.on('upgrade', (req, clientSocket, head) => {
     return;
   }
 
-  const bridgeSocket = net.createConnection(BRIDGE_PORT, BRIDGE_HOST, () => {
-    const upgradeReq =
-      `${req.method} / HTTP/${req.httpVersion}\r\n` +
-      Object.entries(req.headers)
-        .filter(([k]) => k !== 'host')
-        .map(([k, v]) => `${k}: ${v}`)
-        .join('\r\n') +
-      `\r\nHost: ${BRIDGE_HOST}:${BRIDGE_PORT}\r\n\r\n`;
+  // Use http.request to perform a proper HTTP upgrade to the bridge
+  const proxyReq = http.request({
+    hostname: BRIDGE_HOST,
+    port: BRIDGE_PORT,
+    path: '/',
+    method: req.method,
+    headers: {
+      ...req.headers,
+      host: `${BRIDGE_HOST}:${BRIDGE_PORT}`,
+    },
+  });
 
-    bridgeSocket.write(upgradeReq);
-    if (head.length > 0) bridgeSocket.write(head);
+  proxyReq.on('upgrade', (proxyRes, bridgeSocket, bridgeHead) => {
+    // Send the 101 response back to the client
+    const resHeaders = [`HTTP/1.1 ${proxyRes.statusCode} ${proxyRes.statusMessage}`];
+    for (const [k, v] of Object.entries(proxyRes.headers)) {
+      resHeaders.push(`${k}: ${v}`);
+    }
+    clientSocket.write(resHeaders.join('\r\n') + '\r\n\r\n');
+    if (bridgeHead.length > 0) clientSocket.write(bridgeHead);
 
+    // Bi-directional pipe
     bridgeSocket.pipe(clientSocket);
     clientSocket.pipe(bridgeSocket);
   });
 
-  bridgeSocket.on('error', () => clientSocket.destroy());
-  clientSocket.on('error', () => bridgeSocket.destroy());
+  proxyReq.on('error', () => clientSocket.destroy());
+  clientSocket.on('error', () => proxyReq.destroy());
+
+  proxyReq.end();
 });
 
 server.listen(PORT, '0.0.0.0', () => {
-  console.log(`\n  Bubbaloop Dashboard Server\n`);
-  console.log(`  Local:   http://localhost:${PORT}/`);
+  const proto = useHttps ? 'https' : 'http';
+  console.log(`\n  Bubbaloop Dashboard Server ${useHttps ? '(HTTPS)' : '(HTTP)'}\n`);
+  console.log(`  Local:   ${proto}://localhost:${PORT}/`);
   for (const addrs of Object.values(os.networkInterfaces())) {
     for (const addr of addrs) {
       if (addr.family === 'IPv4' && !addr.internal) {
-        console.log(`  Network: http://${addr.address}:${PORT}/`);
+        console.log(`  Network: ${proto}://${addr.address}:${PORT}/`);
       }
     }
   }

--- a/dashboard/src/lib/subscription-manager.ts
+++ b/dashboard/src/lib/subscription-manager.ts
@@ -534,14 +534,16 @@ export class ZenohSubscriptionManager {
     }
 
     try {
-      const subscriber = await endpoint.session.declareSubscriber('bubbaloop/**', {
+      // Subscribe to global topics only — excludes local/** (SHM raw frames)
+      // which are machine-local and would overwhelm the WebSocket bridge.
+      const subscriber = await endpoint.session.declareSubscriber('bubbaloop/global/**', {
         handler: (sample) => {
           this.handleMonitorSample(sample, endpointId);
         },
       });
 
       endpoint.monitorSubscriber = subscriber;
-      console.log(`[SubscriptionManager] Started monitoring all topics on ${endpointId}`);
+      console.log(`[SubscriptionManager] Started monitoring global topics on ${endpointId}`);
     } catch (e) {
       console.error(`[SubscriptionManager] Failed to start monitoring:`, e);
     }

--- a/python-sdk/bubbaloop_sdk/__init__.py
+++ b/python-sdk/bubbaloop_sdk/__init__.py
@@ -11,7 +11,7 @@ from .decode_sample import ProtoDecoder
 from .discover import NodeInfo, discover_nodes
 from .get_sample import GetSampleTimeout, get_sample
 from .publisher import JsonPublisher, ProtoPublisher, RawPublisher
-from .subscriber import RawSubscriber, TypedSubscriber
+from .subscriber import ProtoSubscriber, RawSubscriber
 from .node import run_node
 
 __all__ = [
@@ -21,9 +21,9 @@ __all__ = [
     "NodeInfo",
     "ProtoDecoder",
     "ProtoPublisher",
+    "ProtoSubscriber",
     "RawPublisher",
     "RawSubscriber",
-    "TypedSubscriber",
     "discover_nodes",
     "get_sample",
     "run_node",

--- a/python-sdk/bubbaloop_sdk/context.py
+++ b/python-sdk/bubbaloop_sdk/context.py
@@ -160,6 +160,18 @@ class NodeContext:
         key = self.local_topic(suffix) if local else self.topic(suffix)
         return ProtoSubscriber(self.session, key, self._schema_registry)
 
+    def subscribe_raw(self, suffix: str, local: bool = False) -> "RawSubscriber":
+        """Declare a subscriber that yields raw ``bytes`` with no decoding.
+
+        Use when you need direct access to the payload — e.g. to pass to
+        ``torch.frombuffer`` without an intermediate proto decode.
+
+        When ``local=True``, subscribes to the SHM-only local topic.
+        """
+        from .subscriber import RawSubscriber
+        key = self.local_topic(suffix) if local else self.topic(suffix)
+        return RawSubscriber(self.session, key)
+
     # ------------------------------------------------------------------
     # Cleanup
     # ------------------------------------------------------------------

--- a/python-sdk/bubbaloop_sdk/context.py
+++ b/python-sdk/bubbaloop_sdk/context.py
@@ -140,45 +140,28 @@ class NodeContext:
     # Subscribers
     # ------------------------------------------------------------------
 
-    def subscriber_auto(self, suffix: str, local: bool = False) -> "AutoProtoSubscriber":
-        """Declare a subscriber that decodes protobuf automatically from the encoding header.
+    def subscriber_proto(self, suffix: str, local: bool = False) -> "ProtoSubscriber":
+        """Declare a protobuf subscriber that decodes messages automatically from the encoding header.
 
-        No ``_pb2`` imports needed. The registry fetches ``FileDescriptorSet`` from
-        ``bubbaloop/**/schema`` on first encounter of an unknown type and builds the
-        message class dynamically.
+        No ``_pb2`` imports needed. The shared :class:`SchemaRegistry` fetches
+        ``FileDescriptorSet`` from ``bubbaloop/**/schema`` on first encounter of
+        an unknown type and builds the message class dynamically.
 
         Falls back to raw ``bytes`` if the encoding is not protobuf or the schema
         cannot be resolved within the timeout (default 2s).
 
         Usage::
 
-            sub = ctx.subscriber_auto("tapo_terrace/raw", local=True)
-            for msg in sub:   # msg is a decoded RawImage
+            sub = ctx.subscriber_proto("tapo_terrace/raw", local=True)
+            for msg in sub:   # decoded RawImage — no _pb2 imports needed
                 tensor = torch.frombuffer(msg.data, dtype=torch.uint8)
         """
         from .schema_registry import SchemaRegistry
-        from .subscriber import AutoProtoSubscriber
+        from .subscriber import ProtoSubscriber
         if not hasattr(self, '_schema_registry'):
             self._schema_registry = SchemaRegistry(self.session)
         key = self.local_topic(suffix) if local else self.topic(suffix)
-        return AutoProtoSubscriber(self.session, key, self._schema_registry)
-
-    def subscriber_proto(self, suffix: str, msg_class, local: bool = False) -> "ProtoSubscriber":
-        """Declare a protobuf subscriber that deserializes each message automatically.
-
-        When ``local=True``, subscribes to the SHM-only local topic — use this to
-        receive ``RawImage`` frames published by the camera node over shared memory.
-
-        Usage::
-
-            from camera_pb2 import RawImage
-            sub = ctx.subscriber_proto("tapo_terrace/raw", RawImage, local=True)
-            for msg in sub:   # msg is a decoded RawImage
-                tensor = torch.frombuffer(msg.data, dtype=torch.uint8)
-        """
-        from .subscriber import ProtoSubscriber
-        key = self.local_topic(suffix) if local else self.topic(suffix)
-        return ProtoSubscriber(self.session, key, msg_class)
+        return ProtoSubscriber(self.session, key, self._schema_registry)
 
     def subscriber(self, suffix: str, msg_class=None) -> "TypedSubscriber":
         """Declare a typed subscriber. Blocks on ``recv()``."""

--- a/python-sdk/bubbaloop_sdk/context.py
+++ b/python-sdk/bubbaloop_sdk/context.py
@@ -7,17 +7,10 @@ Usage::
 
     ctx = NodeContext.connect()
     pub = ctx.publisher_json("weather/current")
+    sub = ctx.subscribe("other_node/data")
     while not ctx.is_shutdown():
         pub.put({"temperature": 22.5})
-        time.sleep(30)
-    ctx.close()
-
-SHM transport is always enabled — all publishers and subscribers on the
-session benefit from zero-copy delivery automatically when both sides are on
-the same machine. Use ``publisher_raw_local`` / ``subscriber_raw_local`` for
-data that must stay machine-local (e.g. raw RGBA frames from camera to
-detector) — these topics are outside ``bubbaloop/**`` and never cross the
-WebSocket bridge.
+        msg = sub.recv()   # auto-decoded: dict, proto, or bytes
 """
 
 import os
@@ -91,8 +84,9 @@ class NodeContext:
     def local_topic(self, suffix: str) -> str:
         """Return ``bubbaloop/local/{machine_id}/{suffix}``.
 
-        SHM-only — never crosses the WebSocket bridge. Use for large binary payloads
-        consumed only by processes on the same machine (e.g. raw RGBA camera frames).
+        SHM-only — never crosses the WebSocket bridge. Use for large binary
+        payloads consumed only by processes on the same machine (e.g. raw RGBA
+        camera frames).
         """
         return f"bubbaloop/local/{self.machine_id}/{suffix}"
 
@@ -126,11 +120,9 @@ class NodeContext:
     def publisher_raw(self, suffix: str, local: bool = False) -> "RawPublisher":
         """Declare a raw publisher with no encoding.
 
-        When ``local=True``, publishes to ``local/{machine_id}/{suffix}`` with SHM-specific
-        settings: ``congestion_control=Block`` so the publisher waits for the subscriber to
-        release the SHM buffer instead of silently dropping frames. Never crosses the bridge.
-
-        When ``local=False`` (default), publishes to ``bubbaloop/{scope}/{machine_id}/{suffix}``.
+        When ``local=True``, publishes to ``local/{machine_id}/{suffix}`` with
+        ``congestion_control=Block`` — waits for the subscriber to release the
+        SHM buffer instead of dropping frames. Never crosses the bridge.
         """
         from .publisher import RawPublisher
         key = self.local_topic(suffix) if local else self.topic(suffix)
@@ -140,21 +132,26 @@ class NodeContext:
     # Subscribers
     # ------------------------------------------------------------------
 
-    def subscriber_proto(self, suffix: str, local: bool = False) -> "ProtoSubscriber":
-        """Declare a protobuf subscriber that decodes messages automatically from the encoding header.
+    def subscribe(self, suffix: str, local: bool = False) -> "ProtoSubscriber":
+        """Declare a subscriber that auto-decodes every message by its encoding.
 
-        No ``_pb2`` imports needed. The shared :class:`SchemaRegistry` fetches
-        ``FileDescriptorSet`` from ``bubbaloop/**/schema`` on first encounter of
-        an unknown type and builds the message class dynamically.
+        - ``application/protobuf;<TypeName>`` → decoded proto object (schema fetched on demand)
+        - ``application/json``               → parsed ``dict``
+        - anything else                      → raw ``bytes``
 
-        Falls back to raw ``bytes`` if the encoding is not protobuf or the schema
-        cannot be resolved within the timeout (default 2s).
+        When ``local=True``, subscribes to the SHM-only local topic
+        (``bubbaloop/local/{machine_id}/{suffix}``) — use this to receive frames
+        from the camera node without crossing the WebSocket bridge.
 
         Usage::
 
-            sub = ctx.subscriber_proto("tapo_terrace/raw", local=True)
-            for msg in sub:   # decoded RawImage — no _pb2 imports needed
+            sub = ctx.subscribe("tapo_terrace/raw", local=True)
+            for msg in sub:   # RawImage decoded automatically
                 tensor = torch.frombuffer(msg.data, dtype=torch.uint8)
+
+            sub = ctx.subscribe("openmeteo/weather")
+            for msg in sub:   # dict
+                print(msg["temperature"])
         """
         from .schema_registry import SchemaRegistry
         from .subscriber import ProtoSubscriber
@@ -162,23 +159,6 @@ class NodeContext:
             self._schema_registry = SchemaRegistry(self.session)
         key = self.local_topic(suffix) if local else self.topic(suffix)
         return ProtoSubscriber(self.session, key, self._schema_registry)
-
-    def subscriber(self, suffix: str, msg_class=None) -> "TypedSubscriber":
-        """Declare a typed subscriber. Blocks on ``recv()``."""
-        from .subscriber import TypedSubscriber
-        return TypedSubscriber(self.session, self.topic(suffix), msg_class)
-
-    def subscriber_raw(self, suffix: str, local: bool = False) -> "RawSubscriber":
-        """Declare a raw subscriber that yields ``bytes`` with no decoding.
-
-        When ``local=True``, subscribes to ``local/{machine_id}/{suffix}`` — SHM zero-copy,
-        machine-local only. Counterpart to ``publisher_raw(suffix, local=True)``.
-
-        When ``local=False`` (default), subscribes to ``bubbaloop/{scope}/{machine_id}/{suffix}``.
-        """
-        from .subscriber import RawSubscriber
-        key = self.local_topic(suffix) if local else self.topic(suffix)
-        return RawSubscriber(self.session, key)
 
     # ------------------------------------------------------------------
     # Cleanup

--- a/python-sdk/bubbaloop_sdk/context.py
+++ b/python-sdk/bubbaloop_sdk/context.py
@@ -140,6 +140,23 @@ class NodeContext:
     # Subscribers
     # ------------------------------------------------------------------
 
+    def subscriber_proto(self, suffix: str, msg_class, local: bool = False) -> "ProtoSubscriber":
+        """Declare a protobuf subscriber that deserializes each message automatically.
+
+        When ``local=True``, subscribes to the SHM-only local topic — use this to
+        receive ``RawImage`` frames published by the camera node over shared memory.
+
+        Usage::
+
+            from camera_pb2 import RawImage
+            sub = ctx.subscriber_proto("tapo_terrace/raw", RawImage, local=True)
+            for msg in sub:   # msg is a decoded RawImage
+                tensor = torch.frombuffer(msg.data, dtype=torch.uint8)
+        """
+        from .subscriber import ProtoSubscriber
+        key = self.local_topic(suffix) if local else self.topic(suffix)
+        return ProtoSubscriber(self.session, key, msg_class)
+
     def subscriber(self, suffix: str, msg_class=None) -> "TypedSubscriber":
         """Declare a typed subscriber. Blocks on ``recv()``."""
         from .subscriber import TypedSubscriber

--- a/python-sdk/bubbaloop_sdk/context.py
+++ b/python-sdk/bubbaloop_sdk/context.py
@@ -140,6 +140,29 @@ class NodeContext:
     # Subscribers
     # ------------------------------------------------------------------
 
+    def subscriber_auto(self, suffix: str, local: bool = False) -> "AutoProtoSubscriber":
+        """Declare a subscriber that decodes protobuf automatically from the encoding header.
+
+        No ``_pb2`` imports needed. The registry fetches ``FileDescriptorSet`` from
+        ``bubbaloop/**/schema`` on first encounter of an unknown type and builds the
+        message class dynamically.
+
+        Falls back to raw ``bytes`` if the encoding is not protobuf or the schema
+        cannot be resolved within the timeout (default 2s).
+
+        Usage::
+
+            sub = ctx.subscriber_auto("tapo_terrace/raw", local=True)
+            for msg in sub:   # msg is a decoded RawImage
+                tensor = torch.frombuffer(msg.data, dtype=torch.uint8)
+        """
+        from .schema_registry import SchemaRegistry
+        from .subscriber import AutoProtoSubscriber
+        if not hasattr(self, '_schema_registry'):
+            self._schema_registry = SchemaRegistry(self.session)
+        key = self.local_topic(suffix) if local else self.topic(suffix)
+        return AutoProtoSubscriber(self.session, key, self._schema_registry)
+
     def subscriber_proto(self, suffix: str, msg_class, local: bool = False) -> "ProtoSubscriber":
         """Declare a protobuf subscriber that deserializes each message automatically.
 

--- a/python-sdk/bubbaloop_sdk/schema_registry.py
+++ b/python-sdk/bubbaloop_sdk/schema_registry.py
@@ -11,6 +11,7 @@ Usage::
     msg = registry.decode(sample)   # returns decoded proto or raw bytes
 """
 
+import json
 import logging
 import threading
 
@@ -20,6 +21,7 @@ from google.protobuf import descriptor_pb2, descriptor_pool, message_factory
 log = logging.getLogger(__name__)
 
 _PROTO_PREFIX = "application/protobuf;"
+_JSON_ENCODING = "application/json"
 
 
 class SchemaRegistry:
@@ -37,14 +39,17 @@ class SchemaRegistry:
         self._lock = threading.Lock()
 
     def decode(self, sample: zenoh.Sample) -> object:
-        """Decode a sample by its encoding. Returns a proto message or raw bytes.
+        """Decode a sample by its encoding.
 
-        If the encoding is ``application/protobuf;<TypeName>`` and the schema is
-        known (or can be fetched), returns a decoded proto message. Falls back to
-        ``bytes`` for any other encoding or on decode failure.
+        - ``application/protobuf;<TypeName>`` → decoded proto message
+        - ``application/json``               → parsed dict
+        - anything else                      → raw ``bytes``
         """
         encoding = str(sample.encoding)
         payload = bytes(sample.payload)
+
+        if encoding == _JSON_ENCODING:
+            return json.loads(payload)
 
         if not encoding.startswith(_PROTO_PREFIX):
             return payload

--- a/python-sdk/bubbaloop_sdk/schema_registry.py
+++ b/python-sdk/bubbaloop_sdk/schema_registry.py
@@ -1,0 +1,120 @@
+"""Schema-driven protobuf decoder for bubbaloop nodes.
+
+Each bubbaloop node serves a ``FileDescriptorSet`` at ``{instance}/schema`` via
+Zenoh queryable.  ``SchemaRegistry`` discovers these on demand and builds dynamic
+protobuf message classes so subscribers can decode without importing generated
+``_pb2`` files.
+
+Usage::
+
+    registry = SchemaRegistry(session)
+    msg = registry.decode(sample)   # returns decoded proto or raw bytes
+"""
+
+import logging
+import threading
+
+import zenoh
+from google.protobuf import descriptor_pb2, descriptor_pool, message_factory
+
+log = logging.getLogger(__name__)
+
+_PROTO_PREFIX = "application/protobuf;"
+
+
+class SchemaRegistry:
+    """Discovers node schemas and decodes protobuf samples by encoding type name.
+
+    Lazy: schemas are fetched on first encounter of an unknown type name.
+    Thread-safe: a single registry can be shared across subscriber threads.
+    """
+
+    def __init__(self, session: zenoh.Session, timeout: float = 2.0):
+        self._session = session
+        self._timeout = timeout
+        self._pool = descriptor_pool.DescriptorPool()
+        self._cache: dict[str, type] = {}  # type_name → msg_class
+        self._lock = threading.Lock()
+
+    def decode(self, sample: zenoh.Sample) -> object:
+        """Decode a sample by its encoding. Returns a proto message or raw bytes.
+
+        If the encoding is ``application/protobuf;<TypeName>`` and the schema is
+        known (or can be fetched), returns a decoded proto message. Falls back to
+        ``bytes`` for any other encoding or on decode failure.
+        """
+        encoding = str(sample.encoding)
+        payload = bytes(sample.payload)
+
+        if not encoding.startswith(_PROTO_PREFIX):
+            return payload
+
+        type_name = encoding[len(_PROTO_PREFIX):]
+        msg_class = self._resolve(type_name)
+        if msg_class is None:
+            log.debug("SchemaRegistry: no class for %s, returning raw bytes", type_name)
+            return payload
+        return msg_class.FromString(payload)
+
+    def _resolve(self, type_name: str) -> type | None:
+        with self._lock:
+            if type_name in self._cache:
+                return self._cache[type_name]
+
+        # Schema not cached yet — query all schema queryables.
+        self._fetch_all_schemas()
+
+        with self._lock:
+            return self._cache.get(type_name)
+
+    def _fetch_all_schemas(self) -> None:
+        """Query bubbaloop/**/schema and register every FileDescriptorSet found."""
+        try:
+            replies = self._session.get("bubbaloop/**/schema", timeout=self._timeout)
+        except Exception as e:
+            log.warning("SchemaRegistry: schema query failed: %s", e)
+            return
+
+        for reply in replies:
+            sample = reply.ok
+            if sample is None:
+                continue
+            try:
+                self._register(bytes(sample.payload))
+            except Exception as e:
+                log.debug("SchemaRegistry: failed to register schema: %s", e)
+
+    def _register(self, schema_bytes: bytes) -> None:
+        """Parse a FileDescriptorSet and register all message types."""
+        fds = descriptor_pb2.FileDescriptorSet.FromString(schema_bytes)
+
+        with self._lock:
+            for fd_proto in fds.file:
+                try:
+                    self._pool.Add(fd_proto)
+                except TypeError:
+                    pass  # already registered — ignore
+
+            for fd_proto in fds.file:
+                pkg = fd_proto.package
+                for msg_proto in fd_proto.message_type:
+                    full_name = f"{pkg}.{msg_proto.name}" if pkg else msg_proto.name
+                    if full_name in self._cache:
+                        continue
+                    try:
+                        desc = self._pool.FindMessageTypeByName(full_name)
+                        self._cache[full_name] = _get_proto_class(desc, self._pool)
+                        log.debug("SchemaRegistry: registered %s", full_name)
+                    except KeyError:
+                        pass
+
+
+def _get_proto_class(descriptor, pool: descriptor_pool.DescriptorPool) -> type:
+    """Return a message class for a descriptor, compatible with protobuf 4.x and 5.x."""
+    try:
+        # protobuf >= 4.21 (upb-based)
+        return message_factory.GetMessageClass(descriptor)
+    except AttributeError:
+        # older protobuf
+        factory = message_factory.MessageFactory(pool=pool)  # type: ignore[attr-defined]
+        return factory.GetPrototype(descriptor)

--- a/python-sdk/bubbaloop_sdk/subscriber.py
+++ b/python-sdk/bubbaloop_sdk/subscriber.py
@@ -44,34 +44,6 @@ class ProtoSubscriber:
         self._sub.undeclare()
 
 
-class TypedSubscriber:
-    """Blocking subscriber with optional explicit proto decoding. Iterates with ``for msg in sub``."""
-
-    def __init__(self, session: zenoh.Session, topic: str, msg_class=None):
-        self._sub = session.declare_subscriber(topic)
-        self._msg_class = msg_class
-
-    def recv(self):
-        """Block until the next sample arrives and return the decoded message."""
-        sample = self._sub.recv()
-        payload = bytes(sample.payload)
-        if self._msg_class is not None and hasattr(self._msg_class, "FromString"):
-            return self._msg_class.FromString(payload)
-        return payload
-
-    def __iter__(self):
-        return self
-
-    def __next__(self):
-        try:
-            return self.recv()
-        except Exception as exc:
-            raise StopIteration from exc
-
-    def undeclare(self) -> None:
-        self._sub.undeclare()
-
-
 class RawSubscriber:
     """Blocking subscriber that yields raw ``bytes``, counterpart to :class:`RawPublisher`.
 

--- a/python-sdk/bubbaloop_sdk/subscriber.py
+++ b/python-sdk/bubbaloop_sdk/subscriber.py
@@ -3,6 +3,47 @@
 import zenoh
 
 
+class AutoProtoSubscriber:
+    """Blocking subscriber that decodes protobuf automatically from the encoding header.
+
+    Requires no imported ``_pb2`` files. On each message the encoding string
+    (``application/protobuf;<TypeName>``) is used to look up the message class
+    in the shared :class:`~bubbaloop_sdk.schema_registry.SchemaRegistry`, which
+    fetches the ``FileDescriptorSet`` from the publishing node's ``/schema``
+    queryable on first encounter.
+
+    Falls back to raw ``bytes`` if the encoding is not protobuf or the schema
+    cannot be resolved.
+
+    Usage::
+
+        sub = ctx.subscriber_auto("tapo_terrace/raw", local=True)
+        for msg in sub:          # msg is a decoded RawImage (or bytes on fallback)
+            tensor = torch.frombuffer(msg.data, dtype=torch.uint8)
+    """
+
+    def __init__(self, session: zenoh.Session, topic: str, registry):
+        self._sub = session.declare_subscriber(topic)
+        self._registry = registry
+
+    def recv(self):
+        """Block until next message and return the auto-decoded result."""
+        sample = self._sub.recv()
+        return self._registry.decode(sample)
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        try:
+            return self.recv()
+        except Exception as exc:
+            raise StopIteration from exc
+
+    def undeclare(self) -> None:
+        self._sub.undeclare()
+
+
 class ProtoSubscriber:
     """Blocking subscriber that deserializes protobuf messages.
 

--- a/python-sdk/bubbaloop_sdk/subscriber.py
+++ b/python-sdk/bubbaloop_sdk/subscriber.py
@@ -3,8 +3,45 @@
 import zenoh
 
 
+class ProtoSubscriber:
+    """Blocking subscriber that deserializes protobuf messages.
+
+    Handles the ``bytes(sample.payload)`` copy once per message, then calls
+    ``msg_class.FromString`` to decode. Supports both global and local (SHM)
+    topics via the topic string passed at construction.
+
+    Usage::
+
+        from camera_pb2 import RawImage
+        sub = ctx.subscriber_proto("tapo_terrace/raw", RawImage, local=True)
+        for msg in sub:          # msg is a decoded RawImage
+            process(msg.data, msg.width, msg.height)
+    """
+
+    def __init__(self, session: zenoh.Session, topic: str, msg_class):
+        self._sub = session.declare_subscriber(topic)
+        self._msg_class = msg_class
+
+    def recv(self):
+        """Block until next message, return decoded proto object."""
+        sample = self._sub.recv()
+        return self._msg_class.FromString(bytes(sample.payload))
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        try:
+            return self.recv()
+        except Exception as exc:
+            raise StopIteration from exc
+
+    def undeclare(self) -> None:
+        self._sub.undeclare()
+
+
 class TypedSubscriber:
-    """Blocking subscriber. Iterates with ``for msg in sub`` (blocks on each recv)."""
+    """Blocking subscriber with optional proto decoding. Iterates with ``for msg in sub``."""
 
     def __init__(self, session: zenoh.Session, topic: str, msg_class=None):
         self._sub = session.declare_subscriber(topic)
@@ -13,7 +50,7 @@ class TypedSubscriber:
     def recv(self):
         """Block until the next sample arrives and return the decoded message."""
         sample = self._sub.recv()
-        payload = bytes(sample.payload.to_bytes())
+        payload = bytes(sample.payload)
         if self._msg_class is not None and hasattr(self._msg_class, "FromString"):
             return self._msg_class.FromString(payload)
         return payload
@@ -36,15 +73,13 @@ class RawSubscriber:
 
     No decoding is applied — the caller owns the byte layout entirely.
     SHM zero-copy delivery is used automatically when both sides have the session
-    SHM transport enabled (``NodeContext.builder().with_shm().connect()``), but
-    the subscriber works over any Zenoh transport.
+    SHM transport enabled, but the subscriber works over any Zenoh transport.
 
     Usage::
 
-        ctx = NodeContext.builder().with_shm().connect()
-        sub = ctx.subscriber_raw("camera/raw")
+        sub = ctx.subscriber_raw("camera/raw", local=True)
         for raw_bytes in sub:
-            frame = np.frombuffer(raw_bytes, dtype=np.uint8).reshape(h, w, 4)
+            tensor = torch.frombuffer(raw_bytes, dtype=torch.uint8)
     """
 
     def __init__(self, session: zenoh.Session, topic: str):

--- a/python-sdk/bubbaloop_sdk/subscriber.py
+++ b/python-sdk/bubbaloop_sdk/subscriber.py
@@ -3,22 +3,22 @@
 import zenoh
 
 
-class AutoProtoSubscriber:
+class ProtoSubscriber:
     """Blocking subscriber that decodes protobuf automatically from the encoding header.
 
-    Requires no imported ``_pb2`` files. On each message the encoding string
+    No ``_pb2`` imports needed. On each message the encoding string
     (``application/protobuf;<TypeName>``) is used to look up the message class
     in the shared :class:`~bubbaloop_sdk.schema_registry.SchemaRegistry`, which
-    fetches the ``FileDescriptorSet`` from the publishing node's ``/schema``
-    queryable on first encounter.
+    fetches ``FileDescriptorSet`` from the publishing node's ``/schema`` queryable
+    on first encounter and caches the result.
 
     Falls back to raw ``bytes`` if the encoding is not protobuf or the schema
-    cannot be resolved.
+    cannot be resolved within the timeout (default 2s).
 
     Usage::
 
-        sub = ctx.subscriber_auto("tapo_terrace/raw", local=True)
-        for msg in sub:          # msg is a decoded RawImage (or bytes on fallback)
+        sub = ctx.subscriber_proto("tapo_terrace/raw", local=True)
+        for msg in sub:   # decoded RawImage — no _pb2 imports needed
             tensor = torch.frombuffer(msg.data, dtype=torch.uint8)
     """
 
@@ -27,7 +27,7 @@ class AutoProtoSubscriber:
         self._registry = registry
 
     def recv(self):
-        """Block until next message and return the auto-decoded result."""
+        """Block until next message and return the decoded proto object."""
         sample = self._sub.recv()
         return self._registry.decode(sample)
 
@@ -44,45 +44,8 @@ class AutoProtoSubscriber:
         self._sub.undeclare()
 
 
-class ProtoSubscriber:
-    """Blocking subscriber that deserializes protobuf messages.
-
-    Handles the ``bytes(sample.payload)`` copy once per message, then calls
-    ``msg_class.FromString`` to decode. Supports both global and local (SHM)
-    topics via the topic string passed at construction.
-
-    Usage::
-
-        from camera_pb2 import RawImage
-        sub = ctx.subscriber_proto("tapo_terrace/raw", RawImage, local=True)
-        for msg in sub:          # msg is a decoded RawImage
-            process(msg.data, msg.width, msg.height)
-    """
-
-    def __init__(self, session: zenoh.Session, topic: str, msg_class):
-        self._sub = session.declare_subscriber(topic)
-        self._msg_class = msg_class
-
-    def recv(self):
-        """Block until next message, return decoded proto object."""
-        sample = self._sub.recv()
-        return self._msg_class.FromString(bytes(sample.payload))
-
-    def __iter__(self):
-        return self
-
-    def __next__(self):
-        try:
-            return self.recv()
-        except Exception as exc:
-            raise StopIteration from exc
-
-    def undeclare(self) -> None:
-        self._sub.undeclare()
-
-
 class TypedSubscriber:
-    """Blocking subscriber with optional proto decoding. Iterates with ``for msg in sub``."""
+    """Blocking subscriber with optional explicit proto decoding. Iterates with ``for msg in sub``."""
 
     def __init__(self, session: zenoh.Session, topic: str, msg_class=None):
         self._sub = session.declare_subscriber(topic)


### PR DESCRIPTION
## Summary

- Add `publisher_raw_proto<T>()` to NodeContext SDK for SHM publishers with `APPLICATION_PROTOBUF` encoding headers — enables schema-driven auto-decode on subscribers
- Add `RawPublisher::with_encoding()` for setting encoding on raw publishers
- Fix dashboard WebSocket proxy (`serve.mjs`): use `http.request` upgrade instead of manual header reconstruction (fixes bridge "Junk after client request" errors)
- Add HTTPS support to `serve.mjs` (auto-detects `certs/`, `--no-tls` flag)
- Bind `serve.mjs` to `127.0.0.1` (remote access via `tailscale serve`)
- Narrow monitor subscription from `bubbaloop/**` to `bubbaloop/global/**` — prevents bridge from buffering local SHM topics and OOMing (bridge was hitting 2.7GB in under 4 minutes)
- Update dashboard README with production deployment instructions
- Python SDK: add ProtoSubscriber, subscribe_raw(), SchemaRegistry auto-decode

## Test plan

- [ ] Dashboard loads and shows topics via Tailscale remote access
- [ ] Camera view displays H264 stream through WebSocket bridge
- [ ] Bridge memory stays under 50MB with active browser connection
- [ ] `publisher_raw_proto<RawImage>()` sets correct encoding header
- [ ] Schema queryable responds through bridge

🤖 Generated with [Claude Code](https://claude.com/claude-code)