### PR TITLE
fix(ci): remove stale proto step from workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           cache-dependency-path: dashboard/package-lock.json
 
       - name: Build dashboard
-        run: cd dashboard && npm ci && npm run proto && npm run build
+        run: cd dashboard && npm ci && npm run build
 
       - name: Test dashboard
         run: cd dashboard && npm test

--- a/.github/workflows/release-dash.yml
+++ b/.github/workflows/release-dash.yml
@@ -61,7 +61,7 @@ jobs:
           node-version: '20'
 
       - name: Build dashboard
-        run: cd dashboard && npm ci && npm run proto && npm run build
+        run: cd dashboard && npm ci && npm run build
 
       - name: Build bubbaloop-dash (Linux)
         if: matrix.use_pixi

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -118,25 +118,13 @@ Protobuf code is generated for:
 | Rust | `crates/*/src/proto/` | `prost` |
 | TypeScript | `dashboard/src/proto/` | `protobuf-ts` |
 
-### Regenerating
-
-To regenerate protobuf code:
-
-```bash
-# Rust
-pixi run build
-
-# TypeScript
-cd dashboard && npm run proto
-```
-
 ## Wire Format
 
-Messages are serialized using standard protobuf binary format:
+Messages are serialized using CBOR:
 
-- Efficient binary encoding
-- Cross-language compatibility
-- Forward/backward compatibility for added fields
+- Efficient binary encoding (no code generation needed)
+- Cross-language compatibility via standard CBOR libraries
+- Self-describing via `schema_uri` in the envelope header
 
 ## Next Steps
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -36,9 +36,8 @@ daemon = "RUST_LOG=info cargo run --bin bubbaloop --package bubbaloop --release 
 
 # Dashboard
 dashboard-install = "cd dashboard && npm install"
-dashboard-proto = { cmd = "cd dashboard && npm run proto", depends-on = ["dashboard-install"] }
-dashboard-build = { cmd = "cd dashboard && npm run build", depends-on = ["dashboard-proto"] }
-dashboard = { cmd = "cd dashboard && npm run dev", depends-on = ["dashboard-proto"] }
+dashboard-build = { cmd = "cd dashboard && npm run build", depends-on = ["dashboard-install"] }
+dashboard = { cmd = "cd dashboard && npm run dev", depends-on = ["dashboard-install"] }
 
 # Dashboard server (embedded)
 dash = { cmd = "RUST_LOG=info cargo run --bin bubbaloop-dash --package bubbaloop --features dashboard --release --", depends-on = ["dashboard-build"] }


### PR DESCRIPTION
## Summary
- Remove `npm run proto` from CI and release-dash workflows (script was deleted in CBOR migration)
- Remove `dashboard-proto` pixi task, update dashboard build/dev deps
- Update docs/api wire format section (protobuf → CBOR)

## Test plan
- [ ] CI passes on this PR (the fix itself)

🤖 Generated with [Claude Code](https://claude.com/claude-code)