### PR TITLE
feat(python-sdk): publisher_cbor(local=True) for CBOR+SHM

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,8 @@ bubbaloop-node = { git = "https://github.com/kornia/bubbaloop.git", branch = "ma
 bubbaloop-node-build = { git = "https://github.com/kornia/bubbaloop.git", branch = "main" }
 ```
 
+**Rust ↔ Python SDK parity (MUST hold):** `crates/bubbaloop-node/` (Rust) and `python-sdk/` (Python) are peer APIs, not layered — every publisher/subscriber/context method added to one MUST have an equivalent in the other in the same PR (or a linked tracking issue). Names should match where possible; where the underlying binding can't surface a knob, the Python side collapses it to the simplest equivalent that preserves wire behavior. Example: Rust `publisher_cbor_shm(suffix, slot_count, slot_size)` ↔ Python `publisher_cbor(suffix, local=True)` — `zenoh-python` doesn't expose `ShmProvider` so slot sizing is implicit, but encoding (`application/cbor`) and congestion control (`Block`) are identical on the wire.
+
 **Multi-instance support:** SDK reads `name` from config YAML at startup. Health and schema topics use this name, so `tapo_entrance` and `tapo_terrace` instances of the same binary get separate topics: `bubbaloop/global/host/tapo_entrance/health` vs `bubbaloop/global/host/tapo_terrace/health`.
 
 **Topic key spaces:** Two fixed key spaces replace the old `{scope}`:

--- a/crates/bubbaloop-node/README.md
+++ b/crates/bubbaloop-node/README.md
@@ -2,6 +2,8 @@
 
 Batteries-included framework for writing bubbaloop nodes. Reduces boilerplate from ~300 to ~50 lines.
 
+> **Parity invariant:** This Rust SDK and `python-sdk/` are peer APIs, not layered — every publisher/subscriber/context method added to one MUST have an equivalent in the other in the same PR (or a linked tracking issue). Names should match where possible. Where `zenoh-python` can't surface a knob that Rust exposes, the Python side collapses it to the simplest equivalent that preserves wire behavior. Example: Rust `publisher_cbor_shm(suffix, slot_count, slot_size)` ↔ Python `publisher_cbor(suffix, local=True)` — same `application/cbor` encoding and `CongestionControl::Block` on the wire; Python slot sizing is implicit because `zenoh-python` doesn't expose `ShmProvider`.
+
 ## Quick Start (Rust)
 
 ```rust

--- a/python-sdk/README.md
+++ b/python-sdk/README.md
@@ -3,6 +3,8 @@
 Pure Python wrapper over `zenoh-python` with the same API surface as the Rust Node SDK.
 No compilation required — installable directly from the git repository.
 
+> **Parity invariant:** This SDK is a peer of `crates/bubbaloop-node/` (Rust), not a layer on top of it. Every publisher/subscriber/context method added to one SDK MUST have an equivalent in the other in the same PR. Where `zenoh-python` can't surface a knob that Rust exposes, the Python side collapses it to the simplest equivalent that preserves wire behavior. Example: Rust `publisher_cbor_shm(suffix, slot_count, slot_size)` ↔ Python `publisher_cbor(suffix, local=True)` — same `application/cbor` encoding and `CongestionControl.Block` on the wire; slot sizing is implicit because `zenoh-python` doesn't expose `ShmProvider`.
+
 ## Install
 
 ```bash

--- a/python-sdk/bubbaloop_sdk/context.py
+++ b/python-sdk/bubbaloop_sdk/context.py
@@ -393,6 +393,7 @@ class NodeContext:
         suffix: str,
         schema_uri: str | None = None,
         schema_version: int = 1,
+        local: bool = False,
     ) -> "CborPublisher":
         """Declare a CBOR publisher at ``topic(suffix)`` (auto-scoped).
 
@@ -400,9 +401,17 @@ class NodeContext:
         ``schema_uri`` defaults to
         ``bubbaloop://{instance}/{instance}/{suffix}@v{schema_version}``; pass
         ``schema_uri=""`` to opt out (empty string is respected).
+
+        When ``local=True``, publishes to
+        ``bubbaloop/local/{machine_id}/{instance_name}/{suffix}`` with
+        ``CongestionControl.BLOCK`` — waits for the subscriber to release the
+        SHM buffer instead of silently dropping frames. Use for large binary
+        payloads (e.g. RGBD frames) consumed only by processes on the same
+        machine. Mirrors ``publisher_raw(local=True)`` behaviour for CBOR
+        publishers.
         """
         from .publisher import CborPublisher
-        key = self.topic(suffix)
+        key = self._resolve_topic(suffix, local)
         sfx = self._declare_output(key)
         uri = self._resolve_schema_uri(sfx or suffix, schema_uri, schema_version)
         pub = CborPublisher._declare(
@@ -410,6 +419,7 @@ class NodeContext:
             key,
             source_instance=self.instance_name or "",
             schema_uri=uri,
+            local=local,
         )
         self._wire_manifest_hooks(pub, sfx, is_input=False)
         return pub
@@ -462,14 +472,22 @@ class NodeContext:
         absolute_suffix: str,
         schema_uri: str | None = None,
         schema_version: int = 1,
+        local: bool = False,
     ) -> "CborPublisher":
         """Declare a CBOR publisher at the absolute key (no instance scoping).
 
         Wraps payloads in the same ``{header, body}`` envelope as
         :meth:`publisher_cbor`.
+
+        When ``local=True``, publishes to
+        ``bubbaloop/local/{machine_id}/{absolute_suffix}`` with
+        ``CongestionControl.BLOCK`` — same SHM + backpressure semantics as
+        :meth:`publisher_cbor` with ``local=True``, but without instance-name
+        scoping. Use for shared well-known bus topics consumed on the same
+        machine only.
         """
         from .publisher import CborPublisher
-        key = self.absolute_topic(absolute_suffix)
+        key = self._resolve_absolute_topic(absolute_suffix, local)
         sfx = self._declare_output(key)
         uri = self._resolve_schema_uri(sfx or absolute_suffix, schema_uri, schema_version)
         pub = CborPublisher._declare(
@@ -477,6 +495,7 @@ class NodeContext:
             key,
             source_instance=self.instance_name or "",
             schema_uri=uri,
+            local=local,
         )
         self._wire_manifest_hooks(pub, sfx, is_input=False)
         return pub

--- a/python-sdk/bubbaloop_sdk/publisher.py
+++ b/python-sdk/bubbaloop_sdk/publisher.py
@@ -131,11 +131,21 @@ class CborPublisher(_BasePublisher):
     (wall-clock nanoseconds). Pre-encoded ``bytes``/``bytearray`` payloads
     bypass the envelope (they're treated as already-final wire bytes).
 
+    When ``local=True`` is passed to :meth:`_declare`, the publisher uses
+    ``congestion_control=CongestionControl.BLOCK`` so SHM frames are never
+    silently dropped when the subscriber is slow. The topic key must already
+    live under ``bubbaloop/local/...`` (callers are responsible for that —
+    see :meth:`NodeContext.publisher_cbor`).
+
     Usage::
 
         pub = ctx.publisher_cbor("sensor/data", schema_uri="bubbaloop://sensor/v1")
         pub.put({"temperature": 22.5, "humidity": 60})
         # On wire: {"header": {...}, "body": {"temperature": 22.5, ...}}
+
+        # SHM variant — BLOCK congestion control, local key space:
+        pub = ctx.publisher_cbor("rgbd", local=True, schema_uri="bubbaloop://rgbd/v1")
+        pub.put({"width": 1280, "height": 720, "data": frame_bytes})
     """
 
     def __init__(
@@ -156,8 +166,12 @@ class CborPublisher(_BasePublisher):
         topic: str,
         source_instance: str = "",
         schema_uri: str = "",
+        local: bool = False,
     ) -> "CborPublisher":
-        pub = session.declare_publisher(topic, encoding=_CBOR_ENCODING)
+        kwargs: dict[str, Any] = {"encoding": _CBOR_ENCODING}
+        if local:
+            kwargs["congestion_control"] = zenoh.CongestionControl.BLOCK
+        pub = session.declare_publisher(topic, **kwargs)
         return cls(pub, source_instance=source_instance, schema_uri=schema_uri)
 
     def put(self, value) -> None:

--- a/python-sdk/tests/test_context.py
+++ b/python-sdk/tests/test_context.py
@@ -76,6 +76,7 @@ def test_publisher_cbor_absolute_uses_unscoped_key():
         "bubbaloop/global/bot/bus/x",
         source_instance="emb",
         schema_uri="bubbaloop://bus/v1",
+        local=False,
     )
 
 

--- a/python-sdk/tests/test_publisher_cbor_local.py
+++ b/python-sdk/tests/test_publisher_cbor_local.py
@@ -1,0 +1,119 @@
+"""Tests for publisher_cbor(local=True) and publisher_cbor_absolute(local=True).
+
+Verifies:
+- local=True routes to the ``bubbaloop/local/...`` key space.
+- local=True sets ``CongestionControl.BLOCK`` on the declared publisher.
+- local=False (default) stays on ``bubbaloop/global/...`` with no congestion kwarg.
+- publisher_cbor_absolute(local=True) uses the local absolute key (no instance prefix).
+"""
+
+import threading
+from unittest.mock import MagicMock, patch
+
+import zenoh
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_context(machine_id: str = "host1", instance_name: str = "mynode"):
+    from bubbaloop_sdk.context import NodeContext
+    ctx = object.__new__(NodeContext)
+    ctx.session = MagicMock()
+    ctx.machine_id = machine_id
+    ctx.instance_name = instance_name
+    ctx._shutdown = threading.Event()
+    return ctx
+
+
+# ---------------------------------------------------------------------------
+# publisher_cbor(local=True) — topic key space
+# ---------------------------------------------------------------------------
+
+def test_publisher_cbor_local_true_uses_local_topic():
+    """local=True must route the publisher to ``bubbaloop/local/...``."""
+    from bubbaloop_sdk import publisher as pub_mod
+    ctx = _make_context()
+    with patch.object(pub_mod.CborPublisher, "_declare", return_value=MagicMock()) as mock_declare:
+        ctx.publisher_cbor("rgbd", local=True)
+        declared_key = mock_declare.call_args.args[1]
+    assert declared_key.startswith("bubbaloop/local/host1/mynode/rgbd"), (
+        f"Expected local key, got: {declared_key}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# publisher_cbor(local=True) — congestion control (Zenoh layer)
+# ---------------------------------------------------------------------------
+
+def test_publisher_cbor_local_true_sets_block_congestion_control():
+    """local=True must declare the Zenoh publisher with CongestionControl.BLOCK.
+
+    We call CborPublisher._declare directly (bypassing context.publisher_cbor)
+    so this test is immune to class-attribute pollution from other test modules.
+    """
+    from bubbaloop_sdk.publisher import CborPublisher
+    session = MagicMock()
+    # _declare may be polluted by prior test modules; use the real implementation
+    # by importing the unbound function and calling it explicitly.
+    import importlib
+    import bubbaloop_sdk.publisher as pub_mod
+    importlib.reload(pub_mod)
+    CborPublisherFresh = pub_mod.CborPublisher
+
+    CborPublisherFresh._declare(session, "bubbaloop/local/host1/mynode/rgbd", local=True)
+
+    assert session.declare_publisher.called, "declare_publisher was not called"
+    call_kwargs = session.declare_publisher.call_args.kwargs
+    assert "congestion_control" in call_kwargs, (
+        "Expected congestion_control kwarg when local=True"
+    )
+    assert call_kwargs["congestion_control"] == zenoh.CongestionControl.BLOCK
+
+
+# ---------------------------------------------------------------------------
+# publisher_cbor(local=False) — regression: stays global, no BLOCK
+# ---------------------------------------------------------------------------
+
+def test_publisher_cbor_local_false_stays_global_no_block():
+    """Default local=False must NOT set congestion_control on the Zenoh publisher."""
+    import importlib
+    import bubbaloop_sdk.publisher as pub_mod
+    importlib.reload(pub_mod)
+    CborPublisherFresh = pub_mod.CborPublisher
+
+    session = MagicMock()
+    CborPublisherFresh._declare(session, "bubbaloop/global/host1/mynode/sensor/data", local=False)
+
+    assert session.declare_publisher.called, "declare_publisher was not called"
+    declared_key = session.declare_publisher.call_args.args[0]
+    assert declared_key.startswith("bubbaloop/global/"), (
+        f"Expected global key, got: {declared_key}"
+    )
+    call_kwargs = session.declare_publisher.call_args.kwargs
+    assert "congestion_control" not in call_kwargs, (
+        "congestion_control must NOT be set when local=False"
+    )
+
+
+# ---------------------------------------------------------------------------
+# publisher_cbor_absolute(local=True) — absolute local key, no instance prefix
+# ---------------------------------------------------------------------------
+
+def test_publisher_cbor_absolute_local_true_uses_local_absolute_topic():
+    """publisher_cbor_absolute with local=True must use
+    ``bubbaloop/local/{machine_id}/{absolute_suffix}`` (no instance_name)."""
+    from bubbaloop_sdk import publisher as pub_mod
+    ctx = _make_context(machine_id="host1", instance_name="mynode")
+    with patch.object(pub_mod.CborPublisher, "_declare", return_value=MagicMock()) as mock_declare:
+        ctx.publisher_cbor_absolute("bus/events", local=True)
+        declared_key = mock_declare.call_args.args[1]
+    assert declared_key.startswith("bubbaloop/local/host1/"), (
+        f"Expected local absolute key, got: {declared_key}"
+    )
+    # Must NOT contain the instance name prefix
+    assert "/mynode/" not in declared_key, (
+        f"Absolute publisher must not include instance_name in key: {declared_key}"
+    )
+    assert declared_key == "bubbaloop/local/host1/bus/events"


### PR DESCRIPTION
## Summary

- Adds `local=True` kwarg to `publisher_cbor` / `publisher_cbor_absolute` — mirrors Rust's `publisher_cbor_shm`. When `local=True`, the publisher lives on the local SHM key space and uses `CongestionControl.BLOCK` so frames aren't silently dropped.
- Documents the Rust ↔ Python SDK parity invariant in `CLAUDE.md`, `python-sdk/README.md`, and `crates/bubbaloop-node/README.md`. The two SDKs are peer APIs; every method must land in both.

## Why

Python nodes that needed CBOR+SHM (e.g. `oak-camera` for 2-3 MB RGBD frames) were forced to roll their own envelope and push through `publisher_raw`, which lost the `APPLICATION_CBOR` encoding hint on the wire. Closes that gap.

## Test plan

- [x] `cd python-sdk && python -m pytest tests/ -q` → 61 passed
- [x] `cargo check --lib -p bubbaloop` → green (no Rust changes)
- [x] 4 new tests cover: local=True key space, BLOCK congestion control, local=False regression, absolute variant